### PR TITLE
fix: allow actions to be filtered for superadmins

### DIFF
--- a/core/actions/log/action.ts
+++ b/core/actions/log/action.ts
@@ -24,4 +24,5 @@ export const action = defineAction({
 			.optional(),
 	},
 	icon: Terminal,
+	superAdminOnly: true,
 });

--- a/core/actions/pdf/action.ts
+++ b/core/actions/pdf/action.ts
@@ -20,6 +20,5 @@ export const action = defineAction({
 			.optional(),
 	},
 	icon: FileText,
+	superAdminOnly: true,
 });
-
-// export { run } from "./run";

--- a/core/actions/pushToV6/action.ts
+++ b/core/actions/pushToV6/action.ts
@@ -17,4 +17,5 @@ export const action = defineAction({
 	description: "Sync a PubPub Platform pub to v6",
 	params: { schema: z.object({}).optional() },
 	icon: FileText,
+	superAdminOnly: true,
 });

--- a/core/actions/types.ts
+++ b/core/actions/types.ts
@@ -126,6 +126,10 @@ export type Action<
 	 * and configuring this action
 	 */
 	experimental?: boolean;
+	/**
+	 * This action is only available to super admins
+	 */
+	superAdminOnly?: boolean;
 };
 
 export const defineAction = <

--- a/core/app/c/[communitySlug]/stages/manage/components/panel/StagePanelActionCreator.tsx
+++ b/core/app/c/[communitySlug]/stages/manage/components/panel/StagePanelActionCreator.tsx
@@ -79,6 +79,7 @@ const ActionCell = (props: ActionCellProps) => {
 
 type Props = {
 	onAdd: (actionName: string) => Promise<unknown>;
+	isSuperAdmin?: boolean | null;
 };
 
 export const StagePanelActionCreator = (props: Props) => {
@@ -109,13 +110,15 @@ export const StagePanelActionCreator = (props: Props) => {
 						</DialogDescription>
 					</DialogHeader>
 					<div className="grid grid-cols-2 gap-4">
-						{Object.values(actions).map((action) => (
-							<ActionCell
-								key={action.name}
-								action={action}
-								onClick={onActionSelect}
-							/>
-						))}
+						{Object.values(actions)
+							.filter((action) => !action.superAdminOnly || props.isSuperAdmin)
+							.map((action) => (
+								<ActionCell
+									key={action.name}
+									action={action}
+									onClick={onActionSelect}
+								/>
+							))}
 					</div>
 				</DialogContent>
 			</Dialog>

--- a/core/app/c/[communitySlug]/stages/manage/components/panel/StagePanelActions.tsx
+++ b/core/app/c/[communitySlug]/stages/manage/components/panel/StagePanelActions.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "ui/card";
 import type { PageContext } from "~/app/components/ActionUI/PubsRunActionDropDownMenu";
 import { ActionConfigFormWrapper } from "~/app/components/ActionUI/ActionConfigFormWrapper";
 import { SkeletonCard } from "~/app/components/skeletons/SkeletonCard";
+import { getLoginData } from "~/lib/auth/loginData";
 import { getStage, getStageActions } from "~/lib/db/queries";
 import { addAction, deleteAction } from "../../actions";
 import { StagePanelActionCreator } from "./StagePanelActionCreator";
@@ -25,6 +26,8 @@ const StagePanelActionsInner = async (props: PropsInner) => {
 
 	const onAddAction = addAction.bind(null, stage.communityId, stage.id);
 	const onDeleteAction = deleteAction.bind(null, stage.communityId);
+
+	const { user } = await getLoginData();
 
 	return (
 		<Card>
@@ -58,7 +61,7 @@ const StagePanelActionsInner = async (props: PropsInner) => {
 						</StagePanelActionEditor>
 					))}
 				</div>
-				<StagePanelActionCreator onAdd={onAddAction} />
+				<StagePanelActionCreator onAdd={onAddAction} isSuperAdmin={user?.isSuperAdmin} />
 			</CardContent>
 		</Card>
 	);


### PR DESCRIPTION
## Issue(s) Resolved
Resolve #555

## Test Plan
1. Login as all@pubpub.org
2. Try to create action
3. See all actions

___

1. Login as new@pubpub.org (pubpub-new) (is only an admin, not a superadmin)
2. Try to create action
3. Only see email, pub mover, and http action.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
