### PR TITLE
Multivalue input in form builder, pub editor, and form fill page

### DIFF
--- a/core/app/c/[communitySlug]/types/TypeBlock.tsx
+++ b/core/app/c/[communitySlug]/types/TypeBlock.tsx
@@ -56,6 +56,7 @@ const TypeBlock: React.FC<Props> = function ({ type, allowEditing }) {
 							onClick={() => {
 								setEditing(!editing);
 							}}
+							data-testid={`edit-pubtype-${type.name}`}
 						>
 							<span className="sr-only">Edit Pub Type</span>
 							<Pencil size="12" />

--- a/core/app/components/FormBuilder/ElementPanel/ComponentConfig/MultivalueInput.tsx
+++ b/core/app/components/FormBuilder/ElementPanel/ComponentConfig/MultivalueInput.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+
+import { InputComponent } from "db/public";
+import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "ui/form";
+import { Input } from "ui/input";
+
+import type { ComponentConfigFormProps } from "./types";
+
+export default ({
+	form,
+}: ComponentConfigFormProps<InputComponent.multivalueInput> & {
+	label: string;
+	children?: ReactNode;
+}) => {
+	return (
+		<div className="flex flex-col gap-6">
+			<FormField
+				control={form.control}
+				name="config.label"
+				render={({ field }) => (
+					<FormItem>
+						<FormLabel>Label</FormLabel>
+						<FormControl>
+							<Input placeholder="Description of the selection" {...field} />
+						</FormControl>
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
+			<FormField
+				control={form.control}
+				name="config.help"
+				render={({ field }) => (
+					<FormItem>
+						<FormLabel>Description</FormLabel>
+						<FormControl>
+							<Input placeholder="Optional additional guidance" {...field} />
+						</FormControl>
+						<FormDescription>Appears below the label</FormDescription>
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
+		</div>
+	);
+};

--- a/core/app/components/FormBuilder/ElementPanel/ComponentConfig/index.tsx
+++ b/core/app/components/FormBuilder/ElementPanel/ComponentConfig/index.tsx
@@ -25,6 +25,7 @@ const InputCompomentMap = {
 	[InputComponent.datePicker]: toDynamic("DatePicker"),
 	[InputComponent.fileUpload]: toDynamic("FileUpload"),
 	[InputComponent.memberSelect]: toDynamic("MemberSelect"),
+	[InputComponent.multivalueInput]: toDynamic("MultivalueInput"),
 	[InputComponent.radioGroup]: toDynamic("RadioGroup"),
 	[InputComponent.selectDropdown]: toDynamic("SelectDropdown"),
 	[InputComponent.textArea]: toDynamic("TextArea"),

--- a/core/app/components/FormBuilder/ElementPanel/InputComponentConfigurationForm.tsx
+++ b/core/app/components/FormBuilder/ElementPanel/InputComponentConfigurationForm.tsx
@@ -19,6 +19,7 @@ import { useUnsavedChangesWarning } from "ui/hooks";
 import { ImagePlus } from "ui/icon";
 import { Input } from "ui/input";
 import { Label } from "ui/label";
+import { MultiValueInput } from "ui/multivalue-input";
 import { RadioGroup, RadioGroupItem } from "ui/radio-group";
 import {
 	Select,
@@ -140,6 +141,20 @@ const componentInfo: Record<InputComponent, SchemaComponentData> = {
 			</div>
 		),
 	},
+	[InputComponent.multivalueInput]: {
+		name: "Multivalue Input",
+		demoComponent: () => (
+			<div className="flex flex-col gap-1 text-left text-sm">
+				<div className="text-gray-500">Label</div>
+				<MultiValueInput
+					value={["Value 1"]}
+					onChange={() => {}}
+					className="h-8"
+					valueClassName="h-5"
+				/>
+			</div>
+		),
+	},
 } as const;
 
 const ComponentSelect = ({
@@ -173,7 +188,7 @@ const ComponentSelect = ({
 								onChange(c);
 							}}
 						/>
-						<div className="flex h-[124px] w-full flex-col justify-between rounded-lg border bg-card text-card-foreground shadow-sm peer-checked:border-2 peer-checked:border-ring peer-checked:outline-none">
+						<div className="flex h-32 w-full flex-col justify-between rounded-lg border bg-card text-card-foreground shadow-sm peer-checked:border-2 peer-checked:border-ring peer-checked:outline-none">
 							<label
 								className="cursor-pointer"
 								htmlFor={`component-${c}`}
@@ -183,12 +198,12 @@ const ComponentSelect = ({
 									// 'inert' allows demo components to not be interactive unless they are selected
 									// @ts-ignore inert isn't typed properly in React 18, but will be in 19
 									inert={selected ? undefined : ""}
-									className="flex h-[88px] w-full items-center justify-center p-3"
+									className="flex h-24 w-full items-center justify-center p-3"
 								>
 									{Component && <Component element={element} />}
 								</div>
 								<hr className="w-full" />
-								<div className="w-full py-2 text-center text-sm text-foreground">
+								<div className="my-1 w-full text-center text-sm text-foreground">
 									{name}
 								</div>
 							</label>

--- a/core/app/components/FormBuilder/ElementPanel/InputComponentConfigurationForm.tsx
+++ b/core/app/components/FormBuilder/ElementPanel/InputComponentConfigurationForm.tsx
@@ -149,8 +149,9 @@ const componentInfo: Record<InputComponent, SchemaComponentData> = {
 				<MultiValueInput
 					value={["Value 1"]}
 					onChange={() => {}}
+					// Shrink everything a little to fit into the display box better
 					className="h-8"
-					valueClassName="h-5"
+					valueClassName="h-5 px-1"
 				/>
 			</div>
 		),

--- a/core/app/components/forms/FormElement.tsx
+++ b/core/app/components/forms/FormElement.tsx
@@ -14,6 +14,7 @@ import { ConfidenceElement } from "./elements/ConfidenceElement";
 import { DateElement } from "./elements/DateElement";
 import { FileUploadElement } from "./elements/FileUploadElement";
 import { MemberSelectElement } from "./elements/MemberSelectElement";
+import { MultivalueInputElement } from "./elements/MultivalueInputElement";
 import { RadioGroupElement } from "./elements/RadioGroupElement";
 import { SelectDropdownElement } from "./elements/SelectDropdownElement";
 import { TextAreaElement } from "./elements/TextAreaElement";
@@ -93,6 +94,8 @@ export const FormElement = ({
 		input = <CheckboxGroupElement {...elementProps} />;
 	} else if (component === InputComponent.selectDropdown) {
 		input = <SelectDropdownElement {...elementProps} />;
+	} else if (component === InputComponent.multivalueInput) {
+		input = <MultivalueInputElement {...elementProps} />;
 	}
 
 	if (input) {

--- a/core/app/components/forms/elements/MultivalueInputElement.tsx
+++ b/core/app/components/forms/elements/MultivalueInputElement.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { CoreSchemaType } from "@prisma/client";
+import { Value } from "@sinclair/typebox/value";
+import { useFormContext } from "react-hook-form";
+import { multivalueInputConfigSchema } from "schemas";
+
+import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "ui/form";
+import { MultiValueInput } from "ui/multivalue-input";
+
+import type { ElementProps } from "../types";
+import { useFormElementToggleContext } from "../FormElementToggleContext";
+
+export const MultivalueInputElement = ({ name, config, schemaName }: ElementProps) => {
+	const { control } = useFormContext();
+	const formElementToggle = useFormElementToggleContext();
+	const isEnabled = formElementToggle.isEnabled(name);
+	const isNumeric = schemaName === CoreSchemaType.NumericArray;
+
+	Value.Default(multivalueInputConfigSchema, config);
+	if (!Value.Check(multivalueInputConfigSchema, config)) {
+		return null;
+	}
+
+	return (
+		<FormField
+			control={control}
+			name={name}
+			render={({ field }) => {
+				return (
+					<FormItem>
+						<FormLabel>{config.label ?? name}</FormLabel>
+						<FormControl>
+							<MultiValueInput
+								disabled={!isEnabled}
+								type={isNumeric ? "number" : undefined}
+								{...field}
+							/>
+						</FormControl>
+						<FormDescription>{config.help}</FormDescription>
+						<FormMessage />
+					</FormItem>
+				);
+			}}
+		/>
+	);
+};

--- a/core/app/components/forms/elements/MultivalueInputElement.tsx
+++ b/core/app/components/forms/elements/MultivalueInputElement.tsx
@@ -35,6 +35,7 @@ export const MultivalueInputElement = ({ name, config, schemaName }: ElementProp
 								disabled={!isEnabled}
 								type={isNumeric ? "number" : undefined}
 								{...field}
+								value={field.value ?? []}
 								onChange={(newValues) => {
 									if (isNumeric) {
 										field.onChange(newValues.map((v) => +v));

--- a/core/app/components/forms/elements/MultivalueInputElement.tsx
+++ b/core/app/components/forms/elements/MultivalueInputElement.tsx
@@ -35,6 +35,13 @@ export const MultivalueInputElement = ({ name, config, schemaName }: ElementProp
 								disabled={!isEnabled}
 								type={isNumeric ? "number" : undefined}
 								{...field}
+								onChange={(newValues) => {
+									if (isNumeric) {
+										field.onChange(newValues.map((v) => +v));
+										return;
+									}
+									field.onChange(newValues);
+								}}
 							/>
 						</FormControl>
 						<FormDescription>{config.help}</FormDescription>

--- a/core/app/components/pubs/PubEditor/PubEditorClient.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditorClient.tsx
@@ -270,7 +270,7 @@ export function PubEditorClient(props: Props) {
 								<DropdownMenuContent>
 									{availableStages.map((stage) => (
 										<DropdownMenuItem
-											key={stage.id}
+											key={stage.id || "no-stage"}
 											onClick={() => {
 												field.onChange(stage.id);
 											}}

--- a/core/playwright/externalFormCreatePub.spec.ts
+++ b/core/playwright/externalFormCreatePub.spec.ts
@@ -69,7 +69,7 @@ test("Can create a pub from an external form", async () => {
 });
 
 test.describe("Multivalue inputs", () => {
-	test("Can add a radio and checkbox multivalue input", async () => {
+	test("Can add multivalue inputs", async () => {
 		test.setTimeout(60_000);
 		const fieldsPage = new FieldsPage(page, COMMUNITY_SLUG);
 		await fieldsPage.goto();
@@ -130,7 +130,7 @@ test.describe("Multivalue inputs", () => {
 		await page.getByRole("textbox", { name: "Description" }).fill(fruitElement.description);
 		const fruits = ["mangos", "pineapples", "figs"];
 		for (const fruit of fruits) {
-			await page.getByTestId("multivalue-input").fill(fruit);
+			await page.getByLabel("Dropdown Values").fill(fruit);
 			await page.keyboard.press("Enter");
 			await expect(page.getByTestId(`sortable-value-${fruit}`)).toHaveCount(1);
 		}

--- a/core/playwright/externalFormCreatePub.spec.ts
+++ b/core/playwright/externalFormCreatePub.spec.ts
@@ -93,7 +93,7 @@ test.describe("Multivalue inputs", () => {
 		await page.getByRole("textbox", { name: "Description" }).fill(numberElement.description);
 		const numbers = [0, 1, 2, 3];
 		for (const number of numbers) {
-			await page.getByTestId("multivalue-input").fill(`${number}`);
+			await page.getByLabel("Radio Values").fill(`${number}`);
 			await page.keyboard.press("Enter");
 			await expect(page.getByTestId(`sortable-value-${number}`)).toHaveCount(1);
 		}
@@ -111,7 +111,7 @@ test.describe("Multivalue inputs", () => {
 		await page.getByRole("textbox", { name: "Description" }).fill(animalElement.description);
 		const animals = ["cats", "dogs", "squirrels"];
 		for (const animal of animals) {
-			await page.getByTestId("multivalue-input").fill(animal);
+			await page.getByLabel("Checkbox Values").fill(animal);
 			await page.keyboard.press("Enter");
 			await expect(page.getByTestId(`sortable-value-${animal}`)).toHaveCount(1);
 		}
@@ -138,6 +138,9 @@ test.describe("Multivalue inputs", () => {
 
 		// Save the form builder and go to external form
 		await formEditPage.saveForm();
+		await expect(
+			page.getByRole("status").filter({ hasText: "Form Successfully Saved" })
+		).toHaveCount(1);
 		await formEditPage.goToExternalForm();
 		for (const element of [numberElement, animalElement, fruitElement]) {
 			await expect(page.getByText(element.name)).toHaveCount(1);

--- a/core/playwright/fixtures/pubtype-page.ts
+++ b/core/playwright/fixtures/pubtype-page.ts
@@ -14,7 +14,9 @@ export class PubTypePage {
 		await this.page.goto(`/c/${this.communitySlug}/types`);
 	}
 
-	async addFieldToPubType(pubtypeName: string, fieldSlug: string) {
-		// TODO
+	async addFieldToPubType(pubTypeName: string, fieldSlug: string) {
+		await this.page.getByTestId(`edit-pubtype-${pubTypeName}`).click();
+		await this.page.getByRole("combobox").click();
+		await this.page.getByRole("option", { name: fieldSlug }).click();
 	}
 }

--- a/core/playwright/fixtures/pubtype-page.ts
+++ b/core/playwright/fixtures/pubtype-page.ts
@@ -1,0 +1,20 @@
+import type { Page } from "@playwright/test";
+
+export class PubTypePage {
+	private readonly communitySlug: string;
+
+	constructor(
+		public readonly page: Page,
+		communitySlug: string
+	) {
+		this.communitySlug = communitySlug;
+	}
+
+	async goto() {
+		await this.page.goto(`/c/${this.communitySlug}/types`);
+	}
+
+	async addFieldToPubType(pubtypeName: string, fieldSlug: string) {
+		// TODO
+	}
+}

--- a/core/playwright/pub.spec.ts
+++ b/core/playwright/pub.spec.ts
@@ -116,7 +116,38 @@ test.describe("Creating a pub", () => {
 		await fieldsPage.addField("Animals", CoreSchemaType.StringArray);
 
 		// Add it as a pub type
-		const pubtypePage = new PubTypePage(page, COMMUNITY_SLUG);
-		await pubtypePage.goto();
+		const pubTypePage = new PubTypePage(page, COMMUNITY_SLUG);
+		await pubTypePage.goto();
+		await pubTypePage.addFieldToPubType("Submission", "animals");
+
+		// Now create a pub of this type
+		const pubsPage = new PubsPage(page, COMMUNITY_SLUG);
+		await pubsPage.goTo();
+		const title = "pub with multivalue";
+		await page.getByRole("button", { name: "Create" }).click();
+		await page.getByLabel("Title").fill(title);
+		await page.getByLabel("Content").fill("Some content");
+		await page.getByLabel("Animals").fill("dogs");
+		await page.keyboard.press("Enter");
+		await page.getByLabel("Animals").fill("cats");
+		await page.keyboard.press("Enter");
+		await page.getByRole("button", { name: "Create Pub" }).click();
+		await page.getByRole("link", { name: title }).click();
+		await page.waitForURL(/.*\/c\/.+\/pubs\/.+/);
+		const pubId = page.url().match(/.*\/c\/.+\/pubs\/(?<pubId>.+)/)?.groups?.pubId;
+		await expect(page.getByTestId(`Animals-value`)).toHaveText("dogs,cats");
+
+		// Edit this same pub
+		await pubsPage.goTo();
+		await page.getByTestId("pub-dropdown-button").first().click();
+		await page.getByRole("button", { name: "Update" }).click();
+		await page.getByLabel("Animals").fill("penguins");
+		await page.keyboard.press("Enter");
+		await page.getByTestId("remove-button").first().click();
+		await page.getByRole("button", { name: "Update Pub" }).click();
+		await page.getByTestId("pub-dropdown-button").first().click();
+		await expect(page.getByRole("heading", { name: "Pubs" })).toHaveCount(1);
+		// await page.goto(`/c/${COMMUNITY_SLUG}/pubs/${pubId}`);
+		// await expect(page.getByTestId(`Animals-value`)).toHaveText("cats,penguins");
 	});
 });

--- a/core/playwright/pub.spec.ts
+++ b/core/playwright/pub.spec.ts
@@ -2,7 +2,11 @@ import type { Page } from "@playwright/test";
 
 import { expect, test } from "@playwright/test";
 
+import { CoreSchemaType } from "db/public";
+
+import { FieldsPage } from "./fixtures/fields-page";
 import { PubsPage } from "./fixtures/pubs-page";
+import { PubTypePage } from "./fixtures/pubtype-page";
 import { createCommunity, login } from "./helpers";
 
 const now = new Date().getTime();
@@ -103,5 +107,16 @@ test.describe("Creating a pub", () => {
 		await expect(page.getByRole("status").filter({ hasText: "New pub created" })).toHaveCount(
 			1
 		);
+	});
+
+	test("Can create and edit a multivalue field", async () => {
+		// Add a multivalue field
+		const fieldsPage = new FieldsPage(page, COMMUNITY_SLUG);
+		await fieldsPage.goto();
+		await fieldsPage.addField("Animals", CoreSchemaType.StringArray);
+
+		// Add it as a pub type
+		const pubtypePage = new PubTypePage(page, COMMUNITY_SLUG);
+		await pubtypePage.goto();
 	});
 });

--- a/core/playwright/pub.spec.ts
+++ b/core/playwright/pub.spec.ts
@@ -145,9 +145,10 @@ test.describe("Creating a pub", () => {
 		await page.keyboard.press("Enter");
 		await page.getByTestId("remove-button").first().click();
 		await page.getByRole("button", { name: "Update Pub" }).click();
-		await page.getByTestId("pub-dropdown-button").first().click();
-		await expect(page.getByRole("heading", { name: "Pubs" })).toHaveCount(1);
-		// await page.goto(`/c/${COMMUNITY_SLUG}/pubs/${pubId}`);
-		// await expect(page.getByTestId(`Animals-value`)).toHaveText("cats,penguins");
+		await expect(
+			page.getByRole("status").filter({ hasText: "Pub successfully updated" })
+		).toHaveCount(1);
+		await page.goto(`/c/${COMMUNITY_SLUG}/pubs/${pubId}`);
+		await expect(page.getByTestId(`Animals-value`)).toHaveText("cats,penguins");
 	});
 });

--- a/core/prisma/migrations/20241016174257_add_multivalue_input_to_input_component_enum/migration.sql
+++ b/core/prisma/migrations/20241016174257_add_multivalue_input_to_input_component_enum/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "InputComponent" ADD VALUE 'multivalueInput';

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -479,6 +479,7 @@ enum InputComponent {
   checkboxGroup
   radioGroup
   selectDropdown
+  multivalueInput
 }
 
 // Either a structural element like a header, hr etc. or a pubfield input

--- a/packages/db/src/public/InputComponent.ts
+++ b/packages/db/src/public/InputComponent.ts
@@ -15,6 +15,7 @@ export enum InputComponent {
 	checkboxGroup = "checkboxGroup",
 	radioGroup = "radioGroup",
 	selectDropdown = "selectDropdown",
+	multivalueInput = "multivalueInput",
 }
 
 /** Zod schema for InputComponent */

--- a/packages/db/src/public/PublicSchema.ts
+++ b/packages/db/src/public/PublicSchema.ts
@@ -36,14 +36,6 @@ import type { StagesTable } from "./Stages";
 import type { UsersTable } from "./Users";
 
 export interface PublicSchema {
-	api_access_permissions: ApiAccessPermissionsTable;
-
-	form_to_permissions: FormToPermissionsTable;
-
-	form_elements: FormElementsTable;
-
-	sessions: SessionsTable;
-
 	_prisma_migrations: PrismaMigrationsTable;
 
 	users: UsersTable;
@@ -101,4 +93,12 @@ export interface PublicSchema {
 	api_access_tokens: ApiAccessTokensTable;
 
 	api_access_logs: ApiAccessLogsTable;
+
+	api_access_permissions: ApiAccessPermissionsTable;
+
+	form_to_permissions: FormToPermissionsTable;
+
+	form_elements: FormElementsTable;
+
+	sessions: SessionsTable;
 }

--- a/packages/schemas/src/schemaComponents.ts
+++ b/packages/schemas/src/schemaComponents.ts
@@ -15,11 +15,13 @@ export const componentsBySchema = {
 		InputComponent.checkboxGroup,
 		InputComponent.radioGroup,
 		InputComponent.selectDropdown,
+		InputComponent.multivalueInput,
 	],
 	[CoreSchemaType.StringArray]: [
 		InputComponent.checkboxGroup,
 		InputComponent.radioGroup,
 		InputComponent.selectDropdown,
+		InputComponent.multivalueInput,
 	],
 	[CoreSchemaType.Email]: [InputComponent.textInput],
 	[CoreSchemaType.FileUpload]: [InputComponent.fileUpload],
@@ -83,6 +85,10 @@ export const selectDropdownConfigSchema = Type.Object({
 	help: Type.Optional(Type.String()),
 	values: Type.Union([Type.Array(Type.String()), Type.Array(Type.Number())]),
 });
+export const multivalueInputConfigSchema = Type.Object({
+	label: Type.Optional(Type.String()),
+	help: Type.Optional(Type.String()),
+});
 
 export const componentConfigSchemas = {
 	[InputComponent.checkbox]: checkboxConfigSchema,
@@ -95,4 +101,5 @@ export const componentConfigSchemas = {
 	[InputComponent.checkboxGroup]: checkboxGroupConfigSchema,
 	[InputComponent.radioGroup]: radioGroupConfigSchema,
 	[InputComponent.selectDropdown]: selectDropdownConfigSchema,
+	[InputComponent.multivalueInput]: multivalueInputConfigSchema,
 } as const satisfies Record<InputComponent, TObject>;

--- a/packages/schemas/src/schemaComponents.ts
+++ b/packages/schemas/src/schemaComponents.ts
@@ -12,16 +12,16 @@ export const componentsBySchema = {
 	[CoreSchemaType.DateTime]: [InputComponent.datePicker],
 	[CoreSchemaType.Number]: [InputComponent.textInput],
 	[CoreSchemaType.NumericArray]: [
+		InputComponent.multivalueInput,
 		InputComponent.checkboxGroup,
 		InputComponent.radioGroup,
 		InputComponent.selectDropdown,
-		InputComponent.multivalueInput,
 	],
 	[CoreSchemaType.StringArray]: [
+		InputComponent.multivalueInput,
 		InputComponent.checkboxGroup,
 		InputComponent.radioGroup,
 		InputComponent.selectDropdown,
-		InputComponent.multivalueInput,
 	],
 	[CoreSchemaType.Email]: [InputComponent.textInput],
 	[CoreSchemaType.FileUpload]: [InputComponent.fileUpload],
@@ -69,7 +69,7 @@ export const confidenceIntervalConfigSchema = Type.Object({
 export const checkboxGroupConfigSchema = Type.Object({
 	label: Type.Optional(Type.String()),
 	help: Type.Optional(Type.String()),
-	values: Type.Union([Type.Array(Type.String()), Type.Array(Type.Number())]),
+	values: Type.Union([Type.Array(Type.String()), Type.Array(Type.Number())], { default: [] }),
 	includeOther: Type.Optional(Type.Boolean()),
 	userShouldSelect: Type.Optional(Type.String()),
 	numCheckboxes: Type.Optional(Type.Number()),
@@ -77,13 +77,13 @@ export const checkboxGroupConfigSchema = Type.Object({
 export const radioGroupConfigSchema = Type.Object({
 	label: Type.Optional(Type.String()),
 	help: Type.Optional(Type.String()),
-	values: Type.Union([Type.Array(Type.String()), Type.Array(Type.Number())]),
+	values: Type.Union([Type.Array(Type.String()), Type.Array(Type.Number())], { default: [] }),
 	includeOther: Type.Optional(Type.Boolean()),
 });
 export const selectDropdownConfigSchema = Type.Object({
 	label: Type.Optional(Type.String()),
 	help: Type.Optional(Type.String()),
-	values: Type.Union([Type.Array(Type.String()), Type.Array(Type.Number())]),
+	values: Type.Union([Type.Array(Type.String()), Type.Array(Type.Number())], { default: [] }),
 });
 export const multivalueInputConfigSchema = Type.Object({
 	label: Type.Optional(Type.String()),

--- a/packages/ui/src/multivalue-input.tsx
+++ b/packages/ui/src/multivalue-input.tsx
@@ -26,11 +26,13 @@ const SortableValue = ({
 	value,
 	onRemove,
 	isActive,
+	disabled,
 	className,
 }: {
 	value: string;
 	onRemove: (v: string) => void;
 	isActive: boolean;
+	disabled?: boolean;
 	className?: string;
 }) => {
 	const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: value });
@@ -48,10 +50,14 @@ const SortableValue = ({
 			ref={setNodeRef}
 			style={style}
 			{...attributes}
-			className={cn("bg-muted-foreground py-1", className)}
+			className={cn(
+				"bg-muted-foreground py-1",
+				{ "cursor-auto bg-gray-400 hover:bg-gray-400": disabled },
+				className
+			)}
 			data-testid={`sortable-value-${value}`}
 		>
-			<Button {...listeners} variant="ghost" className="mr-1 h-5 p-0">
+			<Button {...listeners} variant="ghost" className="mr-1 h-5 p-0" disabled={disabled}>
 				<GripVertical size="12" />
 			</Button>
 			{value}
@@ -63,6 +69,7 @@ const SortableValue = ({
 				// height is smaller so hover is only over the xcircle
 				className="ml-2 h-3 p-0"
 				data-testid="remove-button"
+				disabled={disabled}
 			>
 				<XCircle size="12"></XCircle>
 			</Button>
@@ -71,7 +78,7 @@ const SortableValue = ({
 };
 
 export const MultiValueInput = forwardRef<HTMLInputElement, MultiValueInputProps>(
-	({ value: values, onChange, valueClassName, ...props }, ref) => {
+	({ value: values, onChange, valueClassName, disabled, ...props }, ref) => {
 		const [pendingValue, setPendingValue] = useState("");
 		const [activeDrag, setActiveDrag] = useState<Active | null>(null);
 
@@ -105,6 +112,7 @@ export const MultiValueInput = forwardRef<HTMLInputElement, MultiValueInputProps
 						}
 					}}
 					placeholder="Type the value and hit enter"
+					disabled={disabled}
 					{...props}
 					ref={ref}
 					data-testid="multivalue-input"
@@ -115,6 +123,9 @@ export const MultiValueInput = forwardRef<HTMLInputElement, MultiValueInputProps
 						setActiveDrag(active);
 					}}
 					onDragEnd={handleDragEnd}
+					// Need an id or else will get an error in the console
+					// https://github.com/clauderic/dnd-kit/issues/926
+					id="multivalue-dnd-context"
 				>
 					<SortableContext items={values}>
 						<div className="flex flex-wrap gap-x-2 gap-y-2">
@@ -127,6 +138,7 @@ export const MultiValueInput = forwardRef<HTMLInputElement, MultiValueInputProps
 											onChange(values.filter((v) => v !== valueToRemove))
 										}
 										isActive={activeDrag?.id === value}
+										disabled={disabled}
 										className={valueClassName}
 									/>
 								);

--- a/packages/ui/src/multivalue-input.tsx
+++ b/packages/ui/src/multivalue-input.tsx
@@ -35,7 +35,10 @@ const SortableValue = ({
 	disabled?: boolean;
 	className?: string;
 }) => {
-	const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: value });
+	const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+		id: value,
+		disabled,
+	});
 
 	const style = transform
 		? {

--- a/packages/ui/src/multivalue-input.tsx
+++ b/packages/ui/src/multivalue-input.tsx
@@ -1,11 +1,13 @@
 // Adapted from https://gist.github.com/enesien/03ba5340f628c6c812b306da5fedd1a4
 
 import type { Active, DragEndEvent } from "@dnd-kit/core";
-import type { Dispatch, SetStateAction } from "react";
+import type { Dispatch } from "react";
 
 import React, { forwardRef, useState } from "react";
 import { DndContext } from "@dnd-kit/core";
 import { arrayMove, SortableContext, useSortable } from "@dnd-kit/sortable";
+
+import { cn } from "utils";
 
 import type { InputProps } from "./input";
 import { Badge } from "./badge";
@@ -16,16 +18,20 @@ import { Input } from "./input";
 type MultiValueInputProps = Omit<InputProps, "onChange"> & {
 	value: string[];
 	onChange: Dispatch<string[]>;
+	/** Classname to apply to value badges */
+	valueClassName?: string;
 };
 
 const SortableValue = ({
 	value,
 	onRemove,
 	isActive,
+	className,
 }: {
 	value: string;
 	onRemove: (v: string) => void;
 	isActive: boolean;
+	className?: string;
 }) => {
 	const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: value });
 
@@ -42,7 +48,7 @@ const SortableValue = ({
 			ref={setNodeRef}
 			style={style}
 			{...attributes}
-			className="bg-muted-foreground py-1"
+			className={cn("bg-muted-foreground py-1", className)}
 			data-testid={`sortable-value-${value}`}
 		>
 			<Button {...listeners} variant="ghost" className="mr-1 h-5 p-0">
@@ -65,7 +71,7 @@ const SortableValue = ({
 };
 
 export const MultiValueInput = forwardRef<HTMLInputElement, MultiValueInputProps>(
-	({ value: values, onChange, ...props }, ref) => {
+	({ value: values, onChange, valueClassName, ...props }, ref) => {
 		const [pendingValue, setPendingValue] = useState("");
 		const [activeDrag, setActiveDrag] = useState<Active | null>(null);
 
@@ -121,6 +127,7 @@ export const MultiValueInput = forwardRef<HTMLInputElement, MultiValueInputProps
 											onChange(values.filter((v) => v !== valueToRemove))
 										}
 										isActive={activeDrag?.id === value}
+										className={valueClassName}
 									/>
 								);
 							})}


### PR DESCRIPTION
## Issue(s) Resolved
Closes https://github.com/pubpub/platform/issues/706

## High-level Explanation of PR
Adds the multivalue input component to various parts of the app:
* Form builder for `StringArray` and `NumericArray` fields
* Form fill page if the multivalue input component was chosen
* The pub update/create form

## Test Plan
* Add a pub field that is either of type `StringArray` or `NumericArray`
* Add to a form and select the multivalue input field. You should be able to add a label/description if you want.
* Check that the field renders and works as you'd expect it to in the form fill page
* Add the same field to a pub type
* Try to create/edit a pub of this type. You should be able to use the multivalue input component for the field you added

## Screenshots (if applicable)
### Form builder
![image](https://github.com/user-attachments/assets/78cab055-fcb6-49c8-af56-7fd529b3151c)

### Fill page
![image](https://github.com/user-attachments/assets/cc961ad7-a3ff-407f-8808-00900132c9cd)

With field disabled
![image](https://github.com/user-attachments/assets/a017238e-b153-456b-872d-f0612286f799)

### Pub create/edit
![image](https://github.com/user-attachments/assets/1d16d4cd-6149-4881-8237-6c22f6a1f6b1)
![image](https://github.com/user-attachments/assets/803a164d-489a-4cc3-8a35-7b33081385eb)


## Notes
