### PR TITLE
Fix markdown rendering when form is creating a pub

### DIFF
--- a/core/app/c/[communitySlug]/forms/[formSlug]/edit/page.tsx
+++ b/core/app/c/[communitySlug]/forms/[formSlug]/edit/page.tsx
@@ -1,3 +1,4 @@
+import dynamic from "next/dynamic";
 import { notFound } from "next/navigation";
 
 import type { CommunitiesId } from "db/public";
@@ -14,7 +15,11 @@ import { getForm } from "~/lib/server/form";
 import { getPubFields } from "~/lib/server/pubFields";
 import { ContentLayout } from "../../../ContentLayout";
 import { EditFormTitleButton } from "./EditFormTitleButton";
-import { FormCopyButton } from "./FormCopyButton";
+
+const FormCopyButton = dynamic(
+	() => import("./FormCopyButton").then((module) => module.FormCopyButton),
+	{ ssr: false }
+);
 
 const getCommunityStages = (communityId: CommunitiesId) =>
 	db.selectFrom("stages").where("stages.communityId", "=", communityId).selectAll();

--- a/core/lib/server/render/pub/renderMarkdownWithPub.ts
+++ b/core/lib/server/render/pub/renderMarkdownWithPub.ts
@@ -330,3 +330,16 @@ export const renderMarkdownWithPub = async (
 
 	return result.toString().trim();
 };
+
+export const renderMarkdownAsHtml = async (text: string) => {
+	const processor = unified()
+		.use(remarkParse)
+		.use(remarkDirective)
+		.use(remarkRehype)
+		.use(rehypeFormat)
+		.use(rehypeStringify);
+
+	const result = await processor.process(text);
+
+	return result.toString().trim();
+};


### PR DESCRIPTION
## Issue(s) Resolved

Closes https://github.com/pubpub/platform/issues/705

## High-level Explanation of PR
On form create, there is no pub ID. Before, the form just wouldn't render any structural markdown. Now, it renders it, but it won't be able to handle the directives that reference a pub.

## Test Plan
* Create a form with structural paragraph and put markdown in it
* Visit the form's fill page i.e. http://localhost:3000/c/croccroc/public/forms/review/fill
* The markdown should render
* The markdown should also render if you pass a pubId param
* Adding a directive like `:link[view]{field="croccroc:url"}` should work in the URL with the pub id, but should render nothing in the URL without the pub id.

## Screenshots (if applicable)

Without pub ID
![image](https://github.com/user-attachments/assets/95a21745-034a-4a2f-b425-4e99fd935cea)

With pub ID
![image](https://github.com/user-attachments/assets/8ffd83b3-9a78-4376-b44e-486e9f8ce4d7)


## Notes
