### PR TITLE
Fix `NULLS` migration for pg14

### DIFF
--- a/core/prisma/migrations/20240923161145_add_null_core_schema_type_and_make_pubvalues_unique_constraint_not_null_unique/migration.sql
+++ b/core/prisma/migrations/20240923161145_add_null_core_schema_type_and_make_pubvalues_unique_constraint_not_null_unique/migration.sql
@@ -5,5 +5,9 @@ ALTER TYPE "CoreSchemaType" ADD VALUE 'Null';
 -- We want to be able to still have a unique constraint on just pubId and fieldId if there is a null relatedPubId
 BEGIN;
 DROP INDEX "pub_values_pubId_relatedPubId_fieldId_key";
-CREATE UNIQUE INDEX "pub_values_pubId_relatedPubId_fieldId_key" ON "pub_values"("pubId", "relatedPubId", "fieldId") NULLS NOT DISTINCT;
+CREATE UNIQUE INDEX "pub_values_pubId_relatedPubId_fieldId_key" ON "pub_values"("pubId", "relatedPubId", "fieldId")
+WHERE "relatedPubId" IS NOT NULL;
+
+CREATE UNIQUE INDEX "pub_values_pubId_fieldId_key" ON "pub_values"("pubId", "fieldId")
+WHERE "relatedPubId" IS NULL;
 COMMIT;


### PR DESCRIPTION
## Issue(s) Resolved

https://knowledgefutures.slack.com/archives/CMAQM0BNV/p1727361690973769

## High-level Explanation of PR
I used `NULLS NOT DISTINCT` which is only available in pg15, not realizing we are only on pg14 in prod!

## Test Plan

## Screenshots (if applicable)

## Notes
