### PR TITLE
Fix pub creation and editing

### DIFF
--- a/core/app/components/pubs/PubEditor/actions.ts
+++ b/core/app/components/pubs/PubEditor/actions.ts
@@ -145,18 +145,19 @@ export const _updatePub = async ({
 		const existingPubFieldValues = await autoCache(
 			trx
 				.selectFrom("pub_fields")
-				.leftJoin("pub_values", "pub_values.fieldId", "pub_fields.id")
+				.leftJoin("pub_values", (join) =>
+					join
+						.onRef("pub_values.fieldId", "=", "pub_fields.id")
+						.on("pub_values.pubId", "=", pubId)
+				)
 				.where("pub_fields.slug", "in", toBeUpdatedPubFieldSlugs)
-				.distinctOn("pub_fields.id")
-				.orderBy(["pub_fields.id", "pub_values.createdAt desc"])
+				.where("pub_fields.isRelation", "=", false)
 				.select([
 					"pub_values.id as pubValueId",
-					"pub_values.pubId",
 					"pub_fields.slug",
 					"pub_fields.name",
 					"pub_fields.schemaName",
 				])
-				.where("pub_fields.isRelation", "=", false)
 		).execute();
 
 		const validated = validatePubValuesBySchemaName({
@@ -180,9 +181,7 @@ export const _updatePub = async ({
 						Object.entries(pubValues).map(([pubFieldSlug, pubValue]) => ({
 							id:
 								existingPubFieldValues.find(
-									(pubFieldValue) =>
-										pubFieldValue.slug === pubFieldSlug &&
-										pubFieldValue.pubId === pubId
+									(pubFieldValue) => pubFieldValue.slug === pubFieldSlug
 								)?.pubValueId ?? undefined,
 							pubId,
 							value: JSON.stringify(pubValue),

--- a/core/app/components/pubs/PubEditor/helpers.ts
+++ b/core/app/components/pubs/PubEditor/helpers.ts
@@ -45,7 +45,7 @@ export const createPubEditorDefaultValuesFromPubFields = (
 			(acc, { slug }) => {
 				acc[slug] =
 					pubFields.find((e) => e.slug === slug)?.schemaName === CoreSchemaType.DateTime
-						? new Date(pubValues[slug] as string)
+						? pubValues[slug] && new Date(pubValues[slug] as string)
 						: pubValues[slug];
 				return acc;
 			},


### PR DESCRIPTION
## Issue(s) Resolved
#673 
## High-level Explanation of PR
The query we use to update pub values uses the presence of an `id` on the values we insert to determine whether they should be new rows or updates to existing rows. Because of an error in the prior query, we were not setting the id on every value, which this PR fixes.

This also fixes a bug where we were creating invalid dates while making the default values for the pub create form.
## Test Plan
1. Update a pub, it should succeed!
2. Create a dateTime field and add it to a pub type
3. On the pubs page, open the create pub form and select the type with the dateTime field
4. Make sure you can create a pub of that type

