### PR TITLE
Disable PR previews

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,4 +1,4 @@
-previewsEnabled: true
+previewsEnabled: false
 services:
     # core
     - type: web


### PR DESCRIPTION
Since we only have one database and supabase backend, we can't safely run PR previews and a production app. We can reenable if we set these up to use a local backend.

## Issue(s) Resolved
Resolves #150  
## Test Plan

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
