### PR TITLE
Create client side pubId to file upload can work

### DIFF
--- a/core/app/c/[communitySlug]/pubs/PubHeader.tsx
+++ b/core/app/c/[communitySlug]/pubs/PubHeader.tsx
@@ -17,10 +17,7 @@ const PubHeader: React.FC<Props> = ({ communityId, searchParams }) => {
 		<div className="mb-16 flex items-center justify-between">
 			<h1 className="flex-grow text-xl font-bold">Pubs</h1>
 			<div className="flex items-center gap-x-2">
-				<Suspense
-					fallback={<SkeletonButton className="w-20" />}
-					key={new Date().toString()}
-				>
+				<Suspense fallback={<SkeletonButton className="w-20" />}>
 					<CreatePubButton communityId={communityId} searchParams={searchParams} />
 				</Suspense>
 				<Button variant="outline" size="sm" asChild>

--- a/core/app/components/forms/FormElement.tsx
+++ b/core/app/components/forms/FormElement.tsx
@@ -13,7 +13,7 @@ import { TextElement } from "./elements/TextElement";
 import { UserIdSelect } from "./elements/UserSelectElement";
 
 export type FormElementProps = {
-	pubId?: PubsId;
+	pubId: PubsId;
 	element: Form["elements"][number];
 	searchParams: Record<string, unknown>;
 	communitySlug: string;
@@ -53,7 +53,7 @@ export const FormElement = ({
 	if (schemaName === CoreSchemaType.Boolean) {
 		return <BooleanElement {...elementProps} />;
 	}
-	if (schemaName === CoreSchemaType.FileUpload && pubId) {
+	if (schemaName === CoreSchemaType.FileUpload) {
 		return <FileUploadElement pubId={pubId} {...elementProps} />;
 	}
 	if (schemaName === CoreSchemaType.Vector3) {

--- a/core/app/components/pubs/CreatePubButton.tsx
+++ b/core/app/components/pubs/CreatePubButton.tsx
@@ -1,9 +1,10 @@
-import { CommunitiesId, StagesId } from "db/public";
-import { ButtonProps } from "ui/button";
+import type { CommunitiesId, StagesId } from "db/public";
+import type { ButtonProps } from "ui/button";
 import { Plus } from "ui/icon";
 
+import type { PubEditorProps } from "./PubEditor/PubEditor";
 import { PathAwareDialog } from "../PathAwareDialog";
-import { PubEditor, PubEditorProps } from "./PubEditor/PubEditor";
+import { PubEditor } from "./PubEditor/PubEditor";
 
 export type Props = PubEditorProps & {
 	variant?: ButtonProps["variant"];

--- a/core/app/components/pubs/PubEditor/PubEditor.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditor.tsx
@@ -58,8 +58,8 @@ export async function PubEditor(props: PubEditorProps) {
 	>["executeTakeFirstOrThrow"]["pubTypes"][number];
 	let pubFields: Pick<PubField, "id" | "name" | "slug" | "schemaName">[];
 
-	// Create the pubId client side if one doesn't exist. The FileUpload needs
-	// the pubId when uploading the file before the pub exists
+	// Create the pubId before inserting into the DB if one doesn't exist.
+	// FileUpload needs the pubId when uploading the file before the pub exists
 	const isUpdating = !!pub?.id;
 	const pubId = pub?.id ?? (randomUUID() as PubsId);
 

--- a/core/app/components/pubs/PubEditor/PubEditor.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditor.tsx
@@ -1,10 +1,12 @@
+import { randomUUID } from "crypto";
+
 import type { CommunitiesId, PubsId, StagesId } from "db/public";
 import { expect } from "utils";
 
+import type { AutoReturnType, PubField } from "~/lib/types";
 import { db } from "~/kysely/database";
 import { getPubCached } from "~/lib/server";
 import { getPubFields } from "~/lib/server/pubFields";
-import { AutoReturnType, PubField } from "~/lib/types";
 import { FormElement } from "../../forms/FormElement";
 import { makeFormElementDefFromPubFields } from "./helpers";
 import { PubEditorClient } from "./PubEditorClient";
@@ -56,6 +58,11 @@ export async function PubEditor(props: PubEditorProps) {
 	>["executeTakeFirstOrThrow"]["pubTypes"][number];
 	let pubFields: Pick<PubField, "id" | "name" | "slug" | "schemaName">[];
 
+	// Create the pubId client side if one doesn't exist. The FileUpload needs
+	// the pubId when uploading the file before the pub exists
+	const isUpdating = !!pub?.id;
+	const pubId = pub?.id ?? (randomUUID() as PubsId);
+
 	if (pub === undefined) {
 		if (props.searchParams.pubTypeId) {
 			pubType = expect(
@@ -84,7 +91,7 @@ export async function PubEditor(props: PubEditorProps) {
 			searchParams={props.searchParams}
 			communitySlug={community.slug}
 			values={pubValues}
-			pubId={pub?.id}
+			pubId={pubId}
 		/>
 	));
 
@@ -98,10 +105,11 @@ export async function PubEditor(props: PubEditorProps) {
 			formElements={formElements}
 			parentId={"parentId" in props ? props.parentId : undefined}
 			pubFields={pubFields}
-			pubId={pub?.id}
+			pubId={pubId}
 			pubTypeId={pubType?.id}
 			pubValues={pubValues}
 			stageId={currentStageId}
+			isUpdating={isUpdating}
 		/>
 	);
 }

--- a/core/app/components/pubs/PubEditor/PubEditorClient.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditorClient.tsx
@@ -3,7 +3,7 @@
 import type { Static, TObject } from "@sinclair/typebox";
 import type { SubmitHandler } from "react-hook-form";
 
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { useForm } from "react-hook-form";
@@ -86,6 +86,10 @@ export function PubEditorClient(props: Props) {
 	urlSearchParams.delete(`${paramString}-pub-form`);
 	const pathWithoutFormParam = `${path}?${urlSearchParams.toString()}`;
 
+	// Have the client cache the first pubId it gets so that the pubId isn't changing
+	// on re-render (only relevant on Create)
+	const [pubId, _] = useState(props.pubId);
+
 	const schema = useMemo(
 		() => createPubEditorSchemaFromPubFields(props.pubFields),
 		[props.pubFields]
@@ -125,7 +129,7 @@ export function PubEditorClient(props: Props) {
 
 		if (props.isUpdating) {
 			const result = await runUpdatePub({
-				pubId: props.pubId,
+				pubId,
 				pubValues,
 				stageId: stageId as StagesId,
 			});
@@ -146,7 +150,7 @@ export function PubEditorClient(props: Props) {
 			}
 
 			const result = await runCreatePub({
-				pubId: props.pubId,
+				pubId,
 				communityId: props.communityId,
 				parentId: props.parentId,
 				pubTypeId: pubTypeId as PubTypesId,

--- a/core/app/components/pubs/PubEditor/PubEditorClient.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditorClient.tsx
@@ -55,10 +55,12 @@ type Props = {
 	formElements: React.ReactNode[];
 	parentId?: PubsId;
 	pubFields: Pick<PubField, "slug" | "schemaName">[];
-	pubId?: PubsId;
+	pubId: PubsId;
 	pubTypeId: PubTypes["id"];
 	pubValues: PubValues;
 	stageId?: StagesId;
+	/** Is updating or creating? */
+	isUpdating: boolean;
 };
 
 const hasNoValidPubFields = (pubFields: Props["pubFields"], schema: TObject<any>) => {
@@ -121,7 +123,7 @@ export function PubEditorClient(props: Props) {
 	const onSubmit: SubmitHandler<Static<typeof schema>> = async (data) => {
 		const { pubTypeId, stageId, ...pubValues } = data;
 
-		if (props.pubId) {
+		if (props.isUpdating) {
 			const result = await runUpdatePub({
 				pubId: props.pubId,
 				pubValues,
@@ -144,6 +146,7 @@ export function PubEditorClient(props: Props) {
 			}
 
 			const result = await runCreatePub({
+				pubId: props.pubId,
 				communityId: props.communityId,
 				parentId: props.parentId,
 				pubTypeId: pubTypeId as PubTypesId,
@@ -167,7 +170,7 @@ export function PubEditorClient(props: Props) {
 				className={cn("relative flex flex-col gap-6", props.className)}
 				onBlur={(e) => e.preventDefault()}
 			>
-				{!props.pubId && (
+				{!props.isUpdating && (
 					<FormField
 						name="pubTypeId"
 						control={form.control}

--- a/core/app/components/pubs/PubEditor/actions.ts
+++ b/core/app/components/pubs/PubEditor/actions.ts
@@ -5,11 +5,11 @@ import { revalidatePath } from "next/cache";
 import type { CommunitiesId, PubsId, PubTypesId, StagesId } from "db/public";
 import { logger } from "logger";
 
+import type { PubValues } from "~/lib/server";
 import { validatePubValuesBySchemaName } from "~/actions/_lib/validateFields";
 import { db } from "~/kysely/database";
 import { getLoginData } from "~/lib/auth/loginData";
 import { isCommunityAdmin } from "~/lib/auth/roles";
-import { PubValues } from "~/lib/server";
 import { autoCache } from "~/lib/server/cache/autoCache";
 import { autoRevalidate } from "~/lib/server/cache/autoRevalidate";
 import { defineServerAction } from "~/lib/server/defineServerAction";
@@ -21,6 +21,7 @@ export const createPub = defineServerAction(async function createPub({
 	pubValues,
 	path,
 	parentId,
+	pubId,
 }: {
 	communityId: CommunitiesId;
 	stageId: StagesId;
@@ -28,6 +29,7 @@ export const createPub = defineServerAction(async function createPub({
 	pubValues: PubValues;
 	path?: string | null;
 	parentId?: PubsId;
+	pubId?: PubsId;
 }) {
 	const { user } = await getLoginData();
 	if (!user) {
@@ -47,6 +49,7 @@ export const createPub = defineServerAction(async function createPub({
 					db
 						.insertInto("pubs")
 						.values({
+							id: pubId,
 							communityId: communityId,
 							pubTypeId: pubTypeId,
 							parentId: parentId,

--- a/core/app/components/pubs/UpdatePubButton.tsx
+++ b/core/app/components/pubs/UpdatePubButton.tsx
@@ -1,5 +1,5 @@
-import { PubsId } from "db/public";
-import { ButtonProps } from "ui/button";
+import type { PubsId } from "db/public";
+import type { ButtonProps } from "ui/button";
 import { Pencil } from "ui/icon";
 
 import type { PubEditorProps } from "./PubEditor/PubEditor";


### PR DESCRIPTION
## Issue(s) Resolved
https://knowledgefutures.slack.com/archives/CMAQM0BNV/p1727286693619029

## High-level Explanation of PR
File upload was not working on form create. This fixes that by generating a pubId the file uploader can use when uploading files. Also has to remove a Suspense key which was causing the whole form to rerender when changing members or files

## Test Plan

## Screenshots (if applicable)

## Notes
