### PR TITLE
Prevent dialog/modal from closing immediately when opened from child pub row

### DIFF
--- a/core/app/c/[communitySlug]/pubs/[pubId]/components/PubChildrenTable.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/components/PubChildrenTable.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useMemo } from "react";
+
 import type { ChildPubRow, ChildPubRowPubType } from "./types";
 import { DataTable } from "~/app/components/DataTable/DataTable";
 import { getPubChildrenTableColumns } from "./getPubChildrenTableColumns";
@@ -11,9 +13,15 @@ type Props = {
 };
 
 export const PubChildrenTable = (props: Props) => {
-	const columns = getPubChildrenTableColumns(
-		props.childPubRunActionDropdowns,
-		props.childPubType
+	const columns = useMemo(
+		() => getPubChildrenTableColumns(props.childPubRunActionDropdowns, props.childPubType),
+		// When the page re-renders (e.g. the path or search params change) these
+		// columns are recomputed, resulting in a new object. The DataTable
+		// component does a full re-render when the object passed to the `columns`
+		// prop changes. Any open dialogs or menus that are descendants of a table
+		// row will be closed when this happens. To prevent this, we memoize the
+		// columns object so that it only changes when the childPubType changes.
+		[props.childPubType?.id]
 	);
 	return <DataTable columns={columns} data={props.childPubRows} hidePaginationWhenSinglePage />;
 };


### PR DESCRIPTION
## Issue(s) Resolved

Closes #608

## High-level Explanation of PR

This PR memoizes the object passed to the pub children table's `columns` prop. As it turns out, when this reference changes the table will fully re-create all rows, which causes any modals open from a table row to close instantly.

## Test Plan

- Open the pub page of a pub that has one or more children.
- Run an action for that pub. The run action dialog should not close immediately.