### PR TITLE
Add unsaved changes warning to form

### DIFF
--- a/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/ExternalFormWrapper.tsx
+++ b/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/ExternalFormWrapper.tsx
@@ -20,6 +20,7 @@ import type { GetPubResponseBody, JsonValue } from "contracts";
 import type { PubsId, PubTypesId } from "db/public";
 import { CoreSchemaType, ElementType } from "db/public";
 import { Form } from "ui/form";
+import { useUnsavedChangesWarning } from "ui/hooks";
 import { cn } from "utils";
 
 import type { FormElementToggleContext } from "~/app/components/forms/FormElementToggleContext";
@@ -35,20 +36,6 @@ import { SAVE_STATUS_QUERY_PARAM, SUBMIT_ID_QUERY_PARAM } from "./constants";
 import { SubmitButtons } from "./SubmitButtons";
 
 const SAVE_WAIT_MS = 5000;
-
-const useUnsavedChangesWarning = ({ isDirty }: FormState<FieldValues>) => {
-	useEffect(() => {
-		const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-			if (isDirty) {
-				event.preventDefault();
-			}
-		};
-		window.addEventListener("beforeunload", handleBeforeUnload);
-		return () => {
-			window.removeEventListener("beforeunload", handleBeforeUnload);
-		};
-	}, [isDirty]);
-};
 
 const isComplete = (formElements: PubPubForm["elements"], values: FieldValues) => {
 	const requiredElements = formElements.filter((fe) => fe.required && fe.slug);
@@ -82,7 +69,12 @@ const preparePayload = ({
 	// we do not want to pass an empty `email` field to the upsert (it will fail validation)
 	const payload: Record<string, JsonValue> = {};
 	for (const { slug } of formElements) {
-		if (slug && toggleContext.isEnabled(slug) && formState.dirtyFields[slug]) {
+		if (
+			slug &&
+			toggleContext.isEnabled(slug) &&
+			// Only send fields that were changed.
+			formState.dirtyFields[slug]
+		) {
 			payload[slug] = formValues[slug];
 		}
 	}
@@ -240,6 +232,19 @@ export const ExternalFormWrapper = ({
 				if (!isUpdating) {
 					newParams.set("pubId", pubId);
 				}
+
+				if (autoSave) {
+					// Reset dirty state to prevent the unsaved changes warning from
+					// blocking navigation.
+					// See https://stackoverflow.com/questions/63953501/react-hook-form-resetting-isdirty-without-clearing-form
+					formInstance.reset(
+						{},
+						{
+							keepValues: true,
+						}
+					);
+				}
+
 				if (!autoSave && isComplete(formElements, pubValues)) {
 					if (submitButtonId) {
 						newParams.set(SUBMIT_ID_QUERY_PARAM, submitButtonId);
@@ -268,7 +273,7 @@ export const ExternalFormWrapper = ({
 		formInstance.trigger(Object.keys(formInstance.formState.errors));
 	}, [formInstance, toggleContext]);
 
-	useUnsavedChangesWarning(formInstance.formState);
+	useUnsavedChangesWarning(formInstance.formState.isDirty);
 
 	const isSubmitting = formInstance.formState.isSubmitting;
 

--- a/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/page.tsx
+++ b/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/page.tsx
@@ -17,7 +17,7 @@ import { FormElement } from "~/app/components/forms/FormElement";
 import { FormElementToggleProvider } from "~/app/components/forms/FormElementToggleContext";
 import { getLoginData } from "~/lib/auth/loginData";
 import { getCommunityRole } from "~/lib/auth/roles";
-import { getPub } from "~/lib/server";
+import { getPub, getPubCached } from "~/lib/server";
 import { findCommunityBySlug } from "~/lib/server/community";
 import { getForm, userHasPermissionToForm } from "~/lib/server/form";
 import {
@@ -157,7 +157,7 @@ export default async function FormPage({
 			slug: params.formSlug,
 			communityId: community.id,
 		}).executeTakeFirst(),
-		searchParams.pubId ? await getPub(searchParams.pubId) : undefined,
+		searchParams.pubId ? await getPubCached(searchParams.pubId) : undefined,
 	]);
 
 	if (!form) {

--- a/core/app/c/[communitySlug]/forms/[formSlug]/edit/page.tsx
+++ b/core/app/c/[communitySlug]/forms/[formSlug]/edit/page.tsx
@@ -26,10 +26,14 @@ const getCommunityStages = (communityId: CommunitiesId) =>
 
 export default async function Page({
 	params: { formSlug, communitySlug },
+	searchParams: { unsavedChanges },
 }: {
 	params: {
 		formSlug: string;
 		communitySlug: string;
+	};
+	searchParams: {
+		unsavedChanges: boolean;
 	};
 }) {
 	const { user } = await getPageLoginData();
@@ -70,7 +74,7 @@ export default async function Page({
 				<div className="flex items-center gap-2">
 					<FormCopyButton formSlug={formSlug} />
 					{/* <ArchiveFormButton id={form.id} className="border border-slate-950 px-4" />{" "} */}
-					<SaveFormButton form={formBuilderId} />
+					<SaveFormButton form={formBuilderId} disabled={!unsavedChanges} />
 				</div>
 			}
 		>

--- a/core/app/components/FormBuilder/ElementPanel/InputComponentConfigurationForm.tsx
+++ b/core/app/components/FormBuilder/ElementPanel/InputComponentConfigurationForm.tsx
@@ -15,6 +15,7 @@ import { Button } from "ui/button";
 import { Checkbox } from "ui/checkbox";
 import { Confidence } from "ui/customRenderers/confidence/confidence";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "ui/form";
+import { useUnsavedChangesWarning } from "ui/hooks";
 import { ImagePlus } from "ui/icon";
 import { Input } from "ui/input";
 import { Label } from "ui/label";
@@ -223,6 +224,8 @@ export const InputComponentConfigurationForm = ({ index }: Props) => {
 		defaultValues: selectedElement,
 	});
 
+	useUnsavedChangesWarning(form.formState.isDirty);
+
 	const component = form.watch("component");
 
 	const onSubmit = (values: ConfigFormData<typeof component>) => {
@@ -300,7 +303,11 @@ export const InputComponentConfigurationForm = ({ index }: Props) => {
 					>
 						Cancel
 					</Button>
-					<Button type="submit" className="bg-blue-500 hover:bg-blue-600">
+					<Button
+						type="submit"
+						className="bg-blue-500 hover:bg-blue-600"
+						disabled={!form.formState.isDirty}
+					>
 						Save
 					</Button>
 				</div>

--- a/core/app/components/FormBuilder/ElementPanel/SelectAccess.tsx
+++ b/core/app/components/FormBuilder/ElementPanel/SelectAccess.tsx
@@ -1,22 +1,9 @@
 "use client";
 
-import type { ControllerRenderProps } from "react-hook-form";
-
-import React from "react";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm, useFormContext } from "react-hook-form";
-import { z } from "zod";
+import { useFormContext } from "react-hook-form";
 
 import { FormAccessType } from "db/public";
-import {
-	Form,
-	FormControl,
-	FormDescription,
-	FormField,
-	FormItem,
-	FormLabel,
-	FormMessage,
-} from "ui/form";
+import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "ui/form";
 import { Contact, Lock, Users } from "ui/icon";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "ui/select";
 
@@ -41,79 +28,47 @@ const iconsAndCopy = {
 	},
 };
 
-const schema = z.object({
-	access: z.nativeEnum(FormAccessType),
-});
-
 export const SelectAccess = () => {
-	const { getValues, setValue } = useFormContext();
-
-	const access: FormAccessType = getValues("access");
-
-	const form = useForm<z.infer<typeof schema>>({
-		resolver: zodResolver(schema),
-		defaultValues: {
-			access,
-		},
-	});
-
-	const setAccess =
-		(
-			field: ControllerRenderProps<
-				{
-					access: FormAccessType;
-				},
-				"access"
-			>
-		) =>
-		(access: FormAccessType) => {
-			field.onChange(access);
-			setValue("access", access);
-		};
-
+	const { control } = useFormContext();
 	return (
-		<Form {...form}>
-			<form>
-				<FormField
-					control={form.control}
-					name="access"
-					render={({ field }) => (
-						<FormItem>
-							<FormLabel className="text-sm uppercase text-slate-500">
-								Access
-							</FormLabel>
-							<hr />
-							<Select onValueChange={setAccess(field)} defaultValue={field.value}>
-								<FormControl>
-									<SelectTrigger>
-										<SelectValue placeholder="Select a type" />
-									</SelectTrigger>
-								</FormControl>
-								<SelectContent>
-									{Object.values(FormAccessType).map((t) => {
-										const { Icon, description, name } = iconsAndCopy[t];
-										return (
-											<SelectItem key={t} value={t.toString()}>
-												<div className="flex h-auto flex-1 flex-shrink-0 items-center gap-2">
-													<Icon size={16} />
-													<div className="flex flex-col items-start">
-														<div className="font-medium">{name}</div>
-														<div className="text-xs text-slate-500">
-															{description}
-														</div>
-													</div>
+		<FormField
+			control={control}
+			name="access"
+			render={({ field }) => (
+				<FormItem>
+					<FormLabel className="text-sm uppercase text-slate-500">Access</FormLabel>
+					<hr />
+					<Select onValueChange={field.onChange} defaultValue={field.value}>
+						<FormControl>
+							<SelectTrigger>
+								<SelectValue placeholder="Select a type" />
+							</SelectTrigger>
+						</FormControl>
+						<SelectContent>
+							{Object.values(FormAccessType).map((t) => {
+								const { Icon, description, name } = iconsAndCopy[t];
+								return (
+									<SelectItem key={t} value={t.toString()}>
+										<div className="flex h-auto flex-1 flex-shrink-0 items-center gap-2">
+											<Icon size={16} />
+											<div className="flex flex-col items-start">
+												<div className="font-medium">{name}</div>
+												<div className="text-xs text-slate-500">
+													{description}
 												</div>
-											</SelectItem>
-										);
-									})}
-								</SelectContent>
-							</Select>
-							<FormDescription>{iconsAndCopy[field.value].help}</FormDescription>
-							<FormMessage />
-						</FormItem>
-					)}
-				/>
-			</form>
-		</Form>
+											</div>
+										</div>
+									</SelectItem>
+								);
+							})}
+						</SelectContent>
+					</Select>
+					<FormDescription>
+						{iconsAndCopy[field.value as FormAccessType].help}
+					</FormDescription>
+					<FormMessage />
+				</FormItem>
+			)}
+		/>
 	);
 };

--- a/core/app/components/FormBuilder/ElementPanel/StructuralElementConfigurationForm.tsx
+++ b/core/app/components/FormBuilder/ElementPanel/StructuralElementConfigurationForm.tsx
@@ -10,6 +10,7 @@ import { zodToHtmlInputProps } from "ui/auto-form";
 import { Button } from "ui/button";
 import { MarkdownEditor } from "ui/editors";
 import { Form, FormField } from "ui/form";
+import { useUnsavedChangesWarning } from "ui/hooks";
 
 import { useFormBuilder } from "../FormBuilderContext";
 import { structuralElements } from "../StructuralElements";
@@ -38,6 +39,8 @@ export const StructuralElementConfigurationForm = ({ index }: Props) => {
 		resolver,
 		defaultValues: schema.parse(selectedElement),
 	});
+
+	useUnsavedChangesWarning(form.formState.isDirty);
 
 	const onSubmit = (values: z.infer<typeof schema>) => {
 		update(index, { ...selectedElement, ...values, updated: true, configured: true });
@@ -96,7 +99,11 @@ export const StructuralElementConfigurationForm = ({ index }: Props) => {
 					>
 						Cancel
 					</Button>
-					<Button type="submit" className="bg-blue-500 hover:bg-blue-600">
+					<Button
+						type="submit"
+						className="bg-blue-500 hover:bg-blue-600"
+						disabled={!form.formState.isDirty}
+					>
 						Save
 					</Button>
 				</div>

--- a/core/app/components/FormBuilder/FormBuilderContext.tsx
+++ b/core/app/components/FormBuilder/FormBuilderContext.tsx
@@ -23,6 +23,7 @@ type FormBuilderContext = {
 	dispatch: React.Dispatch<PanelEvent>;
 	slug: string;
 	stages: Stages[];
+	isDirty: boolean;
 };
 
 const FormBuilderContext = createContext<FormBuilderContext | undefined>(undefined);

--- a/core/app/components/FormBuilder/SaveFormButton.tsx
+++ b/core/app/components/FormBuilder/SaveFormButton.tsx
@@ -6,9 +6,10 @@ import { cn } from "utils";
 type Props = {
 	form: string;
 	className?: string;
+	disabled?: boolean;
 };
 
-export const SaveFormButton = ({ form, className }: Props) => {
+export const SaveFormButton = ({ form, className, disabled }: Props) => {
 	return (
 		<Button
 			variant="default"
@@ -17,6 +18,7 @@ export const SaveFormButton = ({ form, className }: Props) => {
 			form={form}
 			type="submit"
 			data-testid="save-form-button"
+			disabled={disabled}
 		>
 			Save
 		</Button>

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./useLocalStorage";
+export * from "./useUnsavedChangesWarning";

--- a/packages/ui/src/hooks/useUnsavedChangesWarning.tsx
+++ b/packages/ui/src/hooks/useUnsavedChangesWarning.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import * as React from "react";
+
+export const useUnsavedChangesWarning = (enabled = true) => {
+	React.useEffect(() => {
+		const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+			if (enabled) {
+				// The preventDefault call is necessary to trigger the browser's
+				// confirmation dialog.
+				event.preventDefault();
+			}
+		};
+		window.addEventListener("beforeunload", handleBeforeUnload);
+		return () => {
+			window.removeEventListener("beforeunload", handleBeforeUnload);
+		};
+	}, [enabled]);
+};


### PR DESCRIPTION
## Issue(s) Resolved

Kind of related to #692. These changes would at least notify users if they would lose progress.

Also partially related to #445, in that it introduces a general-purpose React hook for warning about unsaved changes. The general strategy here can be used on the form builder as well.

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->

This PR changes the external form fill page to notify the user about unsaved changes when navigating. It uses the standard `beforeunload` method of notifying the user in a blocking manner, giving them the opportunity to cancel navigation.

The PR accounts for autosave by clearing the "dirty" flag from the form after an auto-save occurs.

I also change the form to only submit _changed_ values which can potentially make Pub editing w/ forms a bit snappier.

## Test Plan

1. Open a form fill page.
2. Change a value. Attempt to navigate or reload the page. You should be prompted by the browser that you have unsaved changes. Hit cancel to stay on the current page.
3. Wait for an auto-save to trigger. Navigate or refresh again. You should not be prompted.
