### PR TITLE
Fix Deadline on Evaluator

### DIFF
--- a/integrations/evaluations/lib/types.ts
+++ b/integrations/evaluations/lib/types.ts
@@ -60,7 +60,7 @@ export type EvaluatorWithInvite = z.infer<typeof EvaluatorWithInvite>;
 export const EvaluatorWhoAccepted = EvaluatorWithInvite.merge(
 	z.object({
 		acceptedAt: z.string(),
-		deadline: z.date().optional(),
+		deadline: z.coerce.date().optional(),
 	})
 );
 export type EvaluatorWhoAccepted = z.infer<typeof EvaluatorWhoAccepted>;


### PR DESCRIPTION
## Issue(s) Resolved
#220 

## Test Plan
- invite two or more evaluators 
- - be sure to accept the invitations
- open integration instance state in prisma editor and delete the deadline for an evaluator in the `IntegrationInstanceState`
- try inviting and accepting another time
- be sure that you are able to invite user
## Screenshots (if applicable)
Not using optional

https://github.com/pubpub/v7/assets/34730449/60f9774b-1727-4fd1-a464-e5c58a31ef85

Using optional and coerce

https://github.com/pubpub/v7/assets/34730449/b58f79db-509e-4be4-8d99-677a16d05110



## Optional

### Notes/Context/Gotchas
The error eric mentioned in the issue is thrown with optional but without coerce. 

this is the correct error without optional but with coerce
<img width="358" alt="image" src="https://github.com/pubpub/v7/assets/34730449/e2bfda39-f302-49e6-a2b7-a9712a000935">

### Supporting Docs
