### PR TITLE
feat: allow pubvalue subsitution in textarea action fields

### DIFF
--- a/core/actions/http/action.ts
+++ b/core/actions/http/action.ts
@@ -67,7 +67,7 @@ export const action = defineAction({
 				fieldType: "custom",
 			},
 			body: {
-				allowedSchemas: false,
+				allowedSchemas: true,
 				fieldType: "textarea",
 				inputProps: {
 					className: "font-mono text-gray-700",
@@ -151,6 +151,7 @@ export const action = defineAction({
 		],
 		fieldConfig: {
 			body: {
+				allowedSchemas: true,
 				fieldType: "textarea",
 				inputProps: {
 					className: "font-mono text-gray-700",

--- a/core/actions/http/run.ts
+++ b/core/actions/http/run.ts
@@ -28,6 +28,8 @@ export const run = defineRun<typeof action>(async ({ pub, config, args }) => {
 
 	const finalOutputMap = args?.outputMap ?? config?.outputMap ?? [];
 
+	const actualBody = body && method !== "GET" ? body : undefined;
+
 	const res = await fetch(url, {
 		method: method,
 		headers: {
@@ -35,7 +37,7 @@ export const run = defineRun<typeof action>(async ({ pub, config, args }) => {
 			"Content-Type": "application/json",
 		},
 
-		body: body && method !== "GET" ? body : undefined,
+		body: actualBody,
 		cache: "no-store",
 	});
 

--- a/core/actions/types.ts
+++ b/core/actions/types.ts
@@ -77,10 +77,6 @@ export type Action<
 				 * `custom` indicates you are defining the component yourself in `[action]/[config|params]/[fieldName].field.tsx`
 				 */
 				fieldType?: FieldConfigItem["fieldType"] | "custom";
-				/**
-				 * TODO: Document this
-				 */
-				allowedSchemas?: CoreSchemaType[] | false;
 			};
 		};
 		dependencies?: Dependency<z.infer<C>>[];
@@ -101,10 +97,6 @@ export type Action<
 				 * Custom indicates you are defining the component yourself in `[action]/[config/params]/[fieldName].field.tsx`
 				 */
 				fieldType?: FieldConfigItem["fieldType"] | "custom";
-				/**
-				 * TODO: Document this
-				 */
-				allowedSchemas?: CoreSchemaType[] | false;
 			};
 		};
 		dependencies?: Dependency<NonNullable<z.infer<A>>>[];

--- a/packages/ui/src/auto-form/fields/textarea.tsx
+++ b/packages/ui/src/auto-form/fields/textarea.tsx
@@ -1,11 +1,17 @@
 import * as React from "react";
 
+import type { AutoFormInputComponentProps } from "../types";
 import { FormControl, FormItem, FormMessage } from "../../form";
+import {
+	PubFieldSelect,
+	PubFieldSelectProvider,
+	PubFieldSelectToggleButton,
+	PubFieldSelectWrapper,
+} from "../../pubFields/pubFieldSelect";
 import { Textarea } from "../../textarea";
 import AutoFormDescription from "../common/description";
 import AutoFormLabel from "../common/label";
 import AutoFormTooltip from "../common/tooltip";
-import { AutoFormInputComponentProps } from "../types";
 
 export default function AutoFormTextarea({
 	label,
@@ -14,27 +20,41 @@ export default function AutoFormTextarea({
 	fieldConfigItem,
 	fieldProps,
 	zodInputProps,
+	field,
+	zodItem,
 }: AutoFormInputComponentProps) {
 	const { showLabel: _showLabel, ...fieldPropsWithoutShowLabel } = fieldProps;
 	const showLabel = _showLabel === undefined ? true : _showLabel;
 	return (
-		<FormItem>
-			{showLabel && (
-				<>
-					<AutoFormLabel label={label} isRequired={isRequired} />
-					{description && <AutoFormDescription description={description} />}
-				</>
-			)}
-			<FormControl>
-				<Textarea
-					{...{
-						//...zodInputProps,
-						...fieldPropsWithoutShowLabel,
-					}}
-				/>
-			</FormControl>
-			<AutoFormTooltip fieldConfigItem={fieldConfigItem} />
-			<FormMessage />
-		</FormItem>
+		<PubFieldSelectProvider
+			field={field}
+			allowedSchemas={fieldConfigItem.allowedSchemas}
+			zodItem={zodItem}
+		>
+			<FormItem>
+				{showLabel && (
+					<>
+						<span className="flex flex-row items-center  justify-between space-x-2">
+							<AutoFormLabel label={label} isRequired={isRequired} />
+							<PubFieldSelectToggleButton />
+						</span>
+						{description && <AutoFormDescription description={description} />}
+					</>
+				)}
+				<FormControl>
+					<Textarea
+						{...{
+							//...zodInputProps,
+							...fieldPropsWithoutShowLabel,
+						}}
+					/>
+				</FormControl>
+				<PubFieldSelectWrapper>
+					<PubFieldSelect />
+				</PubFieldSelectWrapper>
+				<AutoFormTooltip fieldConfigItem={fieldConfigItem} />
+				<FormMessage />
+			</FormItem>
+		</PubFieldSelectProvider>
 	);
 }

--- a/packages/ui/src/auto-form/types.ts
+++ b/packages/ui/src/auto-form/types.ts
@@ -12,7 +12,7 @@ export type FieldConfigItem = {
 	};
 	fieldType?: keyof typeof INPUT_COMPONENTS | React.FC<AutoFormInputComponentProps>;
 	renderParent?: (props: { children: React.ReactNode }) => React.ReactElement | null;
-	allowedSchemas?: CoreSchemaType[] | false;
+	allowedSchemas?: CoreSchemaType[] | boolean;
 };
 
 export type FieldConfig<SchemaType extends z.infer<z.ZodObject<any, any>>> = {

--- a/packages/ui/src/pubFields/pubFieldSelect/determinePubFields.ts
+++ b/packages/ui/src/pubFields/pubFieldSelect/determinePubFields.ts
@@ -3,12 +3,25 @@ import type { z } from "zod";
 import { zodTypeToCoreSchemaType } from "schemas";
 
 // this makes Zod be imported on the client, we might want to change this in the future
-import { coreSchemaTypeSchema } from "db/public";
+import { CoreSchemaType, coreSchemaTypeSchema } from "db/public";
 
 import type { FieldConfigItem } from "../../auto-form/types";
 import type { PubFieldContext } from "../PubFieldContext";
 
 export const getAllowedSchemaNames = (allowedSchemasOrZodItem: AllowedSchemasOrZodItem) => {
+	const allowedSchemas = allowedSchemasOrZodItem.allowedSchemas;
+
+	if (allowedSchemas === true) {
+		return Object.values(CoreSchemaType);
+	}
+
+	if (!allowedSchemas) {
+		return [];
+	}
+
+	if (allowedSchemas?.length === 0) {
+		return [];
+	}
 	if (allowedSchemasOrZodItem.zodItem) {
 		const res = zodTypeToCoreSchemaType(allowedSchemasOrZodItem.zodItem);
 
@@ -17,15 +30,6 @@ export const getAllowedSchemaNames = (allowedSchemasOrZodItem: AllowedSchemasOrZ
 		}
 
 		return [res];
-	}
-	const allowedSchemas = allowedSchemasOrZodItem.allowedSchemas;
-
-	if (!allowedSchemas) {
-		return [];
-	}
-
-	if (allowedSchemas?.length === 0) {
-		return [];
 	}
 	// just to make sure
 	const parsed = coreSchemaTypeSchema.array().safeParse(allowedSchemas);


### PR DESCRIPTION
## Issue(s) Resolved
Allows pubvalue substitution in http body for demo.

## Test Plan
1. Create http action with this setup
- URL: https://postman-echo.com/post
- Method: POST
- Body: do anything, and select some pubfield
2. Run the action in test mode
3. See that you get "data: {value of pubfield}" returned



## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
