### PR TITLE
initialize Vector3Element with null vector for empty string values

### DIFF
--- a/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/FormElement.tsx
+++ b/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/FormElement.tsx
@@ -131,6 +131,7 @@ const Vector3Element = ({ label, name }: ElementProps) => {
 					<FormControl>
 						<Confidence
 							{...field}
+							value={Array.isArray(field.value) ? field.value : [0, 0, 0]}
 							min={0}
 							max={100}
 							onValueChange={(event) => field.onChange(event)}


### PR DESCRIPTION
Temporary fix to prevent Vector3 fields with invalid values (e.g. `""`) from crashing forms.

## Issue(s) Resolved

N/A

## Test Plan

Create a pub with a Vector3 field w/ no value. Invite a user to a form that renders a field for the Vector3 field. It should work!

## Screenshots (if applicable)
<img width="307" alt="Screenshot 2024-09-03 at 3 53 04 PM" src="https://github.com/user-attachments/assets/83485595-8c65-4d34-a883-4f6218286b96">

## Optional

### Notes/Context/Gotchas

### Supporting Docs
