### PR TITLE
Fetch pub values from evaluations integration

### DIFF
--- a/core/app/c/[communitySlug]/integrations/IntegrationsList.tsx
+++ b/core/app/c/[communitySlug]/integrations/IntegrationsList.tsx
@@ -29,7 +29,7 @@ const IntegrationList: React.FC<Props> = function ({ instances }) {
 			</Card>
 			{instances.map((instance) => {
 				return (
-					<Card className="mb-10">
+					<Card className="mb-10" key={instance.id}>
 						<CardContent>
 							<div className="flex justify-between">
 								<div>

--- a/core/lib/contracts/resources/integrations.ts
+++ b/core/lib/contracts/resources/integrations.ts
@@ -21,7 +21,7 @@ export type SuggestedMember = z.infer<typeof SuggestedMembersSchema>;
 export const integrationsApi = contract.router({
 	createPub: {
 		method: "POST",
-		path: "integrations/:instanceId/pubs",
+		path: "/integrations/:instanceId/pubs",
 		summary: "Creates a new pub",
 		description: "A way to create a new pub",
 		body: PubPostSchema,
@@ -35,7 +35,7 @@ export const integrationsApi = contract.router({
 	},
 	getPub: {
 		method: "GET",
-		path: "integrations/:instanceId/pubs/:pubId",
+		path: "/integrations/:instanceId/pubs/:pubId",
 		summary: "Gets a pub",
 		description: "A way to get pubs fields for an integration instance",
 		pathParams: z.object({
@@ -48,7 +48,7 @@ export const integrationsApi = contract.router({
 	},
 	getAllPubs: {
 		method: "GET",
-		path: "integrations/:instanceId/pubs",
+		path: "/integrations/:instanceId/pubs",
 		summary: "Gets all pubs for this instance",
 		description: "A way to get all pubs for an integration instance",
 		pathParams: z.object({
@@ -60,7 +60,7 @@ export const integrationsApi = contract.router({
 	},
 	updatePub: {
 		method: "PATCH",
-		path: "integrations/:instanceId/pubs/:pubId",
+		path: "/integrations/:instanceId/pubs/:pubId",
 		summary: "Adds field(s) to a pub",
 		description: "A way to update a field for an existing pub",
 		body: PubFieldsSchema,
@@ -74,7 +74,7 @@ export const integrationsApi = contract.router({
 	},
 	getSuggestedMembers: {
 		method: "GET",
-		path: "integrations/:instanceId/autosuggest/members/:memberCandidateString",
+		path: "/integrations/:instanceId/autosuggest/members/:memberCandidateString",
 		summary: "autosuggest member",
 		description:
 			"A way to autosuggest members so that integrations users can find users or verify they exist. Will return a name for ",

--- a/integrations/evaluations/app/configure/page.tsx
+++ b/integrations/evaluations/app/configure/page.tsx
@@ -6,7 +6,7 @@ export default async function Page(props: Props) {
 	const instance = (await findInstance(props.searchParams.instanceId)) ?? makeInstance();
 	return (
 		<>
-			<h1>Configure</h1>
+			<h2>Configure</h2>
 			<pre>
 				<code>{JSON.stringify(instance)}</code>
 			</pre>

--- a/integrations/evaluations/app/layout.tsx
+++ b/integrations/evaluations/app/layout.tsx
@@ -9,7 +9,10 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
 	return (
 		<html lang="en">
-			<body>{children}</body>
+			<body>
+				<h1>Evalutions</h1>
+				{children}
+			</body>
 		</html>
 	);
 }

--- a/integrations/evaluations/app/run/page.tsx
+++ b/integrations/evaluations/app/run/page.tsx
@@ -1,14 +1,25 @@
+import { makeClient } from "@pubpub/sdk";
 import { findInstance, makeInstance } from "~/lib/instance";
+import manifest from "~/pubpub-integration.json";
 
-type Props = { searchParams: { instanceId: string } };
+type Props = { searchParams: { instanceId: string; pubId: string } };
+
+const client = makeClient(manifest);
 
 export default async function Page(props: Props) {
-	const instance = (await findInstance(props.searchParams.instanceId)) ?? makeInstance();
+	const { instanceId, pubId } = props.searchParams;
+	const instance = (await findInstance(instanceId)) ?? makeInstance();
+	const { title } = await client.get(instanceId, pubId, "title");
 	return (
 		<>
-			<h1>Run</h1>
+			<h2>Run</h2>
+			<p>Instance</p>
 			<pre>
 				<code>{JSON.stringify(instance)}</code>
+			</pre>
+			<p>Pub Values</p>
+			<pre>
+				<code>{String(title)}</code>
 			</pre>
 		</>
 	);

--- a/integrations/evaluations/pubpub-integration.json
+++ b/integrations/evaluations/pubpub-integration.json
@@ -1,5 +1,9 @@
 {
 	"name": "evaluations",
-	"read": {},
+	"read": {
+		"title": {
+			"id": "aa63cab5-3729-4a12-813b-eae316eceb69"
+		}
+	},
 	"write": {}
 }

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,1 +1,1 @@
-# @pubpub/integration-sdk
+# @pubpub/sdk

--- a/packages/sdk/src/lib/client.ts
+++ b/packages/sdk/src/lib/client.ts
@@ -1,4 +1,4 @@
-import { PubPubError, ResponseError } from "./errors";
+import { InvalidFieldError, PubPubError, ResponseError } from "./errors";
 import { Manifest } from "./types";
 
 export type Get<T extends Manifest> = (
@@ -17,29 +17,35 @@ export type Put<T extends Manifest> = Record<
 	unknown
 >;
 
-export type PutResponse<T extends string[]> = {
+export type PatchResponse<T extends string[]> = {
 	[K in T[number]]: unknown;
 };
 
 export type Client<T extends Manifest> = {
 	get<U extends Get<T>>(instanceId: string, pubId: string, ...fields: U): Promise<GetResponse<U>>;
-	put<U extends string[]>(
+	patch<U extends string[]>(
 		instanceId: string,
 		pubId: string,
 		patch: Put<T>
-	): Promise<PutResponse<U>>;
+	): Promise<PatchResponse<U>>;
 };
 
 export const makeClient = <T extends Manifest>(manifest: T): Client<T> => {
+	const write = new Set(manifest.write ? Object.keys(manifest.write) : null);
+	const read = new Set(manifest.read ? [write.values(), ...Object.keys(manifest.read)] : write);
 	return {
 		async get(instanceId, pubId, ...fields) {
-			const signal = AbortSignal.timeout(5000);
 			try {
+				for (let i = 0; i < fields.length; i++) {
+					if (!read.has(fields[i])) {
+						throw new InvalidFieldError(`Field ${fields[i]} is not readable`);
+					}
+				}
 				const response = await fetch(
-					`${process.env.PUBPUB_URL}/api/${instanceId}/pubs/${pubId}`,
+					`${process.env.PUBPUB_URL}/api/v0/integrations/${instanceId}/pubs/${pubId}`,
 					{
 						method: "GET",
-						signal,
+						signal: AbortSignal.timeout(5000),
 						headers: { "Content-Type": "application/json" },
 					}
 				);
@@ -57,14 +63,18 @@ export const makeClient = <T extends Manifest>(manifest: T): Client<T> => {
 				throw new PubPubError("Failed to get Pub", { cause });
 			}
 		},
-		async put(instanceId, pubId, patch) {
+		async patch(instanceId, pubId, patch) {
 			try {
-				const signal = AbortSignal.timeout(5000);
+				for (const key in patch) {
+					if (!write.has(key)) {
+						throw new InvalidFieldError(`Field ${key} is not writeable`);
+					}
+				}
 				const response = await fetch(
-					`${process.env.PUBPUB_URL}/api/${instanceId}/pubs/${pubId}`,
+					`${process.env.PUBPUB_URL}/api/v0/instances/${instanceId}/pubs/${pubId}`,
 					{
 						method: "PUT",
-						signal,
+						signal: AbortSignal.timeout(5000),
 						headers: { "Content-Type": "application/json" },
 						body: JSON.stringify({ fields: patch }),
 					}

--- a/packages/sdk/src/lib/errors.ts
+++ b/packages/sdk/src/lib/errors.ts
@@ -49,3 +49,5 @@ export class ResponseError extends IntegrationError {
 }
 
 export class PubPubError extends IntegrationError {}
+
+export class InvalidFieldError extends IntegrationError {}


### PR DESCRIPTION
Quick PR that uses the new core API route structure to fetch Pub fields in the evaluations integration.