### PR TITLE
add files directive to next-based packages

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -15,6 +15,7 @@
 		"type-check": "tsc",
 		"type-check-watch": "tsc --watch"
 	},
+  "files": [".next"],
 	"prisma": {
 		"seed": "ts-node prisma/seed.ts"
 	},

--- a/integrations/evaluations/package.json
+++ b/integrations/evaluations/package.json
@@ -8,6 +8,7 @@
 		"start": "next start",
 		"lint": "next lint"
 	},
+  "files": [".next"],
 	"dependencies": {
 		"@hookform/resolvers": "^3.3.1",
 		"@pubpub/sdk": "workspace:*",

--- a/integrations/submissions/package.json
+++ b/integrations/submissions/package.json
@@ -8,6 +8,7 @@
 		"start": "next start",
 		"lint": "next lint"
 	},
+  "files": [".next"],
 	"dependencies": {
 		"@hookform/resolvers": "^3.3.1",
 		"@pubpub/sdk": "workspace:*",


### PR DESCRIPTION
## Issue(s) Resolved

Allows successful use of `pnpm deploy` of packages built with `preconstruct/next`.

## Test Plan

Tested locally, built & deployed to AWS to verify.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

`pnpm deploy` sends all files (including .next AND all source files) to the "output" directory unless `files` is present. Since that includes `next.config.js`, `npx next start` treats the environment as development and fails due to only having prod dependencies.

Once `next build` has been completed, we can ship with ONLY the `.next` directory (for now).

Some maintenance might be required here if more files are needed later, but it should be O(ln) in changes over time.

### Supporting Docs
