### PR TITLE
Display manager's notes on evaluation form

### DIFF
--- a/integrations/evaluations/app/actions/evaluate/evaluate.tsx
+++ b/integrations/evaluations/app/actions/evaluate/evaluate.tsx
@@ -110,6 +110,7 @@ export function Evaluate(props: Props) {
 	const submissionUrl = pub.values["unjournal:url"] as string;
 	const submissionTitle = pub.values[props.instanceConfig.titleFieldSlug] as string;
 	const submissionAbstract = pub.values["unjournal:description"] as string;
+	const managersNotes = pub.values["unjournal:managers-notes"] as string;
 	const deadline = getDeadline(props.instanceConfig, props.evaluator);
 
 	return (
@@ -121,7 +122,7 @@ export function Evaluate(props: Props) {
 					url={submissionUrl}
 					evaluating
 				/>
-				<Process deadline={deadline} />
+				<Process deadline={deadline} managersNotes={managersNotes} />
 				<h2>{pubType.name}</h2>
 				<p>{pubType.description}</p>
 				<Form {...form}>

--- a/integrations/evaluations/lib/components/Process.tsx
+++ b/integrations/evaluations/lib/components/Process.tsx
@@ -2,6 +2,7 @@ import { EvaluatorWhoAccepted } from "../types";
 
 type Props = {
 	deadline: Date;
+	managersNotes: string;
 };
 
 export const Process = (props: Props) => {
@@ -14,6 +15,18 @@ export const Process = (props: Props) => {
 				).toLocaleDateString()}
 			</p>
 			<p>Final deadline, for $300 base honorarium: {props.deadline.toLocaleDateString()}</p>
+			{props.managersNotes && (
+				<>
+					<h2>Manager's Notes</h2>
+					<p>
+						<em>
+							The Evaluation Manager may suggest specific aspects of the research work
+							to focus on, or offer other suggestions here.
+						</em>
+					</p>
+					<p>{props.managersNotes}</p>
+				</>
+			)}
 			<h2>About our evaluation process</h2>
 			<p>
 				We ask evaluators to:


### PR DESCRIPTION
## Issue(s) Resolved

#242 

## Test Plan

1. Create a submission with manager's notes
2. Invite an evaluator
3. Accept the invite
4. Visit the form using the link in the "thanks for accepting" email
5. You should see the manager's notes in a new heading at the position described in #242 (below "Final deadline", above "About our evaluation process")

## Screenshots (if applicable)

<img width="818" alt="Screenshot 2024-03-13 at 12 50 35 PM" src="https://github.com/pubpub/v7/assets/6402908/e7759e3d-bc21-4bef-ba64-e6b02e9bf10a">