### PR TITLE
Try using exec when playwright installs browser

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -98,7 +98,7 @@ jobs:
                   echo "jobs_label=$ECR_REGISTRY/${ECR_REPOSITORY_NAME_OVERRIDE:-$ECR_REPOSITORY_PREFIX-jobs}:$IMAGE_TAG" >> $GITHUB_OUTPUT
                   echo "base_label=$ECR_REGISTRY/$ECR_REPOSITORY_PREFIX:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-            - run: pnpx playwright install chromium --with-deps
+            - run: pnpx exec playwright install chromium --with-deps
 
             - name: Start up core
               run: docker compose -f docker-compose.test.yml --profile integration up -d

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -98,7 +98,7 @@ jobs:
                   echo "jobs_label=$ECR_REGISTRY/${ECR_REPOSITORY_NAME_OVERRIDE:-$ECR_REPOSITORY_PREFIX-jobs}:$IMAGE_TAG" >> $GITHUB_OUTPUT
                   echo "base_label=$ECR_REGISTRY/$ECR_REPOSITORY_PREFIX:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-            - run: pnpx exec playwright install chromium --with-deps
+            - run: pnpm --filter core exec playwright install chromium --with-deps
 
             - name: Start up core
               run: docker compose -f docker-compose.test.yml --profile integration up -d


### PR DESCRIPTION
## Issue(s) Resolved

Call `exec` from `e2e.yml` so that we use the installed version of playwright in `node_modules`. To try not to get an error where we are using two different playwright versions!

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan

## Screenshots (if applicable)

## Notes
