### PR TITLE
Add unsaved changes warning to form builder

### DIFF
--- a/core/app/c/[communitySlug]/forms/[formSlug]/edit/page.tsx
+++ b/core/app/c/[communitySlug]/forms/[formSlug]/edit/page.tsx
@@ -26,10 +26,14 @@ const getCommunityStages = (communityId: CommunitiesId) =>
 
 export default async function Page({
 	params: { formSlug, communitySlug },
+	searchParams: { isDirty },
 }: {
 	params: {
 		formSlug: string;
 		communitySlug: string;
+	};
+	searchParams: {
+		isDirty: boolean;
 	};
 }) {
 	const { user } = await getPageLoginData();
@@ -70,7 +74,7 @@ export default async function Page({
 				<div className="flex items-center gap-2">
 					<FormCopyButton formSlug={formSlug} />
 					{/* <ArchiveFormButton id={form.id} className="border border-slate-950 px-4" />{" "} */}
-					<SaveFormButton form={formBuilderId} />
+					<SaveFormButton form={formBuilderId} disabled={!isDirty} />
 				</div>
 			}
 		>

--- a/core/app/c/[communitySlug]/forms/[formSlug]/edit/page.tsx
+++ b/core/app/c/[communitySlug]/forms/[formSlug]/edit/page.tsx
@@ -26,14 +26,14 @@ const getCommunityStages = (communityId: CommunitiesId) =>
 
 export default async function Page({
 	params: { formSlug, communitySlug },
-	searchParams: { isDirty },
+	searchParams: { unsavedChanges },
 }: {
 	params: {
 		formSlug: string;
 		communitySlug: string;
 	};
 	searchParams: {
-		isDirty: boolean;
+		unsavedChanges: boolean;
 	};
 }) {
 	const { user } = await getPageLoginData();
@@ -74,7 +74,7 @@ export default async function Page({
 				<div className="flex items-center gap-2">
 					<FormCopyButton formSlug={formSlug} />
 					{/* <ArchiveFormButton id={form.id} className="border border-slate-950 px-4" />{" "} */}
-					<SaveFormButton form={formBuilderId} disabled={!isDirty} />
+					<SaveFormButton form={formBuilderId} disabled={!unsavedChanges} />
 				</div>
 			}
 		>

--- a/core/app/components/FormBuilder/ElementPanel/InputComponentConfigurationForm.tsx
+++ b/core/app/components/FormBuilder/ElementPanel/InputComponentConfigurationForm.tsx
@@ -15,6 +15,7 @@ import { Button } from "ui/button";
 import { Checkbox } from "ui/checkbox";
 import { Confidence } from "ui/customRenderers/confidence/confidence";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "ui/form";
+import { useUnsavedChangesWarning } from "ui/hooks";
 import { ImagePlus } from "ui/icon";
 import { Input } from "ui/input";
 import { Label } from "ui/label";
@@ -223,6 +224,8 @@ export const InputComponentConfigurationForm = ({ index }: Props) => {
 		defaultValues: selectedElement,
 	});
 
+	useUnsavedChangesWarning(form.formState.isDirty);
+
 	const component = form.watch("component");
 
 	const onSubmit = (values: ConfigFormData<typeof component>) => {
@@ -300,7 +303,11 @@ export const InputComponentConfigurationForm = ({ index }: Props) => {
 					>
 						Cancel
 					</Button>
-					<Button type="submit" className="bg-blue-500 hover:bg-blue-600">
+					<Button
+						type="submit"
+						className="bg-blue-500 hover:bg-blue-600"
+						disabled={!form.formState.isDirty}
+					>
 						Save
 					</Button>
 				</div>

--- a/core/app/components/FormBuilder/ElementPanel/StructuralElementConfigurationForm.tsx
+++ b/core/app/components/FormBuilder/ElementPanel/StructuralElementConfigurationForm.tsx
@@ -10,6 +10,7 @@ import { zodToHtmlInputProps } from "ui/auto-form";
 import { Button } from "ui/button";
 import { MarkdownEditor } from "ui/editors";
 import { Form, FormField } from "ui/form";
+import { useUnsavedChangesWarning } from "ui/hooks";
 
 import { useFormBuilder } from "../FormBuilderContext";
 import { structuralElements } from "../StructuralElements";
@@ -38,6 +39,8 @@ export const StructuralElementConfigurationForm = ({ index }: Props) => {
 		resolver,
 		defaultValues: schema.parse(selectedElement),
 	});
+
+	useUnsavedChangesWarning(form.formState.isDirty);
 
 	const onSubmit = (values: z.infer<typeof schema>) => {
 		update(index, { ...selectedElement, ...values, updated: true, configured: true });
@@ -96,7 +99,11 @@ export const StructuralElementConfigurationForm = ({ index }: Props) => {
 					>
 						Cancel
 					</Button>
-					<Button type="submit" className="bg-blue-500 hover:bg-blue-600">
+					<Button
+						type="submit"
+						className="bg-blue-500 hover:bg-blue-600"
+						disabled={!form.formState.isDirty}
+					>
 						Save
 					</Button>
 				</div>

--- a/core/app/components/FormBuilder/FormBuilder.tsx
+++ b/core/app/components/FormBuilder/FormBuilder.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { useCallback, useReducer, useRef } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { DndContext } from "@dnd-kit/core";
 import { restrictToParentElement, restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
@@ -13,6 +14,7 @@ import type { Stages } from "db/public";
 import { logger } from "logger";
 import { Button } from "ui/button";
 import { Form, FormControl, FormField, FormItem } from "ui/form";
+import { useUnsavedChangesWarning } from "ui/hooks";
 import { CircleCheck, X } from "ui/icon";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "ui/tabs";
 import { TokenProvider } from "ui/tokens";
@@ -170,6 +172,21 @@ export function FormBuilder({ pubForm, id, stages }: Props) {
 		control: form.control,
 	});
 
+	useUnsavedChangesWarning(form.formState.isDirty);
+
+	const router = useRouter();
+	const pathname = usePathname();
+	const params = useSearchParams();
+	React.useEffect(() => {
+		const newParams = new URLSearchParams(params);
+		if (form.formState.isDirty) {
+			newParams.set("isDirty", "true");
+		} else {
+			newParams.delete("isDirty");
+		}
+		router.replace(`${pathname}?${newParams.toString()}`, { scroll: false });
+	}, [form.formState.isDirty, params]);
+
 	const runSaveForm = useServerAction(saveForm);
 	const onSubmit = async (formData: FormBuilderSchema) => {
 		//TODO: only submit dirty fields
@@ -239,6 +256,7 @@ export function FormBuilder({ pubForm, id, stages }: Props) {
 				dispatch={dispatch}
 				slug={pubForm.slug}
 				stages={stages}
+				isDirty={form.formState.isDirty}
 			>
 				<Tabs defaultValue="builder" className="pr-[380px]">
 					<div className="px-6">

--- a/core/app/components/FormBuilder/FormBuilder.tsx
+++ b/core/app/components/FormBuilder/FormBuilder.tsx
@@ -139,6 +139,9 @@ function PanelWrapper({
 }
 
 export function FormBuilder({ pubForm, id, stages }: Props) {
+	const router = useRouter();
+	const pathname = usePathname();
+	const params = useSearchParams();
 	const form = useForm<FormBuilderSchema>({
 		resolver: zodResolver(formBuilderSchema),
 		values: {
@@ -174,9 +177,6 @@ export function FormBuilder({ pubForm, id, stages }: Props) {
 
 	useUnsavedChangesWarning(form.formState.isDirty);
 
-	const router = useRouter();
-	const pathname = usePathname();
-	const params = useSearchParams();
 	React.useEffect(() => {
 		const newParams = new URLSearchParams(params);
 		if (form.formState.isDirty) {

--- a/core/app/components/FormBuilder/FormBuilder.tsx
+++ b/core/app/components/FormBuilder/FormBuilder.tsx
@@ -180,9 +180,9 @@ export function FormBuilder({ pubForm, id, stages }: Props) {
 	React.useEffect(() => {
 		const newParams = new URLSearchParams(params);
 		if (form.formState.isDirty) {
-			newParams.set("isDirty", "true");
+			newParams.set("unsavedChanges", "true");
 		} else {
-			newParams.delete("isDirty");
+			newParams.delete("unsavedChanges");
 		}
 		router.replace(`${pathname}?${newParams.toString()}`, { scroll: false });
 	}, [form.formState.isDirty, params]);

--- a/core/app/components/FormBuilder/FormBuilderContext.tsx
+++ b/core/app/components/FormBuilder/FormBuilderContext.tsx
@@ -23,6 +23,7 @@ type FormBuilderContext = {
 	dispatch: React.Dispatch<PanelEvent>;
 	slug: string;
 	stages: Stages[];
+	isDirty: boolean;
 };
 
 const FormBuilderContext = createContext<FormBuilderContext | undefined>(undefined);

--- a/core/app/components/FormBuilder/SaveFormButton.tsx
+++ b/core/app/components/FormBuilder/SaveFormButton.tsx
@@ -6,9 +6,10 @@ import { cn } from "utils";
 type Props = {
 	form: string;
 	className?: string;
+	disabled?: boolean;
 };
 
-export const SaveFormButton = ({ form, className }: Props) => {
+export const SaveFormButton = ({ form, className, disabled }: Props) => {
 	return (
 		<Button
 			variant="default"
@@ -17,6 +18,7 @@ export const SaveFormButton = ({ form, className }: Props) => {
 			form={form}
 			type="submit"
 			data-testid="save-form-button"
+			disabled={disabled}
 		>
 			Save
 		</Button>


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #445 

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->

This PR changes the form builder to prompt the user (in a blocking manner) about unsaved changes when navigation occurs.

The top-level form builder, structural element editor, and input component editor all received a `useUnsavedChangesWarning` hook call that triggers the default browser unsaved changes prompt when the form state is dirty (modified).

This means that the warning prompt is triggered:
- if you modify a child (structural/input) form without saving the changes
- if you modify a child (structural/input) form and save the changes, but do not save the form
- if you modify the form itself (e.g. add/delete/reorder elements) without saving it

The "save" button within the structural element editor, input component editor, and top-level form builder were changed to become disabled/uninteractive when its respective form is dirty.

When a save button is pressed, its form state is no longer dirty, so it goes back to the disabled/uninteractive state.

## Test Plan

1. Open the form builder.
2. Refresh the page. No prompt.
3. Change the form structure by adding a field, deleting a field, or reordering existing fields.
  - The top-level save button (top right) should become interactive.
  - Refresh the page without saving the form. The prompt should appear.
4. Re-configure an input component or structural element.
  - The input component or structural element form's save button should become interactive.
  - The top-level save button should remain uninteractive.
  - Refresh the page without saving the child form. The prompt should appear.
5. Repeat step 4, but save the child form without refreshing the page.
  - The input component or structural element form's save button should become uninteractive.
  - The top-level save button should become interactive.
  - Refresh the page. The prompt should appear.

## Screenshots (if applicable)

Note that the top-level "save" button (top right) is disabled because the user has not applied the changes from the inner form to the outer form yet:

![image](https://github.com/user-attachments/assets/3e847764-d103-44d5-a7df-a83079017fe8)