### PR TITLE
Restore id to creating pub

### DIFF
--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -448,6 +448,7 @@ export const createPubRecursiveNew = async <Body extends CreatePubRequestBodyWit
 			trx
 				.insertInto("pubs")
 				.values({
+					id: body.id as PubsId | undefined,
 					communityId: communityId,
 					pubTypeId: body.pubTypeId as PubTypesId,
 					assigneeId: body.assigneeId as UsersId,


### PR DESCRIPTION
## Issue(s) Resolved

Quick follow up to https://github.com/pubpub/platform/pull/676 which replaced the create pub function, but neglected to keep the ability to specify a client side id (doh!)

## High-level Explanation of PR

Needed for https://github.com/pubpub/platform/pull/657 to keep working properly

## Test Plan

* Create a field type of FileUpload
* Add this field type to a pub type
* Create a pub of this pub type and upload a file. In the network tab, you can inspect for what path this file is being uploaded to. Make a note of the pub Id
* Submit the create pub form
* The created pub's id should match the pub id that the file upload went up to (this is currently broken after https://github.com/pubpub/platform/pull/676!)

## Screenshots (if applicable)

## Notes
