### PR TITLE
fix: render pub page if it has no children correctly

### DIFF
--- a/core/app/c/[communitySlug]/pubs/[pubId]/components/PubChildrenTableWrapper.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/components/PubChildrenTableWrapper.tsx
@@ -109,7 +109,12 @@ async function PubChildrenTableWrapper(props: Props) {
 	const pubChildren = await getPubChildrenTable(
 		props.parentPubId,
 		props.pageContext.searchParams.selectedPubType as PubTypesId
-	).executeTakeFirstOrThrow();
+	).executeTakeFirst();
+
+	if (!pubChildren) {
+		return <PubChildrenTable childPubRows={[]} childPubRunActionDropdowns={[]} />;
+	}
+
 	const selectedPubTypeId = pubChildren.active_pubtype?.id;
 
 	const selectedPubType = pubChildren.active_pubtype;


### PR DESCRIPTION
## Issue(s) Resolved
Currently if you go to a pub page on app.pubpub.org it crashes if it doesn't have any children.

## Test Plan
1. Go to a pub with no children
2. Page does not crash

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
