### PR TITLE
Update title and description

### DIFF
--- a/core/app/layout.tsx
+++ b/core/app/layout.tsx
@@ -5,8 +5,8 @@ import { PublicEnvProvider } from "next-runtime-env";
 import "./globals.css";
 
 export const metadata = {
-	title: "PubPub v7 Mockup Demo",
-	description: "Just a demo to show the models and structure.",
+	title: "PubPub v7",
+	description: "A more flexible PubPub",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Issue(s) Resolved
It was a little embarrassing to see the old title and description every time we paste a link in slack.