### PR TITLE
fix: make settingsform work

### DIFF
--- a/core/app/(user)/settings/SettingsForm.tsx
+++ b/core/app/(user)/settings/SettingsForm.tsx
@@ -9,8 +9,6 @@ import LogoutButton from "~/app/components/LogoutButton";
 import { UserPutBody, UserSettings } from "~/lib/types";
 import { useEnvContext } from "next-runtime-env";
 
-const { NEXT_PUBLIC_PUBPUB_URL } = useEnvContext()
-
 type Props = UserSettings;
 
 export default function SettingsForm({
@@ -20,6 +18,7 @@ export default function SettingsForm({
 	slug,
 	communities,
 }: Props) {
+	const { NEXT_PUBLIC_PUBPUB_URL } = useEnvContext();
 	const [firstName, setFirstName] = useState(initFirstName);
 	const [lastName, setLastName] = useState(initLastName);
 	const [email, setEmail] = useState(initEmail);


### PR DESCRIPTION
## Issue(s) Resolved

If you go to http://blake-lb-staging-624252319.us-east-1.elb.amazonaws.com/settings you will see a client side error being thrown.

This is because the `useEnvContext` hook is used outside of the scope of the component, which is not allowed in React.
I moved it inside, now it should work.

## Test Plan

1. Go to `/settings`
2. Page should not break

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
