### PR TITLE
Conditionally parse HTTP action body

### DIFF
--- a/core/actions/_lib/resolvePubfields.ts
+++ b/core/actions/_lib/resolvePubfields.ts
@@ -15,7 +15,8 @@ const pubFieldsSchema = z
  */
 export const resolveWithPubfields = <T extends Record<string, any>>(
 	argsOrConfig: T,
-	pubValues: Awaited<ReturnType<typeof getPubCached>>["values"]
+	pubValues: Awaited<ReturnType<typeof getPubCached>>["values"],
+	overrides: Set<string>
 ) => {
 	const parsedConfig = pubFieldsSchema.safeParse(argsOrConfig);
 	if (!parsedConfig.success) {
@@ -49,6 +50,8 @@ export const resolveWithPubfields = <T extends Record<string, any>>(
 			if (value === undefined) {
 				return [] as const;
 			}
+
+			overrides.add(arg);
 
 			return [[arg, value]] as const;
 		})

--- a/core/actions/_lib/runActionInstance.ts
+++ b/core/actions/_lib/runActionInstance.ts
@@ -135,19 +135,25 @@ const _runActionInstance = async (
 	// 	};
 	// }
 
+	const argsFieldOverrides = new Set<string>();
+	const configFieldOverrides = new Set<string>();
+
 	const argsWithPubfields = resolveWithPubfields(
 		{ ...parsedArgs.data, ...args.actionInstanceArgs },
-		pub.values
+		pub.values,
+		argsFieldOverrides
 	);
 	const configWithPubfields = resolveWithPubfields(
 		{ ...(actionInstance.config as {}), ...parsedConfig.data },
-		pub.values
+		pub.values,
+		configFieldOverrides
 	);
 
 	try {
 		const result = await actionRun({
 			// FIXME: get rid of any
 			config: configWithPubfields as any,
+			configFieldOverrides,
 			pub: {
 				id: pub.id,
 				// FIXME: get rid of any
@@ -157,6 +163,7 @@ const _runActionInstance = async (
 			},
 			// FIXME: get rid of any
 			args: argsWithPubfields as any,
+			argsFieldOverrides,
 			stageId: actionInstance.stageId,
 			communityId: pub.communityId as CommunitiesId,
 		});

--- a/core/actions/http/action.ts
+++ b/core/actions/http/action.ts
@@ -30,6 +30,21 @@ export const action = defineAction({
 					.describe("Response|Expected type to return"),
 				body: z
 					.string()
+					// this makes sure that the body is valid JSON
+					.transform((str, ctx) => {
+						if (!str) {
+							return undefined;
+						}
+						try {
+							// we just want to check if it can be parsed
+							const parsed = JSON.parse(str);
+							return str;
+						} catch (e) {
+							ctx.addIssue({ code: "custom", message: "Invalid JSON" });
+							return z.NEVER;
+						}
+					})
+					.optional()
 					.describe(
 						"Body|Body to send with the request. Only sent for non-GET requests."
 					),

--- a/core/actions/http/run.ts
+++ b/core/actions/http/run.ts
@@ -18,76 +18,81 @@ const findNestedStructure = (json: unknown, path) => {
 	return result;
 };
 
-export const run = defineRun<typeof action>(async ({ pub, config, args }) => {
-	const { url, method, authToken, body } = {
-		url: args?.url ?? config.url,
-		method: args?.method ?? config.method,
-		authToken: args?.authToken ?? config.authToken,
-		body: args?.body ?? config.body,
-	};
-
-	const finalOutputMap = args?.outputMap ?? config?.outputMap ?? [];
-
-	const actualBody = body && method !== "GET" ? JSON.stringify(JSON.parse(body)) : undefined;
-
-	const res = await fetch(url, {
-		method: method,
-		headers: {
-			...(authToken && { Authorization: `Bearer ${authToken}` }),
-			"Content-Type": "application/json",
-		},
-
-		body: actualBody,
-		cache: "no-store",
-	});
-
-	if (res.status !== 200) {
-		return {
-			title: "Error",
-			error: `Error ${res.status} ${res.statusText}`,
+export const run = defineRun<typeof action>(
+	async ({ pub, config, configFieldOverrides, args, argsFieldOverrides }) => {
+		const { url, method, authToken } = {
+			url: args?.url ?? config.url,
+			method: args?.method ?? config.method,
+			authToken: args?.authToken ?? config.authToken,
 		};
-	}
 
-	if (
-		finalOutputMap.length > 0 &&
-		!res.headers.get("content-type")?.includes("application/json")
-	) {
-		return {
-			title: "Error",
-			error: `Expected application/json response, got ${res.headers.get("content-type")}`,
-		};
-	}
+		const finalOutputMap = args?.outputMap ?? config?.outputMap ?? [];
 
-	const result = await res.json();
+		let body: string | undefined;
 
-	if (!finalOutputMap || finalOutputMap.length === 0) {
-		return {
-			success: true,
-			report: `<p>The HTTP request ran successfully without mapping</p>
+		if (args.body) {
+			body = argsFieldOverrides.has("body") ? JSON.stringify(args.body) : args.body;
+		} else if (config.body) {
+			body = configFieldOverrides.has("body") ? JSON.stringify(config.body) : config.body;
+		}
+
+		const res = await fetch(url, {
+			method: method,
+			headers: {
+				...(authToken && { Authorization: `Bearer ${authToken}` }),
+				"Content-Type": "application/json",
+			},
+			body,
+			cache: "no-store",
+		});
+
+		if (res.status !== 200) {
+			return {
+				title: "Error",
+				error: `Error ${res.status} ${res.statusText}`,
+			};
+		}
+
+		if (
+			finalOutputMap.length > 0 &&
+			!res.headers.get("content-type")?.includes("application/json")
+		) {
+			return {
+				title: "Error",
+				error: `Expected application/json response, got ${res.headers.get("content-type")}`,
+			};
+		}
+
+		const result = await res.json();
+
+		if (!finalOutputMap || finalOutputMap.length === 0) {
+			return {
+				success: true,
+				report: `<p>The HTTP request ran successfully without mapping</p>
   <pre> 
 		${JSON.stringify(result, null, 2)}
   </pre>`,
-			data: {},
-		};
-	}
-
-	const mappedOutputs = finalOutputMap.map(({ pubField, responseField }) => {
-		if (responseField === undefined) {
-			throw new Error(`Field ${pubField} was not provided in the output map`);
+				data: {},
+			};
 		}
-		const resValue = findNestedStructure(result, responseField);
-		if (resValue === undefined || (Array.isArray(resValue) && resValue.length === 0)) {
-			throw new Error(
-				`Field "${responseField}" not found in response. Response was ${JSON.stringify(result)}`
-			);
-		}
-		return { pubField, resValue };
-	});
 
-	if (args?.test) {
-		return {
-			success: true,
-			report: `<div>
+		const mappedOutputs = finalOutputMap.map(({ pubField, responseField }) => {
+			if (responseField === undefined) {
+				throw new Error(`Field ${pubField} was not provided in the output map`);
+			}
+			const resValue = findNestedStructure(result, responseField);
+			if (resValue === undefined || (Array.isArray(resValue) && resValue.length === 0)) {
+				throw new Error(
+					`Field "${responseField}" not found in response. Response was ${JSON.stringify(result)}`
+				);
+			}
+			return { pubField, resValue };
+		});
+
+		if (args?.test) {
+			return {
+				success: true,
+				report: `<div>
 			<p>HTTP request ran successfully</p>
 			<p>The resulting mapping would have been:</p>
 			<div>
@@ -95,34 +100,35 @@ ${mappedOutputs.map(({ pubField, resValue }) => `<p>${pubField}: ${pub.values[pu
 <span>Data</span>
 				<p>${JSON.stringify(result, null, 2)}</p>
 			</div>`,
+				data: { result },
+			};
+		}
+
+		const fields = mappedOutputs.map(({ pubField, resValue }) => ({
+			slug: pubField,
+			value: resValue,
+		}));
+
+		const updateResult = await _updatePub({
+			pubId: pub.id as PubsId,
+			fields,
+		});
+
+		if (updateResult.error) {
+			logger.debug(updateResult.error);
+			return {
+				title: "Error",
+				error: `Failed to update fields: ${updateResult.error}`,
+				cause: updateResult.error,
+			};
+		}
+
+		return {
+			success: true,
+			report: `<p>Successfully updated fields</p>
+			<div>
+${mappedOutputs.map(({ pubField, resValue }) => `<p>${pubField}: ${pub.values[pubField]} ➡️ ${resValue}</p>`).join("\n")}`,
 			data: { result },
 		};
 	}
-
-	const fields = mappedOutputs.map(({ pubField, resValue }) => ({
-		slug: pubField,
-		value: resValue,
-	}));
-
-	const updateResult = await _updatePub({
-		pubId: pub.id as PubsId,
-		fields,
-	});
-
-	if (updateResult.error) {
-		logger.debug(updateResult.error);
-		return {
-			title: "Error",
-			error: `Failed to update fields: ${updateResult.error}`,
-			cause: updateResult.error,
-		};
-	}
-
-	return {
-		success: true,
-		report: `<p>Successfully updated fields</p>
-			<div>
-${mappedOutputs.map(({ pubField, resValue }) => `<p>${pubField}: ${pub.values[pubField]} ➡️ ${resValue}</p>`).join("\n")}`,
-		data: { result },
-	};
-});
+);

--- a/core/actions/types.ts
+++ b/core/actions/types.ts
@@ -35,8 +35,10 @@ export type RunProps<T extends Action> =
 	>
 		? {
 				config: C["_output"] & { pubFields: { [K in keyof C["_output"]]?: string[] } };
+				configFieldOverrides: Set<string>;
 				pub: ActionPub<P>;
 				args: A["_output"] & { pubFields: { [K in keyof A["_output"]]?: string[] } };
+				argsFieldOverrides: Set<string>;
 				stageId: StagesId;
 				communityId: CommunitiesId;
 			}


### PR DESCRIPTION
Updates the HTTP action to stringify field-substituted configs/args, leaving the raw/textarea-provided configs/args unchanged.