### PR TITLE
Disable updatedAt plugin to fix password resets

### DIFF
--- a/core/kysely/database.ts
+++ b/core/kysely/database.ts
@@ -36,7 +36,7 @@ const updatedAtPlugin = new UpdatedAtPlugin(tablesWithUpdateAt);
 export const db = new Kysely<Database>({
 	dialect,
 	log: kyselyLogger,
-	plugins: [updatedAtPlugin],
+	// plugins: [updatedAtPlugin],
 });
 
 const PostgresError = z.object({


### PR DESCRIPTION
## Issue(s) Resolved
Password resets aren't working
## High-level Explanation of PR
The recently added plugin from #597 is causing the password setting query to look like this:
```
update "users" set "updatedAt" = current_timestamp where "id" = $1; --Parameters: ["24b8c285-9c9a-4c57-b6ec-ca3370695cfe"]
```
when it should look like 
```
update "users" set "passwordHash" = $1 where "id" = $2; --Parameters: ["$argon2id$v=19$m=19456,t=2,p=1$g5kALrkkV4mwMR2rG0DXpg$IY8aCKCxKdA7P0mJ1w7sp8JefkysW9ABRAzWrN3R2RE","24b8c285-9c9a-4c57-b6ec-ca3370695cfe"]
```
Disabling it fixes this, and will allow people to reset their passwords until we fix the plugin.
## Test Plan
Reset the password of one of the test users that don't have a passwordHash in the db, then observe that a hash is actually set and you can login
