### PR TITLE
hotfix: set parentid correctly in sitebuilding api, even if nonrecursively creating pubs

### DIFF
--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -476,7 +476,7 @@ export const createPubRecursiveNew = async ({
 					communityId: communityId,
 					pubTypeId: body.pubTypeId as PubTypesId,
 					assigneeId: body.assigneeId as UsersId,
-					...(parent && { parentId: parentId as PubsId }),
+					parentId: parentId as PubsId,
 				})
 				.returningAll()
 		).executeTakeFirstOrThrow();


### PR DESCRIPTION
## Issue(s) Resolved

## Test Plan

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
