### PR TITLE
fix: copy integration data to the correct folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,10 +135,10 @@ CMD node core/server.js
 FROM prod-setup AS next-app-integration-submissions
 WORKDIR /usr/src/app
 COPY --from=withpackage --chown=node:node /usr/src/app/integrations/submissions/.next/standalone .
-COPY --from=withpackage --chown=node:node /usr/src/app/integrations/submissions/.next/static ./integrations/evaluations/.next/static
-COPY --from=withpackage --chown=node:node /usr/src/app/integrations/submissions/public ./integrations/evaluations/public
+COPY --from=withpackage --chown=node:node /usr/src/app/integrations/submissions/.next/static ./integrations/submissions/.next/static
+COPY --from=withpackage --chown=node:node /usr/src/app/integrations/submissions/public ./integrations/submissions/public
 # needed to set the database url correctly based on PGHOST variables
-COPY --from=withpackage --chown=node:node /usr/src/app/core/.env.docker ./integrations/evaluations/.env
+COPY --from=withpackage --chown=node:node /usr/src/app/core/.env.docker ./integrations/submissions/.env
 
 CMD node integrations/submissions/server.js
 
@@ -147,10 +147,10 @@ CMD node integrations/submissions/server.js
 FROM prod-setup AS next-app-integration-evaluations
 WORKDIR /usr/src/app
 COPY --from=withpackage --chown=node:node /usr/src/app/integrations/evaluations/.next/standalone ./
-COPY --from=withpackage --chown=node:node /usr/src/app/integrations/evaluations/.next/static ./integrations/submissions/.next/static
-COPY --from=withpackage --chown=node:node /usr/src/app/integrations/evaluations/public ./integrations/submissions/public
+COPY --from=withpackage --chown=node:node /usr/src/app/integrations/evaluations/.next/static ./integrations/evaluations/.next/static
+COPY --from=withpackage --chown=node:node /usr/src/app/integrations/evaluations/public ./integrations/evaluations/public
 # needed to set the database url correctly based on PGHOST variables
-COPY --from=withpackage --chown=node:node /usr/src/app/core/.env.docker ./integrations/submissions/.env
+COPY --from=withpackage --chown=node:node /usr/src/app/core/.env.docker ./integrations/evaluations/.env
 
 CMD node integrations/evaluations/server.js
 


### PR DESCRIPTION
## Issue(s) Resolved

Static assets not properly resolved for integrations because they were copied to the wrong place in the dockerfile.

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan
Send it.

## Screenshots (if applicable)

## Notes
