### PR TITLE
Use community slug not name

### DIFF
--- a/core/app/c/[communitySlug]/fields/FieldForm.tsx
+++ b/core/app/c/[communitySlug]/fields/FieldForm.tsx
@@ -114,7 +114,6 @@ const SchemaSelectField = ({ form, isDisabled }: { form: FormType; isDisabled?: 
 const SlugField = ({ form, communitySlug }: { form: FormType; communitySlug: string }) => {
 	const { watch, setValue } = form;
 
-	const community = communitySlug;
 	const watchName = watch("name");
 
 	useEffect(() => {
@@ -132,7 +131,7 @@ const SlugField = ({ form, communitySlug }: { form: FormType; communitySlug: str
 						<FormLabel>Slug</FormLabel>
 						<FormControl>
 							<div className="mr-2 flex items-baseline rounded-md border border-input text-sm">
-								<span className="whitespace-nowrap pl-2">{community}:</span>
+								<span className="whitespace-nowrap pl-2">{communitySlug}:</span>
 								<Input
 									placeholder="Slug"
 									// A little margin on focus or else the focus ring will cover the `:` after the community name


### PR DESCRIPTION
## Issue(s) Resolved
The name in this slug field is wrong 
![image](https://github.com/user-attachments/assets/dd10ff81-ff9c-4d60-be1a-1746407dcfc1)

Should be the community's slug, not a slugified version of its name! Also, adds a `nowrap` so that the span doesn't break on the `-`s

## Test Plan

1. Make a new community that has a different name than its slug at http://localhost:3000/communities. 
2. Make the slug have a `-` in it
3. In the newly created community, try adding a new field at http://localhost:3000/c/cool-cats/fields. you should see a screen that looks like this (`cool-cats` all on one line):

![image](https://github.com/user-attachments/assets/ebaeff4c-2089-4d0f-8d77-0de7017f47d3)


## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
