### PR TITLE
RFC: add explanation field to PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,8 +7,4 @@
 
 ## Screenshots (if applicable)
 
-## Optional
-
-### Notes/Context/Gotchas
-
-### Supporting Docs
+## Notes


### PR DESCRIPTION
## Issue(s) Resolved

Awkward placement of PR documentation

## High-level Explanation of PR

I would like to have a (better) dedicated space where we explain what this PR does at a high level.

Currently, in the template, this is delegated to `## Optional > ### Notes/Supporting docs`, which I think is a bit of an awkward spot.

The idea here is not to rehash the contents of the issue, but talk more of the implementation details that are not explicitly mentioned in the issue.

Often this field should probably be extremely brief, especially if the issue is well scoped and the PR is small, but I kind of often want this in a PR.

## Test Plan

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

Do you agree that this is useful? Any better ideas for a name?


### Supporting Docs
