### PR TITLE
dev: run e2e tests before deploying

### DIFF
--- a/.github/workflows/on_main.yml
+++ b/.github/workflows/on_main.yml
@@ -29,7 +29,9 @@ jobs:
 
     deploy-all:
         uses: ./.github/workflows/awsdeploy.yml
-        needs: build-all
+        needs:
+            - build-all
+            - run-e2e
         with:
             proper-name: stevie
             environment: production

--- a/.github/workflows/on_main.yml
+++ b/.github/workflows/on_main.yml
@@ -18,6 +18,15 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
+    run-e2e:
+        needs:
+            - ci
+            - build-all
+        uses: ./.github/workflows/e2e.yml
+        secrets:
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+
     deploy-all:
         uses: ./.github/workflows/awsdeploy.yml
         needs: build-all


### PR DESCRIPTION
- **dev: make e2e tests run on promotion to main**
- **fix: make deploy wait for e2e, duh**

## Issue(s) Resolved

## High-level Explanation of PR
We should probably be good children and eat our vegetables and just run e2e tests on promotion to main even though we require you to run be up to speed with main anyway.
<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan

## Screenshots (if applicable)

## Notes
