### PR TITLE
fix: Allow evaluation form to be submitted without upload

### DIFF
--- a/packages/sdk/src/react/generateFormFields.tsx
+++ b/packages/sdk/src/react/generateFormFields.tsx
@@ -190,7 +190,7 @@ const CustomRenderer = (props: CustomRendererProps) => {
 			<FormField
 				control={control}
 				name={fieldName}
-				defaultValue={fieldSchema.default ?? [0, 0, 0]}
+				defaultValue={fieldSchema.default ?? [{}]}
 				render={({ field }) => (
 					<FormItem className="mb-6">
 						<FormLabel>{fieldSchema.title}</FormLabel>


### PR DESCRIPTION
## Issue(s) Resolved
Fixes https://github.com/pubpub/v7/issues/183

The issue was that the default input field schema didn't conform to the basic shape specified in the form field schema (`[{}]`).

## Test Plan
- Invite yourself to review a pub
- Visit form
- Make sure there's no local storage of previously uploaded files
- Submit form without uploading anything (but with entering in some other values)

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
