### PR TITLE
Skip checking token expiration

### DIFF
--- a/core/lib/server/token.ts
+++ b/core/lib/server/token.ts
@@ -43,13 +43,13 @@ export const validateToken = async (token: string) => {
 	// 	throw new UnauthorizedError('Token already used')
 	// }
 
-	const { hash, user, expiresAt } = dbToken
+	const { hash, user } = dbToken
 
 	// Check if the token is expired. Expiration times are stored in the DB to enable tokens with
 	// different expiration periods
-	if (expiresAt < new Date()) {
-		throw new UnauthorizedError('Expired token')
-	}
+	// if (expiresAt < new Date()) {
+	// 	throw new UnauthorizedError('Expired token')
+	// }
 
 	// Finally, hash the token string input and do a constant time comparison between this value and the hash retrieved from the database
 	const inputHash = createHash(tokenString).digest()


### PR DESCRIPTION
## Issue(s) Resolved
#258

## Test Plan
Kind of a pain in the ass, but here's what I did.
Locally, replicate the issue in #258:
1. Invite an evaluator to evaluate a pub
2. Open inbucket and click the link to accept
3. Copy the first part of the token in the URL up to the `.` which is the token id
4. Open prisma studio or the supabase table editor or your preferred sql client
5. In the `auth_tokens` table, ppdate the token matching the copied token id to have an `expiresAt` in the past
6. Return to the browser and refresh the page (evaluations integration evaluator response page). It shouldn't look any different
7. To see the error in #258, `git checkout main` and refresh the page. You should see a json error message
