### PR TITLE
Restore setting html to render rich text in forms

### DIFF
--- a/core/app/components/forms/FormElement.tsx
+++ b/core/app/components/forms/FormElement.tsx
@@ -1,8 +1,7 @@
-import Markdown from "react-markdown";
-
 import type { GetPubResponseBody } from "contracts";
 import type { MembersId, PubsId } from "db/public";
 import { CoreSchemaType, ElementType } from "db/public";
+import { expect } from "utils";
 
 import type { Form } from "~/lib/server/form";
 import { BooleanElement } from "./elements/BooleanElement";
@@ -33,7 +32,13 @@ export const FormElement = ({
 	const { schemaName, label: labelProp, slug } = element;
 	if (!slug) {
 		if (element.type === ElementType.structural) {
-			return <Markdown>{element.content}</Markdown>;
+			return (
+				<div
+					className="prose"
+					// TODO: sanitize content
+					dangerouslySetInnerHTML={{ __html: expect(element.content) }}
+				/>
+			);
 		}
 		return null;
 	}


### PR DESCRIPTION
## Issue(s) Resolved
Closes https://github.com/pubpub/pubpub/issues/3178

## High-level Explanation of PR

https://github.com/pubpub/platform/pull/528 refactored the rendering of structural components to use `react-markdown` instead, but the components are actually saved as HTML so `react-markdown` just renders an escaped version of the html rather than what the html says to render. I restored what was originally there, though we should do a pass thru the app and sanitize all the places we put `TODO: sanitize`! Also, not sure if there was a particular reason it was changed to `Markdown` in that PR that I'm missing?

## Test Plan
* Add a structural element to a form with markdown
* View the `fill` version of the form. the markdown should render as expected

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/6d5c7178-5846-422f-8f14-c7558f03bf15)


## Notes
