### PR TITLE
use remark-stringify instead of rehype-stringify

### DIFF
--- a/core/lib/server/render/pub/renderMarkdownWithPub.ts
+++ b/core/lib/server/render/pub/renderMarkdownWithPub.ts
@@ -11,6 +11,7 @@ import rehypeStringify from "rehype-stringify";
 import remarkDirective from "remark-directive";
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
+import remarkStringify from "remark-stringify";
 import { unified } from "unified";
 import { visit } from "unist-util-visit";
 
@@ -285,7 +286,7 @@ export const renderMarkdownWithPub = async (
 
 	if (asMarkdown) {
 		// Convert the HTML back to markdown using rehype-remark
-		processor = processorBase.use(rehypeRemark).use(rehypeStringify);
+		processor = processorBase.use(rehypeRemark).use(remarkStringify);
 	} else {
 		processor = processorBase.use(rehypeStringify);
 	}


### PR DESCRIPTION
I messed up a rebase and didn't test because I thought it would be "easy". Quick fix to get emails working again!