### PR TITLE
feat: add hacky way to use memberId selector in pub create form

### DIFF
--- a/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/InnerForm.tsx
+++ b/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/InnerForm.tsx
@@ -8,7 +8,7 @@ import { db } from "~/kysely/database";
 import { autoCache } from "~/lib/server/cache/autoCache";
 import { FormElement } from "./FormElement";
 
-const UserIdSelect = async ({
+export const UserIdSelect = async ({
 	label,
 	name,
 	id,

--- a/core/app/c/[communitySlug]/pubs/PubHeader.tsx
+++ b/core/app/c/[communitySlug]/pubs/PubHeader.tsx
@@ -7,14 +7,15 @@ import { PubCreateButton } from "~/app/components/PubCRUD/PubCreateButton";
 
 type Props = {
 	communityId: CommunitiesId;
+	searchParams?: Record<string, unknown>;
 };
 
-const PubHeader: React.FC<Props> = ({ communityId }) => {
+const PubHeader: React.FC<Props> = ({ communityId, searchParams }) => {
 	return (
 		<div className="mb-16 flex items-center justify-between">
 			<h1 className="flex-grow text-xl font-bold">Pubs</h1>
 			<div className="flex items-center gap-x-2">
-				<PubCreateButton communityId={communityId} />
+				<PubCreateButton communityId={communityId} searchParams={searchParams} />
 				<Button variant="outline" size="sm" asChild>
 					<Link href="types">Manage Types</Link>
 				</Button>

--- a/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
@@ -150,6 +150,7 @@ export default async function Page({
 			<PubCreateButton
 				communityId={community.id as CommunitiesId}
 				parentId={pub.id as PubsId}
+				searchParams={searchParams}
 			/>
 			<Suspense fallback={<SkeletonTable /> /* does not exist yet */}>
 				<PubChildrenTableWrapper pub={pub} members={community.members} />

--- a/core/app/c/[communitySlug]/pubs/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/page.tsx
@@ -26,9 +26,9 @@ const getStages = async (communityId: string) => {
 	});
 };
 
-type Props = { params: { communitySlug: string } };
+type Props = { params: { communitySlug: string }; searchParams?: Record<string, unknown> };
 
-export default async function Page({ params }: Props) {
+export default async function Page({ params, searchParams }: Props) {
 	const loginData = await getLoginData();
 	if (!loginData) {
 		redirect("/login");
@@ -50,7 +50,7 @@ export default async function Page({ params }: Props) {
 
 	return (
 		<>
-			<PubHeader communityId={community.id as CommunitiesId} />
+			<PubHeader communityId={community.id as CommunitiesId} searchParams={searchParams} />
 			<PubList pubs={pubs} token={token} />
 		</>
 	);

--- a/core/app/c/[communitySlug]/stages/manage/components/panel/StagePanelPubs.tsx
+++ b/core/app/c/[communitySlug]/stages/manage/components/panel/StagePanelPubs.tsx
@@ -33,7 +33,10 @@ const StagePanelPubsInner = async (props: PropsInner) => {
 				<div className="flex flex-wrap items-center justify-between">
 					<h4 className="mb-2 text-base font-semibold">Pubs</h4>
 					<Suspense fallback={<SkeletonCard />}>
-						<PubCreateButton stageId={props.stageId as StagesId} />
+						<PubCreateButton
+							stageId={props.stageId as StagesId}
+							searchParams={props.pageContext.searchParams}
+						/>
 					</Suspense>
 				</div>
 				{stagePubs.map((pub) => (


### PR DESCRIPTION
## Issue(s) Resolved

## Test Plan

1. In crocroc, create a Pub in the following places 
	- on the Pubs page
	- as a child pub of a pub
	- in stages panel in the pubs tab
2. Try to
	- Add a member that's not in the community
	- Add a member that is in the community
3. Confirm by looking at the pub page (or the db) and seeing that a correct pub value has been initialized



## Screenshots (if applicable)


https://github.com/user-attachments/assets/65fc2928-543f-43b9-aebf-96b52a20e0f0



## Optional

### Notes/Context/Gotchas

### Supporting Docs
