### PR TITLE
Check auth token in sendEmail route

### DIFF
--- a/core/pages/api/v0/[...ts-rest].ts
+++ b/core/pages/api/v0/[...ts-rest].ts
@@ -95,7 +95,8 @@ const integrationsRouter = createNextRoute(api.integrations, {
 			body: user,
 		};
 	},
-	sendEmail: async ({ params, body }) => {
+	sendEmail: async ({ headers, params, body }) => {
+		checkApiKey(getBearerToken(headers.authorization));
 		await emailUser(body.to, body.subject, body.message, params.instanceId);
 		return {
 			status: 200,


### PR DESCRIPTION
This PR adds basic API key auth to the new `sendEmail` route. Breaking protocol a bit here, gonna go ahead and merge.