### PR TITLE
Fix onChange of slider component

### DIFF
--- a/core/app/components/forms/elements/ConfidenceElement.tsx
+++ b/core/app/components/forms/elements/ConfidenceElement.tsx
@@ -27,22 +27,27 @@ export const Vector3Element = ({ label, name }: ElementProps) => {
 			control={control}
 			name={name}
 			defaultValue={[0, 0, 0]}
-			render={({ field }) => (
-				<FormItem className="mb-6">
-					<FormLabel className="text-[0.9em]">{label}</FormLabel>
-					<FormControl>
-						<Confidence
-							{...field}
-							disabled={!isEnabled}
-							min={0}
-							max={100}
-							onValueChange={(event) => field.onChange(event)}
-							className="confidence"
-						/>
-					</FormControl>
-					<FormMessage />
-				</FormItem>
-			)}
+			render={({ field }) => {
+				// Need to pass the field's onChange as onValueChange in Confidence
+				// and make sure it is not passed in as the default onChange
+				const { onChange, ...fieldProps } = field;
+				return (
+					<FormItem className="mb-6">
+						<FormLabel className="text-[0.9em]">{label}</FormLabel>
+						<FormControl>
+							<Confidence
+								{...fieldProps}
+								disabled={!isEnabled}
+								min={0}
+								max={100}
+								onValueChange={onChange}
+								className="confidence"
+							/>
+						</FormControl>
+						<FormMessage />
+					</FormItem>
+				);
+			}}
 		/>
 	);
 };

--- a/core/app/components/forms/elements/ConfidenceElement.tsx
+++ b/core/app/components/forms/elements/ConfidenceElement.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { forwardRef } from "react";
 import dynamic from "next/dynamic";
 import { useFormContext } from "react-hook-form";
 
@@ -16,6 +17,13 @@ const Confidence = dynamic(
 		loading: () => <div>Loading...</div>,
 	}
 );
+
+// Workaround for forwarding refs to dynamic components
+// https://github.com/vercel/next.js/issues/4957#issuecomment-413841689
+const ForwardedRefConfidence = forwardRef<
+	React.ElementRef<typeof Confidence>,
+	React.ComponentPropsWithoutRef<typeof Confidence>
+>((props, ref) => <Confidence {...props} forwardedRef={ref} />);
 
 export const Vector3Element = ({ label, name }: ElementProps) => {
 	const { control } = useFormContext();
@@ -35,7 +43,7 @@ export const Vector3Element = ({ label, name }: ElementProps) => {
 					<FormItem className="mb-6">
 						<FormLabel className="text-[0.9em]">{label}</FormLabel>
 						<FormControl>
-							<Confidence
+							<ForwardedRefConfidence
 								{...fieldProps}
 								disabled={!isEnabled}
 								min={0}

--- a/packages/sdk/src/react/generateFormFields.tsx
+++ b/packages/sdk/src/react/generateFormFields.tsx
@@ -169,25 +169,28 @@ const CustomRenderer = (props: CustomRendererProps) => {
 				control={control}
 				name={fieldName}
 				defaultValue={fieldSchema.default ?? [0, 0, 0]}
-				render={({ field }) => (
-					<FormItem className="mb-6">
-						<FormLabel className="text-[0.9em]">{fieldSchema.title}</FormLabel>
-						<FormDescription
-							className="text-[0.8em]"
-							dangerouslySetInnerHTML={{ __html: fieldSchema.description }}
-						/>
-						<FormControl>
-							<Confidence
-								{...field}
-								min={min}
-								max={max}
-								onValueChange={(event) => field.onChange(event)}
-								className="confidence"
+				render={({ field }) => {
+					const { onChange, ...fieldProps } = field;
+					return (
+						<FormItem className="mb-6">
+							<FormLabel className="text-[0.9em]">{fieldSchema.title}</FormLabel>
+							<FormDescription
+								className="text-[0.8em]"
+								dangerouslySetInnerHTML={{ __html: fieldSchema.description }}
 							/>
-						</FormControl>
-						<FormMessage />
-					</FormItem>
-				)}
+							<FormControl>
+								<Confidence
+									{...fieldProps}
+									min={min}
+									max={max}
+									onValueChange={onChange}
+									className="confidence"
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					);
+				}}
 			/>
 		);
 	}

--- a/packages/ui/src/customRenderers/confidence/confidence.tsx
+++ b/packages/ui/src/customRenderers/confidence/confidence.tsx
@@ -7,8 +7,10 @@ import { cn } from "utils";
 
 const Slider = React.forwardRef<
 	React.ElementRef<typeof SliderPrimitive.Root>,
-	React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
+	React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
+		forwardedRef?: React.ForwardedRef<any>;
+	}
+>(({ className, forwardedRef, ...props }, ref) => (
 	<SliderPrimitive.Root
 		ref={ref}
 		className={cn("relative flex w-full touch-none select-none items-center", className)}


### PR DESCRIPTION
## Issue(s) Resolved

Closes https://github.com/pubpub/platform/issues/681

## High-level Explanation of PR
I don't know why this didn't happen before, but it appears that we need to be careful not to pass `onChange` to `Confidence` if we are passing `onValueChange`. This PR just makes sure we don't pass `onChange` along with `onValueChange` since that results in a bad set state

## Test Plan

See repro steps in https://github.com/pubpub/platform/issues/681 only the page shouldn't crash anymore!

## Screenshots (if applicable)

https://github.com/user-attachments/assets/886044f5-9de9-4879-b8a1-748918e9084b

## Notes

~~There is also a forwardRef error which I was able to fix but not without being TS compliant, so I'm still looking into it...~~

Fixed! There was a forwardRef error showing up in the console which was a result of dynamically importing the slider component. Fixed using the strategy described in https://github.com/vercel/next.js/issues/4957#issuecomment-413841689
