### PR TITLE
fix: only show pubfields from community in pubtype editor

### DIFF
--- a/core/app/c/[communitySlug]/types/page.tsx
+++ b/core/app/c/[communitySlug]/types/page.tsx
@@ -4,6 +4,7 @@ import { PubFieldProvider } from "ui/pubFields";
 
 import { getLoginData } from "~/lib/auth/loginData";
 import { isCommunityAdmin } from "~/lib/auth/roles";
+import { findCommunityBySlug } from "~/lib/server/community";
 import { getPubFields } from "~/lib/server/pubFields";
 import { getAllPubTypesForCommunity } from "~/lib/server/pubtype";
 import { CreatePubType } from "./CreatePubType";
@@ -11,14 +12,18 @@ import TypeList from "./TypeList";
 
 export default async function Page({ params: { communitySlug } }) {
 	const { user } = await getLoginData();
-	if (!user) {
+
+	const community = await findCommunityBySlug();
+
+	if (!user || !community) {
 		return notFound();
 	}
+
 	const allowEditing = isCommunityAdmin(user, { slug: communitySlug });
 
 	const [types, { fields }] = await Promise.all([
 		getAllPubTypesForCommunity(communitySlug).execute(),
-		getPubFields().executeTakeFirstOrThrow(),
+		getPubFields({ communityId: community.id }).executeTakeFirstOrThrow(),
 	]);
 
 	if (!types || !fields) {


### PR DESCRIPTION
## Issue(s) Resolved
Resolves #554

## Test Plan

1. Try to edit PubType on croccroc
2. Only see fields starting with `croccroc:`
3. Do same for unjournal

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
