### PR TITLE
fix: restore base image build on pr/main 

### DIFF
--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -123,7 +123,7 @@ jobs:
                   task-definition: ${{ steps.task-def-service.outputs.task-definition }}
                   service: ${{ env.ECS_SERVICE }}
                   cluster: ${{ env.ECS_CLUSTER }}
-                  wait-for-service-stability: false
+                  wait-for-service-stability: true
 
             - name: Deploy Amazon ECS task definition including migrations
               id: deploy-service-and-migrations
@@ -134,3 +134,4 @@ jobs:
                   task-definition: ${{ steps.task-def-migration.outputs.task-definition }}
                   service: ${{ env.ECS_SERVICE }}
                   cluster: ${{ env.ECS_CLUSTER }}
+                  wait-for-service-stability: true

--- a/.github/workflows/ecrbuild-all.yml
+++ b/.github/workflows/ecrbuild-all.yml
@@ -23,14 +23,12 @@ jobs:
                   sha_short=$(git describe --always --abbrev=40 --dirty)
                   echo "Building containers with tag:"
                   echo "$sha_short"
-    # TODO: restore the commented `needs` lines
-    # and the `build-base` job
-    # once we implement Docker build caching in github actions
-    # build-base:
-    #     uses: ./.github/workflows/ecrbuild-template.yml
-    #     secrets:
-    #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+
+    build-base:
+        uses: ./.github/workflows/ecrbuild-template.yml
+        secrets:
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
     build-core:
         uses: ./.github/workflows/ecrbuild-template.yml


### PR DESCRIPTION
- **fix: restore building the base image, as we need it for migrations**
- **feat: make ECS deploy task wait until service is stable**

## Issue(s) Resolved
Core was not deploying correctly

## High-level Explanation of PR
For the integration tests PR, i commented out the building of the base image (up until the `monorepo` step in `Dockerfile`), because I thought it was unnecessary.
Turns out we use it for migrations, and core needs it to be able to run. Thus, it is restored.

I added the `wait-for-service-stability: true` flag on the ECS deploy task, which should hopefully fail CD (show us an x) if the service does not start succesfully in the future.

<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan
1. Make sure base image builds and is pushed during CI.
2. Send it.

## Screenshots (if applicable)

## Notes
