### PR TITLE
fix: add labels for newly added form elements and show correct icon

### DIFF
--- a/core/app/components/FormBuilder/ElementPanel.tsx
+++ b/core/app/components/FormBuilder/ElementPanel.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { SCHEMA_TYPES_WITH_ICONS } from "schemas";
+
 import type { PubFieldsId } from "db/public";
 import { ElementType, StructuralFormElement } from "db/public";
 import { Button } from "ui/button";
@@ -83,6 +85,8 @@ export const ElementPanel = ({ state }: ElementPanelProps) => {
 				) {
 					return null;
 				}
+				const Icon =
+					(field.schemaName && SCHEMA_TYPES_WITH_ICONS[field.schemaName]?.icon) || Type;
 				return (
 					<Button
 						type="button"
@@ -98,7 +102,7 @@ export const ElementPanel = ({ state }: ElementPanelProps) => {
 						}}
 						data-testid={`field-button-${field.slug}`}
 					>
-						<Type size={20} className="my-auto text-emerald-500" />
+						<Icon size={20} className="my-auto text-emerald-500" />
 						<div className="flex flex-col items-start text-left">
 							<div className="text-muted-foreground">{field.slug}</div>
 							<div className="text-left font-semibold">{field.name}</div>


### PR DESCRIPTION
- **fix: pass through name as default label for newly added form element**
- **fix: show correct component icon for new components**

## Issue(s) Resolved
Resolves #560

## Test Plan

1. Create new form
2. Try to add element
3. Observe that the elements in the element list have the correct icon
4. Add an element
5. Save
6. Look at form
7. Observe that newly added element has a label with the name of its corresponding form field

## Screenshots (if applicable)

Correct icons
<img width="362" alt="image" src="https://github.com/user-attachments/assets/7d348af3-433b-4389-95a3-b2da7a1cb249">

Newly added form element (veccy) has the correct label. The boolean checkbox above it was added before these fixes, and thus does not have a label

<img width="775" alt="image" src="https://github.com/user-attachments/assets/e11464b6-efa7-4034-a452-76cd2e4d2c48">


## Optional

### Notes/Context/Gotchas

The proper way to fix this is to allow labels to actually be configured, as per #551 

Q: Does this also need to happen for structure elements?

### Supporting Docs
