### PR TITLE
handle null content attr for paragraph nodes

### DIFF
--- a/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/page.tsx
+++ b/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/page.tsx
@@ -96,8 +96,10 @@ const renderElementMarkdownContent = async (
 	element: Form["elements"][number],
 	renderWithPubContext: RenderWithPubContext
 ) => {
-	const content = expect(element.content, "Expected element to have content");
-	return renderMarkdownWithPub(content, renderWithPubContext);
+	if (element.content === null) {
+		return "";
+	}
+	return renderMarkdownWithPub(element.content, renderWithPubContext);
 };
 
 export default async function FormPage({


### PR DESCRIPTION
We were asserting that a paragraph's element content must be defined/have a string value. But in fact a `element.content === null` is a perfectly valid state. This PR just removes that assertion and returns an empty string if the paragraph element's content is `null`.