### PR TITLE
Return content unchanged when structural elements contain invalid markdown

### DIFF
--- a/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/page.tsx
+++ b/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/page.tsx
@@ -97,7 +97,9 @@ const renderElementMarkdownContent = async (
 	if (element.content === null) {
 		return "";
 	}
-	return renderMarkdownWithPub(element.content, renderWithPubContext);
+	return renderMarkdownWithPub(element.content, renderWithPubContext).catch(
+		() => element.content
+	);
 };
 
 export async function generateMetadata({


### PR DESCRIPTION
## Issue(s) Resolved
https://kfg.sentry.io/issues/5947937548/?referrer=slack&notification_uuid=1cd3906b-24f1-4645-97ce-
afcbfd8b50ad&alert_rule_id=14700264&alert_type=issue
https://kfg.sentry.io/issues/5947682287/?referrer=slack&notification_uuid=bdeb0e60-f32f-4430-8042-336074f9fbbd&alert_rule_id=14700264&alert_type=issue
## High-level Explanation of PR
This is just a quick fix to stop the fill page from crashing. In the future we'll provide feedback on the fill page to stop people from saving invalid markdown in the first place
## Test Plan
Add a paragraph element to a form, then set it's contents to a directive syntax error such as a bare `:link` 
Visit the fill page and make sure you don't see an error

