### PR TITLE
fix: remove character limit on email action

### DIFF
--- a/core/actions/email/action.ts
+++ b/core/actions/email/action.ts
@@ -12,7 +12,7 @@ export const action = defineAction({
 		schema: z.object({
 			recipient: z.string().uuid().describe("Recipient"),
 			subject: z.string().describe("Email subject"),
-			body: markdown().min(0).max(2_000).describe("Email body"),
+			body: markdown().min(0).describe("Email body"),
 		}),
 		fieldConfig: {
 			recipient: {
@@ -37,7 +37,6 @@ export const action = defineAction({
 					.optional(),
 				body: markdown()
 					.min(0)
-					.max(1_000)
 					.describe("Email body|Overrides the body specified in the action config.")
 					.optional(),
 			})


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #516 partially

## Test Plan

1. Create email action
2. Configure the content with a ton of characters
3. See no error
4. Run email action
5. Repeat 2-3

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
