### PR TITLE
Fix error introduced by merging branch without updating first

### DIFF
--- a/core/pages/api/v0/[...ts-rest].ts
+++ b/core/pages/api/v0/[...ts-rest].ts
@@ -57,7 +57,7 @@ const integrationsRouter = createNextRoute(api.integrations, {
 		return { status: 200, body: info };
 	},
 	getPubType: async ({ headers, params }) => {
-		checkApiKey(getBearerToken(headers.authorization));
+		checkAuthentication(headers.authorization);
 		const pub = await getPubType(params.pubTypeId);
 		return { status: 200, body: pub };
 	},


### PR DESCRIPTION
I refactored this code in my branch, someone else added a new endpoint in a different branch and merged that change, then I merged my branch. This is the scenario that the `Require branches to be up to date before merging` branch protection rule helps with, but we don't have that since this is an unpaid private repo.

For now, I've settled for a reminder option
<img width="788" alt="image" src="https://github.com/pubpub/v7/assets/473542/bc3c4d64-0214-4bdd-84b2-0fd0172f043c">
