### PR TITLE
Add slug editing

### DIFF
--- a/core/app/c/[communitySlug]/forms/NewFormButton.tsx
+++ b/core/app/c/[communitySlug]/forms/NewFormButton.tsx
@@ -37,6 +37,7 @@ import { createForm } from "./actions";
 const schema = z.object({
 	pubTypeName: z.string(),
 	name: z.string(),
+	slug: z.string().regex(/^[a-zA-Z0-9-]+$/, "Only letters, numbers, and hyphens (-) are allowed"),
 });
 
 type Props = {
@@ -54,7 +55,7 @@ export const NewFormButton = ({ pubTypes }: Props) => {
 	const community = useCommunity();
 	const router = useRouter();
 
-	const onSubmit = async ({ pubTypeName, name }: z.infer<typeof schema>) => {
+	const onSubmit = async ({ pubTypeName, name, slug }: z.infer<typeof schema>) => {
 		const pubTypeId = pubTypes.find((type) => type.name === pubTypeName)?.id;
 		if (!pubTypeId) {
 			toast({
@@ -64,8 +65,8 @@ export const NewFormButton = ({ pubTypes }: Props) => {
 			});
 			return;
 		}
-		const slug = await runCreateForm(pubTypeId, name, community.id);
-		if (didSucceed(slug)) {
+		const result = await runCreateForm(pubTypeId, name, slug, community.id);
+		if (didSucceed(result)) {
 			toast({
 				title: "Success",
 				description: "Form created",
@@ -132,6 +133,23 @@ export const NewFormButton = ({ pubTypes }: Props) => {
 										<Input placeholder="Name" {...field} />
 									</FormControl>
 									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<FormField
+							control={form.control}
+							name="slug"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Slug</FormLabel>
+									<FormControl>
+										<Input placeholder="slug-example" {...field} />
+									</FormControl>
+									<FormMessage />
+									<FormDescription>
+										The URL-friendly identifier for this form. This cannot be
+										changed.
+									</FormDescription>
 								</FormItem>
 							)}
 						/>

--- a/core/app/components/FormBuilder/ElementPanel.tsx
+++ b/core/app/components/FormBuilder/ElementPanel.tsx
@@ -3,11 +3,11 @@
 import type { PubFieldsId } from "db/public";
 import { ElementType, StructuralFormElement } from "db/public";
 import { Button } from "ui/button";
+import { FormLabel } from "ui/form";
 import { ChevronLeft, PlusCircle, Type } from "ui/icon";
 import { Input } from "ui/input";
 import { usePubFieldContext } from "ui/pubFields";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "ui/tabs";
-import { toast } from "ui/use-toast";
 
 import type { PanelState } from "./types";
 import { ConfigureElement } from "./ConfigureElement";
@@ -20,7 +20,7 @@ type ElementPanelProps = {
 export const ElementPanel = ({ state }: ElementPanelProps) => {
 	const fields = usePubFieldContext();
 
-	const { addElement, elementsCount, removeIfUnconfigured, dispatch } = useFormBuilder();
+	const { addElement, elementsCount, removeIfUnconfigured, dispatch, slug } = useFormBuilder();
 
 	const addToForm = (
 		newElement:
@@ -52,7 +52,7 @@ export const ElementPanel = ({ state }: ElementPanelProps) => {
 	switch (state.state) {
 		case "initial":
 			return (
-				<div className="flex flex-col gap-4">
+				<div className="mb-4 flex flex-col gap-4">
 					<p>This form has {elementsCount} elements.</p>
 					<Button
 						type="button"
@@ -62,6 +62,11 @@ export const ElementPanel = ({ state }: ElementPanelProps) => {
 					>
 						<PlusCircle /> Add New
 					</Button>
+					<div className="mt-8">
+						<FormLabel className="text-slate-500">Slug</FormLabel>
+						<hr className="my-2" />
+						<Input disabled value={slug} />
+					</div>
 				</div>
 			);
 		case "selecting":

--- a/core/app/components/FormBuilder/FormBuilder.tsx
+++ b/core/app/components/FormBuilder/FormBuilder.tsx
@@ -204,6 +204,7 @@ export function FormBuilder({ pubForm, id }: Props) {
 			}
 			update={update}
 			dispatch={dispatch}
+			slug={pubForm.slug}
 		>
 			{" "}
 			<Tabs defaultValue="builder" className="pr-[380px]">

--- a/core/app/components/FormBuilder/FormBuilderContext.tsx
+++ b/core/app/components/FormBuilder/FormBuilderContext.tsx
@@ -18,6 +18,7 @@ type FormBuilderContext = {
 	update: (index: number, element: FormElementData) => void;
 	removeIfUnconfigured: () => void;
 	dispatch: React.Dispatch<PanelEvent>;
+	slug: string;
 };
 
 const FormBuilderContext = createContext<FormBuilderContext | undefined>(undefined);


### PR DESCRIPTION
## Issue(s) Resolved
Resolves #447 
## Test Plan
On the forms page, click the button to create a new form. Try putting invalid characters in the slug field to test validation, then enter a valid slug and create the form. You should be redirected to the form builder, and see the slug in the sidebar panel.
## Screenshots (if applicable)
<img width="366" alt="image" src="https://github.com/user-attachments/assets/6795d2bb-9c87-422f-be83-b06ea82c20ce">
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/53d2f3ba-9d1f-4ad4-95f8-e0235cd4abc9">