### PR TITLE
explicit cast to Date because unstable_cache stringifies objects

### DIFF
--- a/core/app/components/PubTitle.tsx
+++ b/core/app/components/PubTitle.tsx
@@ -15,7 +15,7 @@ export const PubTitle: React.FC<Props> = function (props: Props) {
 	) as string | undefined;
 	return (
 		<h3 className="text-md font-semibold">
-			{title ?? `Untitled Pub - ${props.pub.createdAt.toDateString()}`}{" "}
+			{title ?? `Untitled Pub - ${new Date(props.pub.createdAt).toDateString()}`}{" "}
 		</h3>
 	);
 };


### PR DESCRIPTION
## Issue(s) Resolved
`unstable_cache` serializes cached results with `JSON.stringify`. This means Dates are coerced into strings, and when the cache is hit we are working with a string rather than the expected Date object. We should probably opt out Kysely's date casting/coercion if we plan to continue using `unstable_cache`.
