### PR TITLE
Don't cache community stages

### DIFF
--- a/core/lib/server/stages.ts
+++ b/core/lib/server/stages.ts
@@ -9,31 +9,29 @@ import { pubValuesByRef } from "./pub";
 // TODO: Finish making this output match the type of getCommunityStages in
 // core/app/c/[communitySlug]/stages/page.tsx (add pub children and other missing joins)
 export const getCommunityStages = (communityId: CommunitiesId) =>
-	autoCache(
-		db
-			.selectFrom("stages")
-			.where("communityId", "=", communityId)
-			.select((eb) => [
-				jsonArrayFrom(
-					eb
-						.selectFrom("move_constraint")
-						.whereRef("move_constraint.stageId", "=", "stages.id")
-						.selectAll()
-				).as("move_constraints"),
-				jsonArrayFrom(
-					eb
-						.selectFrom("move_constraint")
-						.whereRef("move_constraint.destinationId", "=", "stages.id")
-						.selectAll()
-				).as("move_constraint_sources"),
-				jsonArrayFrom(
-					eb
-						.selectFrom("PubsInStages")
-						.select("pubId")
-						.whereRef("stageId", "=", "stages.id")
-						.select(pubValuesByRef("pubId"))
-				).as("pubs"),
-			])
-			.selectAll("stages")
-			.orderBy("order asc")
-	);
+	db
+		.selectFrom("stages")
+		.where("communityId", "=", communityId)
+		.select((eb) => [
+			jsonArrayFrom(
+				eb
+					.selectFrom("move_constraint")
+					.whereRef("move_constraint.stageId", "=", "stages.id")
+					.selectAll()
+			).as("move_constraints"),
+			jsonArrayFrom(
+				eb
+					.selectFrom("move_constraint")
+					.whereRef("move_constraint.destinationId", "=", "stages.id")
+					.selectAll()
+			).as("move_constraint_sources"),
+			jsonArrayFrom(
+				eb
+					.selectFrom("PubsInStages")
+					.select("pubId")
+					.whereRef("stageId", "=", "stages.id")
+					.select(pubValuesByRef("pubId"))
+			).as("pubs"),
+		])
+		.selectAll("stages")
+		.orderBy("order asc");


### PR DESCRIPTION
## Issue(s) Resolved
- The stage list for submit buttons in the form builder was being permanently cached, which could make it impossible to save the form after selecting a stage, if that stage was no longer present
## Test Plan
I can't actually reproduce this bug locally, so I think we should test it in prod by merging.

## Optional

### Notes/Context/Gotchas

- Theoretically we are actually manually revalidating tags when the stages are edited, so I would have expected autocache to be safe here. And in local testing it does seem to! But on prod, the list of stages for a submit button is a little bit wrong in every community (a few missing or additional stages and/or out of date names), so I don't think it's being revalidated properly.
- The workflows page may not show every stage if they're disconnected from the graph, but that's not a caching bug