### PR TITLE
fix: allow admins to access stage editor

### DIFF
--- a/core/app/c/[communitySlug]/SideNav.tsx
+++ b/core/app/c/[communitySlug]/SideNav.tsx
@@ -80,7 +80,7 @@ const ManageLinks = ({
 				text={"Workflows"}
 				icon={<img src="/icons/stages.svg" alt="" />}
 			/>
-			{isSuperAdmin && (
+			{isAdmin && (
 				<NavLink
 					href={`${prefix}/stages/manage`}
 					text={"Stage editor"}


### PR DESCRIPTION
## Issue(s) Resolved
Resolves #633

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->
Just makes uses `isAdmin` rather than `isSuperAdmin` for the `stages/manage` page.

## Test Plan
1. Login as a regular admin (new@pubpub.org, `pubpub-new`)
2. See the `Stage Editor` in the sidebar to the left

## Screenshots (if applicable)

## Notes
I will fix the highlighting in a follow up PR, have one semi ready where I introduce shadcn's new sidebar component.
