### PR TITLE
fix: use default runners instead of paid ones

### DIFF
--- a/.github/workflows/ecrbuild-all.yml
+++ b/.github/workflows/ecrbuild-all.yml
@@ -38,7 +38,8 @@ jobs:
         with:
             package: core
             # we require a bigger lad
-            runner: ubuntu-latest-m
+            # We are now public, default public runner is big enough
+            # runner: ubuntu-latest-m
         secrets:
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Issue(s) Resolved
Jobs using `m-ubuntu-latest` were stalling.

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->

Default runner in public repos is 4vCpu/16GB RAM (https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)

`m-ubuntu` runner we were using for private repo is only 14Gb. Also we can't use it anymore, I think it's for private repos only? If you go to https://github.com/pubpub/platform/settings/actions/runners you see that no runners are even configured atm, which was probably why they were stalling.

## Test Plan
See if CI completes

## Screenshots (if applicable)

## Notes
