### PR TITLE
Remove declaration of server-actions

### DIFF
--- a/core/next.docker.config.js
+++ b/core/next.docker.config.js
@@ -1,6 +1,5 @@
 const baseConfig = {
 	experimental: {
-		serverActions: true,
 		instrumentationHook: true,
 	},
 };

--- a/integrations/evaluations/next.docker.config.js
+++ b/integrations/evaluations/next.docker.config.js
@@ -2,7 +2,6 @@ const baseConfig = {
 	basePath: "/intg/evaluations",
 	assetPrefix: "/intg/evaluations",
 	experimental: {
-		serverActions: true,
 		instrumentationHook: true,
 	},
 };

--- a/integrations/submissions/next.docker.config.js
+++ b/integrations/submissions/next.docker.config.js
@@ -2,7 +2,6 @@ const baseConfig = {
 	basePath: "/intg/submissions",
 	assetPrefix: "/intg/submissions",
 	experimental: {
-		serverActions: true,
 		instrumentationHook: true,
 	},
 };

--- a/jobs/next.docker.config.js
+++ b/jobs/next.docker.config.js
@@ -1,6 +1,5 @@
 const baseConfig = {
 	experimental: {
-		serverActions: true,
 		instrumentationHook: true,
 	},
 };


### PR DESCRIPTION
## Issue(s) Resolved

These configs were removed in the build-time next.config.js when we updated to next 14, which enables them by default.

However, we have these minimal "runtime next.docker.config.js" files that are loaded into the docker image for configurations that are demanded by next at runtime (currently, only the `instrumentationHook` directive.


## Test Plan

Once this is deployed, we can see that during boot-up, containers don't emit this (benign) warning:
```
May 06, 2024 at 16:06 (UTC-7:00)	⚠ Server Actions are available by default now, `experimental.serverActions` option can be safely removed.	[180246665e1c470db51fe475bfbb090b](https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/blake-ecs-cluster-staging/services/blake-integration-evaluations/tasks/180246665e1c470db51fe475bfbb090b?region=us-east-1)	integration-evaluations
May 06, 2024 at 16:06 (UTC-7:00)	⚠ Invalid next.config.js options detected:	[180246665e1c470db51fe475bfbb090b](https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/blake-ecs-cluster-staging/services/blake-integration-evaluations/tasks/180246665e1c470db51fe475bfbb090b?region=us-east-1)	integration-evaluations
May 06, 2024 at 16:06 (UTC-7:00)	⚠ Expected object, received boolean at "experimental.serverActions"
```

in [logs](https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/blake-ecs-cluster-staging/services/blake-integration-evaluations/logs?region=us-east-1).

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

The configuration spread between two files like this is unfortunate, but some build-time directives fail to load at run-time with the minimal dependency set for production. Probably it is reasonable to import these files into the main `next.config.js` rather than maintain the `instrumentationHook` directly, but this doesn't really solve the problem that a dev who adds a runtime config needs to know to put it here rather than in the "normal" place.

However, since we are only just getting started normalizing the docker workflow, we have no evidence this is really painful. So let's let it play out for now.

### Supporting Docs
