### PR TITLE
List supabase users instead of hardcoding uuid

### DIFF
--- a/core/prisma/seed.ts
+++ b/core/prisma/seed.ts
@@ -21,8 +21,8 @@ async function createUserMembers(email, password, slug, name, prismaCommunityIds
 		email_confirm: true,
 	});
 	if (error) {
-		const { data, error } = await supabase.auth.admin.getUserById('d86c5427-2600-4991-a675-7526ec4b9d2f')
-		user = data.user
+		const { data, error } = await supabase.auth.admin.listUsers()
+		user = data.users[0]
 	} else {
 		user = data.user;
 	}


### PR DESCRIPTION
This fixes login, which was failing because the UUID of our sole supabase auth user didn't match the UUID in the postgres database. I had hardcoded that value in the seed script previously, but the supabase auth user was deleted and recreated (not by the script) which gave it a new UUID.

To fix, instead of looking up the user by hardcoded id, we list all supabase users and just take the first one. This won't work once we have multiple users! But I'm not sure a better way at the moment because supabase doesn't let you look up users by email.
