### PR TITLE
Read from new memberships tables

### DIFF
--- a/core/actions/email/config/recipient.field.tsx
+++ b/core/actions/email/config/recipient.field.tsx
@@ -1,4 +1,4 @@
-import type { MembersId } from "db/public";
+import type { CommunityMembershipsId } from "db/public";
 
 import { defineActionFormFieldServerComponent } from "~/actions/_lib/custom-form-field/defineConfigServerComponent";
 import { MemberSelectServer } from "~/app/components/MemberSelect/MemberSelectServer";
@@ -22,7 +22,7 @@ const component = defineActionFormFieldServerComponent(
 				fieldName="recipient"
 				fieldLabel="Recipient email address"
 				community={community}
-				value={actionInstance.config?.recipient as MembersId}
+				value={actionInstance.config?.recipient as CommunityMembershipsId | undefined}
 				query={query}
 				queryParamName={queryParamName}
 			/>

--- a/core/actions/email/params/recipient.field.tsx
+++ b/core/actions/email/params/recipient.field.tsx
@@ -1,4 +1,4 @@
-import type { CommunityMembershipsId, MembersId } from "db/public";
+import type { CommunityMembershipsId } from "db/public";
 
 import { defineActionFormFieldServerComponent } from "~/actions/_lib/custom-form-field/defineConfigServerComponent";
 import { MemberSelectServer } from "~/app/components/MemberSelect/MemberSelectServer";

--- a/core/actions/email/params/recipient.field.tsx
+++ b/core/actions/email/params/recipient.field.tsx
@@ -1,4 +1,4 @@
-import type { MembersId } from "db/public";
+import type { CommunityMembershipsId, MembersId } from "db/public";
 
 import { defineActionFormFieldServerComponent } from "~/actions/_lib/custom-form-field/defineConfigServerComponent";
 import { MemberSelectServer } from "~/app/components/MemberSelect/MemberSelectServer";
@@ -22,7 +22,7 @@ const component = defineActionFormFieldServerComponent(
 				fieldName="recipient"
 				fieldLabel="Recipient email address"
 				community={community}
-				value={actionInstance.config?.recipient as MembersId}
+				value={actionInstance.config?.recipient as CommunityMembershipsId | undefined}
 				query={query}
 				queryParamName={queryParamName}
 			/>

--- a/core/actions/email/run.ts
+++ b/core/actions/email/run.ts
@@ -2,7 +2,7 @@
 
 import { jsonObjectFrom } from "kysely/helpers/postgres";
 
-import type { MembersId } from "db/public";
+import type { CommunityMembershipsId } from "db/public";
 import { logger } from "logger";
 import { expect } from "utils";
 
@@ -12,7 +12,6 @@ import { db } from "~/kysely/database";
 import { getPubCached } from "~/lib/server";
 import { getCommunitySlug } from "~/lib/server/cache/getCommunitySlug";
 import * as Email from "~/lib/server/email";
-import { smtpclient } from "~/lib/server/mailgun";
 import { renderMarkdownWithPub } from "~/lib/server/render/pub/renderMarkdownWithPub";
 import { defineRun } from "../types";
 
@@ -30,19 +29,19 @@ export const run = defineRun<typeof action>(async ({ pub, config, args, communit
 			parentPub = await getPubCached(parentId);
 		}
 
-		const recipientId = expect(args?.recipient ?? config.recipient) as MembersId;
+		const recipientId = expect(args?.recipient ?? config.recipient) as CommunityMembershipsId;
 
 		// TODO: similar to the assignee, the recipient args/config should accept
 		// the pub assignee, a pub field, a static email address, a member, or a
 		// member group.
 		const recipient = await db
-			.selectFrom("members")
+			.selectFrom("community_memberships")
 			.select((eb) => [
-				"members.id",
+				"community_memberships.id",
 				jsonObjectFrom(
 					eb
 						.selectFrom("users")
-						.whereRef("users.id", "=", "members.userId")
+						.whereRef("users.id", "=", "community_memberships.userId")
 						.selectAll("users")
 				)
 					.$notNull()

--- a/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/page.tsx
+++ b/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/page.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 
 import { notFound } from "next/navigation";
 
-import type { Communities, MembersId, PubsId, UsersId } from "db/public";
+import type { Communities, PubsId } from "db/public";
 import { MemberRole, StructuralFormElement } from "db/public";
 import { expect } from "utils";
 
@@ -89,7 +89,8 @@ const ExpiredTokenPage = ({
 				<RequestLink
 					formSlug={params.formSlug}
 					token={searchParams.token}
-					pubId={searchParams.pubId as PubsId}
+					// TODO: handle undefined pubId
+					pubId={searchParams.pubId!}
 				/>
 			</div>
 		</div>
@@ -204,16 +205,16 @@ export default async function FormPage({
 		}
 	}
 
-	const parentPub = pub?.parentId ? await getPub(pub.parentId as PubsId) : undefined;
+	const parentPub = pub?.parentId ? await getPub(pub.parentId) : undefined;
 
 	const member = expect(user.memberships.find((m) => m.communityId === community?.id));
 
 	const memberWithUser = {
 		...member,
-		id: member.id as MembersId,
+		id: member.id,
 		user: {
 			...user,
-			id: user.id as UsersId,
+			id: user.id,
 		},
 	};
 
@@ -289,7 +290,7 @@ export default async function FormPage({
 								{form.elements.map((e) => (
 									<FormElement
 										key={e.elementId}
-										pubId={pubId as PubsId}
+										pubId={pubId}
 										element={e}
 										searchParams={searchParams}
 										communitySlug={params.communitySlug}

--- a/core/app/c/[communitySlug]/members/[[...add]]/AddMember.tsx
+++ b/core/app/c/[communitySlug]/members/[[...add]]/AddMember.tsx
@@ -93,7 +93,10 @@ const createCachedGetUser = ({
 			return { user, state: "user-found" as const, error: null };
 		},
 		{
-			revalidateTags: createCommunityCacheTags(["members", "users"], community.slug),
+			revalidateTags: createCommunityCacheTags(
+				["community_memberships", "users"],
+				community.slug
+			),
 		}
 	);
 };

--- a/core/app/c/[communitySlug]/members/[[...add]]/actions.ts
+++ b/core/app/c/[communitySlug]/members/[[...add]]/actions.ts
@@ -89,7 +89,7 @@ export const addMember = defineServerAction(async function addMember({
 		const member = await dbAddMember({
 			userId: user.id as UsersId,
 			communityId: result.community.id,
-			role,
+			role: role ?? MemberRole.editor,
 		}).executeTakeFirst();
 
 		// TODO: send email to user confirming their membership,

--- a/core/app/c/[communitySlug]/members/[[...add]]/actions.ts
+++ b/core/app/c/[communitySlug]/members/[[...add]]/actions.ts
@@ -2,7 +2,7 @@
 
 import { cache } from "react";
 
-import type { MembersId, UsersId } from "db/public";
+import type { UsersId } from "db/public";
 import { MemberRole } from "db/public";
 
 import type { TableMember } from "./getMemberTableColumns";
@@ -220,7 +220,7 @@ export const removeMember = defineServerAction(async function removeMember({
 			};
 		}
 
-		const removedMember = await dbRemoveMember(member.id as MembersId).executeTakeFirst();
+		const removedMember = await dbRemoveMember(member.id).executeTakeFirst();
 
 		if (!removedMember) {
 			return {

--- a/core/app/c/[communitySlug]/members/[[...add]]/getMemberTableColumns.tsx
+++ b/core/app/c/[communitySlug]/members/[[...add]]/getMemberTableColumns.tsx
@@ -2,7 +2,7 @@
 
 import type { ColumnDef } from "@tanstack/react-table";
 
-import type { MemberRole } from "db/public";
+import type { CommunityMembershipsId, MemberRole } from "db/public";
 import { Avatar, AvatarFallback, AvatarImage } from "ui/avatar";
 import { Badge } from "ui/badge";
 import { Button } from "ui/button";
@@ -20,7 +20,7 @@ import { MoreVertical } from "ui/icon";
 import { RemoveMemberButton } from "./RemoveMemberButton";
 
 export type TableMember = {
-	id: string;
+	id: CommunityMembershipsId;
 	avatar: string | null;
 	email: string;
 	firstName: string;

--- a/core/app/c/[communitySlug]/members/[[...add]]/page.tsx
+++ b/core/app/c/[communitySlug]/members/[[...add]]/page.tsx
@@ -22,12 +22,12 @@ export const metadata: Metadata = {
 const getCachedMembers = (communityId: CommunitiesId) =>
 	autoCache(
 		db
-			.selectFrom("members")
+			.selectFrom("community_memberships")
 			.select((eb) => [
-				"members.id as id",
-				"members.role",
-				"members.communityId",
-				"createdAt",
+				"community_memberships.id as id",
+				"community_memberships.role",
+				"community_memberships.communityId",
+				"community_memberships.createdAt",
 				jsonObjectFrom(
 					eb
 						.selectFrom("users")
@@ -41,7 +41,7 @@ const getCachedMembers = (communityId: CommunitiesId) =>
 							"users.isSuperAdmin as isSuperAdmin",
 							"users.slug as slug",
 						])
-						.whereRef("users.id", "=", "members.userId")
+						.whereRef("users.id", "=", "community_memberships.userId")
 				)
 					.$notNull()
 					.as("user"),

--- a/core/app/c/[communitySlug]/pubs/[pubId]/components/queries.ts
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/components/queries.ts
@@ -28,13 +28,13 @@ const memberFields = (pubId: Expression<string>) =>
 			.selectFrom("pub_values")
 			.innerJoin("pub_fields", "pub_fields.id", "pub_values.fieldId")
 			.innerJoin(
-				"members",
-				"members.id",
-				sql`pub_values.value #>> '{}'` as unknown as "members.id"
+				"community_memberships",
+				"community_memberships.id",
+				sql`pub_values.value #>> '{}'` as unknown as "community_memberships.id"
 			)
 			.select((eb) => [
-				"members.id",
-				"members.userId",
+				"community_memberships.id",
+				"community_memberships.userId",
 				"pub_fields.id as fieldId",
 				jsonObjectFrom(
 					eb
@@ -45,7 +45,7 @@ const memberFields = (pubId: Expression<string>) =>
 							"users.avatar",
 							"users.email",
 						])
-						.whereRef("users.id", "=", "members.userId")
+						.whereRef("users.id", "=", "community_memberships.userId")
 				)
 					.$notNull()
 					.as("user"),

--- a/core/app/c/[communitySlug]/pubs/[pubId]/components/types.ts
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/components/types.ts
@@ -1,13 +1,12 @@
 import type { JsonValue } from "contracts";
 import type {
 	ActionInstances,
+	CommunityMembershipsId,
 	CoreSchemaType,
-	MembersId,
 	PubFieldsId,
 	PubsId,
 	PubTypesId,
 	Stages,
-	StagesId,
 } from "db/public";
 
 export type ChildPubRowPubType = {
@@ -21,7 +20,7 @@ export type ChildPubRowPubType = {
 };
 
 export type ChildPubRowMemberField = {
-	id: MembersId;
+	id: CommunityMembershipsId;
 	fieldId: PubFieldsId;
 	user: {
 		avatar: string | null;

--- a/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
@@ -20,7 +20,6 @@ import SkeletonTable from "~/app/components/skeletons/SkeletonTable";
 import { db } from "~/kysely/database";
 import { getPageLoginData } from "~/lib/auth/loginData";
 import { getCommunityBySlug, getStage, getStageActions } from "~/lib/db/queries";
-import { getPubUsers } from "~/lib/permissions";
 import { pubValuesByVal } from "~/lib/server";
 import { pubInclude } from "~/lib/server/_legacy-integration-queries";
 import { autoCache } from "~/lib/server/cache/autoCache";
@@ -87,7 +86,7 @@ export default async function Page({
 	if (!pub) {
 		return null;
 	}
-	const users = getPubUsers(pub.permissions);
+
 	const community = await getCommunityBySlug(params.communitySlug);
 
 	if (community === null) {
@@ -193,14 +192,20 @@ export default async function Page({
 					<div>
 						<div className="mb-1 text-lg font-bold">Members</div>
 						<div className="flex flex-row flex-wrap">
-							{users.map((user) => {
+							{pub.members.map((member) => {
 								return (
-									<div key={user.id}>
-										<Avatar className="mr-2 h-8 w-8">
-											<AvatarImage src={user.avatar || undefined} />
-											<AvatarFallback>{user.firstName[0]}</AvatarFallback>
-										</Avatar>
-									</div>
+									member.user && (
+										<div key={member.user.id}>
+											<Avatar className="mr-2 h-8 w-8">
+												<AvatarImage
+													src={member.user.avatar || undefined}
+												/>
+												<AvatarFallback>
+													{member.user.firstName[0]}
+												</AvatarFallback>
+											</Avatar>
+										</div>
+									)
 								);
 							})}
 						</div>

--- a/core/app/c/[communitySlug]/stages/manage/components/panel/StagePanelMembers.tsx
+++ b/core/app/c/[communitySlug]/stages/manage/components/panel/StagePanelMembers.tsx
@@ -17,7 +17,7 @@ const StagePanelMembersInner = async (props: PropsInner) => {
 		<Card>
 			<CardContent className="space-y-2 p-4">
 				<h4 className="mb-2 text-base font-semibold">Members</h4>
-				{members.map(({ user }) => (
+				{members.map((user) => (
 					<div key={user.id} className="flex items-center justify-between">
 						{user.firstName} {user.lastName}
 					</div>

--- a/core/app/components/MemberSelect/MemberSelectClient.tsx
+++ b/core/app/components/MemberSelect/MemberSelectClient.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import assert from "assert";
-
 import { useCallback, useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useDebouncedCallback } from "use-debounce";

--- a/core/app/components/MemberSelect/MemberSelectServer.tsx
+++ b/core/app/components/MemberSelect/MemberSelectServer.tsx
@@ -1,4 +1,4 @@
-import type { Communities, CommunityMembershipsId, MembersId } from "db/public";
+import type { Communities, CommunityMembershipsId } from "db/public";
 
 import type { MemberSelectUser, MemberSelectUserWithMembership } from "./types";
 import { getMember } from "~/lib/server/member";

--- a/core/app/components/MemberSelect/MemberSelectServer.tsx
+++ b/core/app/components/MemberSelect/MemberSelectServer.tsx
@@ -1,4 +1,4 @@
-import type { Communities, MembersId } from "db/public";
+import type { Communities, CommunityMembershipsId, MembersId } from "db/public";
 
 import type { MemberSelectUser, MemberSelectUserWithMembership } from "./types";
 import { getMember } from "~/lib/server/member";
@@ -17,7 +17,7 @@ type Props = {
 	 * would result in the same query parameter being used for all instances.
 	 */
 	queryParamName: string;
-	value?: MembersId;
+	value?: CommunityMembershipsId;
 	allowPubFieldSubstitution?: boolean;
 	helpText?: string;
 };

--- a/core/app/components/MemberSelect/types.ts
+++ b/core/app/components/MemberSelect/types.ts
@@ -1,11 +1,11 @@
-import type { Members, Users } from "db/public";
+import type { CommunityMemberships, Users } from "db/public";
 
 export type MemberSelectUserWithMembership = Omit<Users, "passwordHash"> & {
-	member: Members;
+	member: Omit<CommunityMemberships, "memberGroupId">;
 };
 
 export type MemberSelectUser = Omit<MemberSelectUserWithMembership, "member"> & {
-	member?: Members | null;
+	member?: Omit<CommunityMemberships, "memberGroupId"> | null;
 };
 
 export const isMemberSelectUserWithMembership = (

--- a/core/app/components/__tests__/PubTitle.test.tsx
+++ b/core/app/components/__tests__/PubTitle.test.tsx
@@ -136,7 +136,7 @@ test("PubTitle component includes the pub title", async () => {
 		],
 		integrationInstances: [],
 		children: [],
-		permissions: [],
+		members: [],
 	};
 
 	render(<PubTitle pub={pub} />);

--- a/core/app/components/forms/FormElement.tsx
+++ b/core/app/components/forms/FormElement.tsx
@@ -1,7 +1,7 @@
 import { defaultComponent } from "schemas";
 
 import type { GetPubResponseBody } from "contracts";
-import type { MembersId, PubsId } from "db/public";
+import type { CommunityMembershipsId, MembersId, PubsId } from "db/public";
 import { CoreSchemaType, ElementType, InputComponent } from "db/public";
 import { logger } from "logger";
 import { expect } from "utils";
@@ -77,7 +77,7 @@ export const FormElement = ({
 	} else if (component === InputComponent.datePicker) {
 		input = <DateElement {...elementProps} />;
 	} else if (component === InputComponent.memberSelect) {
-		const userId = values[element.slug!] as MembersId | undefined;
+		const userId = values[element.slug!] as CommunityMembershipsId | undefined;
 		input = (
 			<MemberSelectElement
 				config={elementProps.config}

--- a/core/app/components/forms/FormElement.tsx
+++ b/core/app/components/forms/FormElement.tsx
@@ -1,7 +1,7 @@
 import { defaultComponent } from "schemas";
 
 import type { GetPubResponseBody } from "contracts";
-import type { CommunityMembershipsId, MembersId, PubsId } from "db/public";
+import type { CommunityMembershipsId, PubsId } from "db/public";
 import { CoreSchemaType, ElementType, InputComponent } from "db/public";
 import { logger } from "logger";
 import { expect } from "utils";

--- a/core/app/components/forms/elements/MemberSelectElement.tsx
+++ b/core/app/components/forms/elements/MemberSelectElement.tsx
@@ -3,7 +3,7 @@
 import { Value } from "@sinclair/typebox/value";
 import { memberSelectConfigSchema } from "schemas";
 
-import type { MembersId } from "db/public";
+import type { CommunityMembershipsId, MembersId } from "db/public";
 
 import { db } from "~/kysely/database";
 import { autoCache } from "~/lib/server/cache/autoCache";
@@ -19,7 +19,7 @@ export const MemberSelectElement = async ({
 }: {
 	name: string;
 	id: string;
-	value?: MembersId;
+	value?: CommunityMembershipsId;
 	searchParams: Record<string, unknown>;
 	communitySlug: string;
 	config: any;

--- a/core/app/components/forms/elements/MemberSelectElement.tsx
+++ b/core/app/components/forms/elements/MemberSelectElement.tsx
@@ -3,7 +3,7 @@
 import { Value } from "@sinclair/typebox/value";
 import { memberSelectConfigSchema } from "schemas";
 
-import type { CommunityMembershipsId, MembersId } from "db/public";
+import type { CommunityMembershipsId } from "db/public";
 
 import { db } from "~/kysely/database";
 import { autoCache } from "~/lib/server/cache/autoCache";

--- a/core/lib/auth/actions.ts
+++ b/core/lib/auth/actions.ts
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 import { captureException } from "@sentry/nextjs";
 import { z } from "zod";
 
-import type { Communities, Members, Users, UsersId } from "db/public";
+import type { Communities, CommunityMemberships, Members, Users, UsersId } from "db/public";
 import { AuthTokenType } from "db/public";
 
 import type { Prettify } from "../types";
@@ -32,7 +32,11 @@ type LoginUser = Prettify<
 const getUserWithPasswordHash = async (props: Parameters<typeof getUser>[0]) =>
 	getUser(props).select("users.passwordHash").executeTakeFirst();
 
-function redirectUser(memberships?: (Members & { community: Communities | null })[]): never {
+function redirectUser(
+	memberships?: (Omit<CommunityMemberships, "memberGroupId"> & {
+		community: Communities | null;
+	})[]
+): never {
 	if (!memberships?.length) {
 		redirect("/settings");
 	}

--- a/core/lib/auth/actions.ts
+++ b/core/lib/auth/actions.ts
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 import { captureException } from "@sentry/nextjs";
 import { z } from "zod";
 
-import type { Communities, CommunityMemberships, Members, Users, UsersId } from "db/public";
+import type { Communities, CommunityMemberships, Users, UsersId } from "db/public";
 import { AuthTokenType } from "db/public";
 
 import type { Prettify } from "../types";
@@ -25,7 +25,7 @@ const schema = z.object({
 
 type LoginUser = Prettify<
 	Omit<Users, "orcid" | "avatar"> & {
-		memberships: (Members & { community: Communities | null })[];
+		memberships: (CommunityMemberships & { community: Communities | null })[];
 	}
 >;
 

--- a/core/lib/db/queries.ts
+++ b/core/lib/db/queries.ts
@@ -49,21 +49,10 @@ export const getStagePubs = cache((stageId: StagesId) => {
 export const getStageMembers = cache((stageId: StagesId) => {
 	return autoCache(
 		db
-			.selectFrom("members")
-			.innerJoin("permissions", "permissions.memberId", "members.id")
-			.innerJoin("_PermissionToStage", "_PermissionToStage.A", "permissions.id")
-			.where("_PermissionToStage.B", "=", stageId)
-			.selectAll("members")
-			.select((eb) =>
-				jsonObjectFrom(
-					eb
-						.selectFrom("users")
-						.select(SAFE_USER_SELECT)
-						.whereRef("users.id", "=", "members.userId")
-				)
-					.$notNull()
-					.as("user")
-			)
+			.selectFrom("stage_memberships")
+			.where("stage_memberships.stageId", "=", stageId)
+			.innerJoin("users", "users.id", "stage_memberships.userId")
+			.select(SAFE_USER_SELECT)
 	);
 });
 

--- a/core/lib/permissions.ts
+++ b/core/lib/permissions.ts
@@ -1,24 +1,3 @@
-import type {
-	PermissionPayload,
-	PermissionPayloadUser,
-} from "./server/_legacy-integration-queries";
-
-export const getPubUsers = (permissions: PermissionPayload[]) => {
-	const users: PermissionPayloadUser[] = [];
-	for (const permission of permissions) {
-		if (permission.member) {
-			users.push(permission.member.user);
-		} else if (permission.memberGroup) {
-			for (const user of permission.memberGroup.users) {
-				users.push(user);
-			}
-		} else {
-			throw new Error("Invalid permission");
-		}
-	}
-	return users;
-};
-
 enum Capabilities {
 	movePub = "movePub",
 	createPub = "createPub",

--- a/core/lib/server/_legacy-integration-queries.ts
+++ b/core/lib/server/_legacy-integration-queries.ts
@@ -297,35 +297,6 @@ export const makeRecursiveInclude = <T extends string, U extends {}>(
 	} as RecursiveInclude<T, U>;
 };
 
-export const permissionInclude = {
-	member: {
-		include: {
-			user: {
-				select: {
-					id: true,
-					firstName: true,
-					lastName: true,
-					avatar: true,
-					email: true,
-				},
-			},
-		},
-	},
-	memberGroup: {
-		include: {
-			users: {
-				select: {
-					id: true,
-					firstName: true,
-					lastName: true,
-					avatar: true,
-					email: true,
-				},
-			},
-		},
-	},
-} satisfies Prisma.PermissionInclude;
-
 export const pubValuesInclude = {
 	values: {
 		distinct: ["fieldId"],
@@ -370,19 +341,18 @@ export const pubInclude = {
 			3
 		),
 	},
-	permissions: { include: permissionInclude },
+	members: {
+		include: {
+			user: true,
+		},
+	},
 } satisfies Prisma.PubInclude;
-
-export type PermissionPayload = Prisma.PermissionGetPayload<{ include: typeof permissionInclude }>;
-
-export type PermissionPayloadUser = NonNullable<PermissionPayload["member"]>["user"];
-export type PermissionPayloadMember = NonNullable<PermissionPayload["member"]>;
 
 export const communityMemberInclude = {
 	user: true,
 };
 
-export type CommunityMemberPayload = Prisma.MemberGetPayload<{
+export type CommunityMemberPayload = Prisma.CommunityMembershipGetPayload<{
 	include: typeof communityMemberInclude;
 }>;
 
@@ -390,7 +360,6 @@ export const stageInclude = {
 	actionInstances: true,
 	pubs: { include: { pub: { include: pubInclude } } },
 	integrationInstances: { include: { integration: true } },
-	permissions: { include: permissionInclude },
 	moveConstraints: { include: { destination: true } },
 	moveConstraintSources: true,
 } satisfies Prisma.StageInclude;

--- a/core/lib/server/cache/autoCache.ts
+++ b/core/lib/server/cache/autoCache.ts
@@ -104,9 +104,9 @@ const executeWithCache = <
  * 		"lastName",
  * 		"avatar",
  * 		jsonObjectAgg(
- * 			eb.selectFrom("members").selectAll().whereRef("members.user_id", "=", "users.id")
+ * 			eb.selectFrom("community_memberships").selectAll("community_memberships").whereRef("community_memberships.user_id", "=", "users.id")
  * 		)
- * 			.where("community_id", "=", communityId)
+ * 			.where("community_memberships.communityId", "=", communityId)
  * 			.as("memberships"),
  * 	])
  * );
@@ -145,7 +145,7 @@ const executeWithCache = <
  * 		"lastName",
  * 		"avatar",
  * 		jsonObjectAgg(
- * 			eb.selectFrom("members").selectAll().whereRef("members.user_id", "=", "users.id")
+ * 			eb.selectFrom("community_memberships").selectAll("community_memberships").whereRef("community_memberships.user_id", "=", "users.id")
  * 		)
  * 			.where("community_id", "=", "s")
  * 			.as("memberships"),

--- a/core/lib/server/cache/cache.test.ts
+++ b/core/lib/server/cache/cache.test.ts
@@ -66,22 +66,28 @@ describe("cachedFindTables", () => {
 		const qb = mockedDb
 			.selectFrom("users")
 			.select(["id", "firstName"])
-			.where("id", "=", mockedDb.selectFrom("members").select("userId").limit(1));
+			.where(
+				"id",
+				"=",
+				mockedDb.selectFrom("community_memberships").select("userId").limit(1)
+			);
 
 		const tables = await compileAndFindTables(qb, "select");
 
-		expect(tables).toEqual(["users", "members"]);
+		expect(tables).toEqual(["users", "community_memberships"]);
 	});
 
 	it("should return the correct tables for a query with a subquery in an array", async () => {
 		const qb = mockedDb
 			.selectFrom("users")
 			.select(["id", "firstName"])
-			.where("id", "=", [mockedDb.selectFrom("members").select("userId").limit(1)]);
+			.where("id", "=", [
+				mockedDb.selectFrom("community_memberships").select("userId").limit(1),
+			]);
 
 		const tables = await compileAndFindTables(qb, "select");
 
-		expect(tables).toEqual(["users", "members"]);
+		expect(tables).toEqual(["users", "community_memberships"]);
 	});
 
 	it("should not return the tables used in select subqueries/CTEs for mutation queries", async () => {
@@ -93,15 +99,16 @@ describe("cachedFindTables", () => {
 			// as it will not change
 			.with("firstCommunity", (qb) => qb.selectFrom("communities").selectAll().limit(1))
 			// members SHOULD be included in the to be invalidated tags
-			.insertInto("members")
+			.insertInto("community_memberships")
 			.values((eb) => ({
 				userId: eb.selectFrom("firstUser").select("firstUser.id"),
 				communityId: eb.selectFrom("firstCommunity").select("firstCommunity.id"),
+				role: MemberRole.editor,
 			}));
 
 		const tables = await compileAndFindTables(qb, "mutation");
 
-		expect(tables).toEqual(["members"]);
+		expect(tables).toEqual(["community_memberships"]);
 	});
 
 	it("should not filter out the tables used in select subqueries/CTEs for mutation queries if they are also mutated", async () => {
@@ -114,15 +121,16 @@ describe("cachedFindTables", () => {
 					.where("id", "=", qb.selectFrom("firstUser").select("firstUser.id"))
 			)
 			.with("firstCommunity", (qb) => qb.selectFrom("communities").selectAll().limit(1))
-			.insertInto("members")
+			.insertInto("community_memberships")
 			.values((eb) => ({
 				userId: eb.selectFrom("firstUser").select("firstUser.id"),
 				communityId: eb.selectFrom("firstCommunity").select("firstCommunity.id"),
+				role: MemberRole.editor,
 			}));
 
 		const tables = await compileAndFindTables(qb, "mutation");
 
-		expect(tables).toEqual(["members", "users"]);
+		expect(tables).toEqual(["community_memberships", "users"]);
 	});
 
 	it("should return the correct tables for a rather complex query", async () => {
@@ -187,7 +195,7 @@ describe("cachedFindTables", () => {
 	});
 
 	it("should include joins in select queries", async () => {
-		const query = mockedDb.selectFrom("members");
+		const query = mockedDb.selectFrom("community_memberships");
 
 		const joins = [
 			"innerJoin",
@@ -202,27 +210,28 @@ describe("cachedFindTables", () => {
 			joins.map(async (joinType) => {
 				const tables = await compileAndFindTables(
 					// @ts-expect-error shh
-					query[joinType]("users", "users.id", "members.user_id"),
+					query[joinType]("users", "users.id", "community_memberships.user_id"),
 					"select"
 				);
-				return expect(tables).toEqual(["members", "users"]);
+				return expect(tables).toEqual(["community_memberships", "users"]);
 			})
 		);
 	});
 
 	it("should not include joins in mutation queries", async () => {
-		const query = mockedDb.insertInto("members").values((eb) => ({
+		const query = mockedDb.insertInto("community_memberships").values((eb) => ({
 			userId: eb
 				.selectFrom("users")
-				.innerJoin("members", "members.userId", "users.id")
-				.innerJoin("communities", "communities.id", "members.communityId")
+				.innerJoin("community_memberships", "community_memberships.userId", "users.id")
+				.innerJoin("communities", "communities.id", "community_memberships.communityId")
 				.select("users.id"),
 			communityId: eb.selectFrom("communities").select("communities.id"),
+			role: MemberRole.editor,
 		}));
 
 		const tables = await compileAndFindTables(query, "mutation");
 
-		expect(tables).toEqual(["members"]);
+		expect(tables).toEqual(["community_memberships"]);
 
 		// function here to make sure the query is not executed
 		() => {

--- a/core/lib/server/community.ts
+++ b/core/lib/server/community.ts
@@ -48,9 +48,9 @@ export type CommunityData = Awaited<ReturnType<typeof findCommunityByPubId>>;
 // TODO: cache this
 export const getAvailableCommunities = async (userId: UsersId) => {
 	return await db
-		.selectFrom("members")
-		.where("members.userId", "=", userId)
-		.innerJoin("communities", "communities.id", "members.communityId")
+		.selectFrom("community_memberships")
+		.where("community_memberships.userId", "=", userId)
+		.innerJoin("communities", "communities.id", "community_memberships.communityId")
 		.selectAll("communities")
 		.execute();
 };

--- a/core/lib/server/form.ts
+++ b/core/lib/server/form.ts
@@ -3,14 +3,7 @@ import type { QueryCreator } from "kysely";
 import { sql } from "kysely";
 import { jsonArrayFrom } from "kysely/helpers/postgres";
 
-import type {
-	CommunitiesId,
-	CommunityMembershipsId,
-	FormsId,
-	PublicSchema,
-	PubsId,
-	UsersId,
-} from "db/public";
+import type { CommunitiesId, FormsId, PublicSchema, PubsId, UsersId } from "db/public";
 import { AuthTokenType } from "db/public";
 
 import type { XOR } from "../types";
@@ -116,18 +109,7 @@ export const addMemberToForm = async (
 
 	if (existingPermission === undefined) {
 		await autoRevalidate(
-			db
-				.with("new_permission", (db) =>
-					db.insertInto("permissions").values({ memberId }).returning("id")
-				)
-				.with("form_membership", (db) =>
-					db.insertInto("form_memberships").values({ formId: form.id, userId })
-				)
-				.insertInto("form_to_permissions")
-				.values((eb) => ({
-					formId: form.id,
-					permissionId: eb.selectFrom("new_permission").select("new_permission.id"),
-				}))
+			db.insertInto("form_memberships").values({ formId: form.id, userId })
 		).execute();
 	}
 };

--- a/core/lib/server/form.ts
+++ b/core/lib/server/form.ts
@@ -3,7 +3,14 @@ import type { QueryCreator } from "kysely";
 import { sql } from "kysely";
 import { jsonArrayFrom } from "kysely/helpers/postgres";
 
-import type { CommunitiesId, FormsId, MembersId, PublicSchema, PubsId, UsersId } from "db/public";
+import type {
+	CommunitiesId,
+	CommunityMembershipsId,
+	FormsId,
+	PublicSchema,
+	PubsId,
+	UsersId,
+} from "db/public";
 import { AuthTokenType } from "db/public";
 
 import type { XOR } from "../types";
@@ -63,29 +70,27 @@ export const userHasPermissionToForm = async (
 ) => {
 	const formPermission = await autoCache(
 		db
-			.selectFrom("permissions")
-			.innerJoin("members", "members.id", "permissions.memberId")
-
+			.selectFrom("form_memberships")
 			// userId / email split
 			.$if(Boolean(props.email), (eb) =>
 				eb
-					.innerJoin("users", "users.id", "members.userId")
+					.innerJoin("users", "users.id", "form_memberships.userId")
 					.where("users.email", "=", props.email!)
 			)
-			.$if(Boolean(props.userId), (eb) => eb.where("members.userId", "=", props.userId!))
-
-			.innerJoin("form_to_permissions", "permissionId", "permissions.id")
+			.$if(Boolean(props.userId), (eb) =>
+				eb.where("form_memberships.userId", "=", props.userId!)
+			)
 
 			// formSlug / formId split
 			.$if(Boolean(props.formSlug), (eb) =>
 				eb
-					.innerJoin("forms", "forms.id", "form_to_permissions.formId")
+					.innerJoin("forms", "forms.id", "form_memberships.formId")
 					.where("forms.slug", "=", props.formSlug!)
 			)
 			.$if(Boolean(props.formId), (eb) =>
-				eb.where("form_to_permissions.formId", "=", props.formId!)
+				eb.where("form_memberships.formId", "=", props.formId!)
 			)
-			.select(["permissions.id"])
+			.select(["form_memberships.id"])
 	).executeTakeFirst();
 
 	return Boolean(formPermission);
@@ -95,22 +100,18 @@ export const userHasPermissionToForm = async (
  * Gives a community member permission to a form
  */
 export const addMemberToForm = async (
-	props: { communityId: CommunitiesId; memberId: MembersId; userId: UsersId } & XOR<
-		{ slug: string },
-		{ id: FormsId }
-	>
+	props: { communityId: CommunitiesId; userId: UsersId } & XOR<{ slug: string }, { id: FormsId }>
 ) => {
 	// TODO: Rewrite as single, `autoRevalidate`-d query with CTEs
-	const { memberId, userId, ...getFormProps } = props;
+	const { userId, ...getFormProps } = props;
 	const form = await getForm(getFormProps).executeTakeFirstOrThrow();
 
 	const existingPermission = await autoCache(
 		db
-			.selectFrom("form_to_permissions")
-			.innerJoin("permissions", "permissions.id", "form_to_permissions.permissionId")
-			.selectAll()
-			.where("form_to_permissions.formId", "=", form.id)
-			.where("permissions.memberId", "=", memberId)
+			.selectFrom("form_memberships")
+			.selectAll("form_memberships")
+			.where("form_memberships.formId", "=", form.id)
+			.where("form_memberships.userId", "=", userId)
 	).executeTakeFirst();
 
 	if (existingPermission === undefined) {

--- a/core/lib/server/member.ts
+++ b/core/lib/server/member.ts
@@ -3,12 +3,10 @@ import { jsonObjectFrom } from "kysely/helpers/postgres";
 import type {
 	CommunitiesId,
 	CommunityMembershipsId,
-	MembersId,
-	MembersUpdate,
+	CommunityMembershipsUpdate,
 	NewCommunityMemberships,
 	UsersId,
 } from "db/public";
-import { MemberRole } from "db/public";
 
 import type { XOR } from "../types";
 import { db } from "~/kysely/database";
@@ -78,50 +76,22 @@ export const getMembers = ({ communityId }: { communityId: CommunitiesId }, trx 
 export const inviteMember = (props: NewCommunityMemberships & { userId: UsersId }, trx = db) =>
 	autoRevalidate(
 		trx
-			.with("member", (db) =>
-				db
-					.insertInto("members")
-					.values({
-						userId: props.userId,
-						communityId: props.communityId,
-						role: props.role ?? MemberRole.editor,
-					})
-					.returning("members.id")
-			)
 			.insertInto("community_memberships")
-			.values((eb) => ({
-				id: eb.selectFrom("member").select("id") as unknown as CommunityMembershipsId,
+			.values({
 				userId: props.userId,
 				communityId: props.communityId,
 				role: props.role,
-			}))
+			})
 			.returningAll()
 	);
 
-export const updateMember = ({ id, ...props }: MembersUpdate & { id: MembersId }, trx = db) =>
+export const updateMember = (
+	{ id, ...props }: CommunityMembershipsUpdate & { id: CommunityMembershipsId },
+	trx = db
+) =>
 	autoRevalidate(
-		trx
-			.with("community_membership", (db) =>
-				db
-					.updateTable("community_memberships")
-					.set(props)
-					.where("id", "=", id as unknown as CommunityMembershipsId)
-			)
-			.updateTable("members")
-			.set(props)
-			.where("id", "=", id)
-			.returningAll()
+		trx.updateTable("community_memberships").set(props).where("id", "=", id).returningAll()
 	);
 
-export const removeMember = (props: MembersId, trx = db) =>
-	autoRevalidate(
-		trx
-			.with("community_membership", (db) =>
-				db
-					.deleteFrom("community_memberships")
-					.where("id", "=", props as unknown as CommunityMembershipsId)
-			)
-			.deleteFrom("members")
-			.where("id", "=", props)
-			.returningAll()
-	);
+export const removeMember = (props: CommunityMembershipsId, trx = db) =>
+	autoRevalidate(trx.deleteFrom("community_memberships").where("id", "=", props).returningAll());

--- a/core/lib/server/member.ts
+++ b/core/lib/server/member.ts
@@ -20,57 +20,59 @@ import { SAFE_USER_SELECT } from "./user";
  * Either get a member by their id, or by userId and communityId
  */
 export const getMember = (
-	props: XOR<{ id: MembersId }, { userId: UsersId; communityId: CommunitiesId }>,
+	props: XOR<{ id: CommunityMembershipsId }, { userId: UsersId; communityId: CommunitiesId }>,
 	trx = db
 ) => {
 	return autoCache(
 		trx
-			.selectFrom("members")
+			.selectFrom("community_memberships")
 			.select((eb) => [
-				"members.id",
-				"members.userId",
-				"members.createdAt",
-				"members.updatedAt",
-				"members.role",
-				"members.communityId",
+				"community_memberships.id",
+				"community_memberships.userId",
+				"community_memberships.createdAt",
+				"community_memberships.updatedAt",
+				"community_memberships.role",
+				"community_memberships.communityId",
 				jsonObjectFrom(
 					eb
 						.selectFrom("users")
 						.select(SAFE_USER_SELECT)
-						.whereRef("users.id", "=", "members.userId")
+						.whereRef("users.id", "=", "community_memberships.userId")
 				)
 					.$notNull()
 					.as("user"),
 			])
-			.$if(Boolean(props.userId), (eb) => eb.where("members.userId", "=", props.userId!))
-			.$if(Boolean(props.communityId), (eb) =>
-				eb.where("members.communityId", "=", props.communityId!)
+			.$if(Boolean(props.userId), (eb) =>
+				eb.where("community_memberships.userId", "=", props.userId!)
 			)
-			.$if(Boolean(props.id), (eb) => eb.where("members.id", "=", props.id!))
+			.$if(Boolean(props.communityId), (eb) =>
+				eb.where("community_memberships.communityId", "=", props.communityId!)
+			)
+			.$if(Boolean(props.id), (eb) => eb.where("community_memberships.id", "=", props.id!))
 	);
 };
 
 export const getMembers = ({ communityId }: { communityId: CommunitiesId }, trx = db) =>
 	autoCache(
 		trx
-			.selectFrom("members")
+			.selectFrom("community_memberships")
 			.select((eb) => [
-				"members.id",
-				"members.userId",
-				"members.createdAt",
-				"members.updatedAt",
-				"members.role",
-				"members.communityId",
+				"community_memberships.id",
+				"community_memberships.userId",
+				"community_memberships.createdAt",
+				"community_memberships.updatedAt",
+				"community_memberships.role",
+				"community_memberships.communityId",
 				jsonObjectFrom(
 					eb
 						.selectFrom("users")
 						.select(SAFE_USER_SELECT)
-						.whereRef("users.id", "=", "members.userId")
+						.whereRef("users.id", "=", "community_memberships.userId")
 				)
 					.$notNull()
 					.as("user"),
 			])
-			.where("members.communityId", "=", communityId)
+			.where("community_memberships.communityId", "=", communityId)
 	);
 
 export const inviteMember = (props: NewMembers, trx = db) =>

--- a/core/lib/server/member.ts
+++ b/core/lib/server/member.ts
@@ -5,7 +5,7 @@ import type {
 	CommunityMembershipsId,
 	MembersId,
 	MembersUpdate,
-	NewMembers,
+	NewCommunityMemberships,
 	UsersId,
 } from "db/public";
 import { MemberRole } from "db/public";
@@ -75,22 +75,22 @@ export const getMembers = ({ communityId }: { communityId: CommunitiesId }, trx 
 			.where("community_memberships.communityId", "=", communityId)
 	);
 
-export const inviteMember = (props: NewMembers, trx = db) =>
+export const inviteMember = (props: NewCommunityMemberships & { userId: UsersId }, trx = db) =>
 	autoRevalidate(
 		trx
-			.with("community_membership", (db) =>
+			.with("member", (db) =>
 				db
-					.insertInto("community_memberships")
+					.insertInto("members")
 					.values({
 						userId: props.userId,
 						communityId: props.communityId,
 						role: props.role ?? MemberRole.editor,
 					})
-					.returning("community_memberships.id")
+					.returning("members.id")
 			)
-			.insertInto("members")
+			.insertInto("community_memberships")
 			.values((eb) => ({
-				id: eb.selectFrom("community_membership").select("id") as unknown as MembersId,
+				id: eb.selectFrom("member").select("id") as unknown as CommunityMembershipsId,
 				userId: props.userId,
 				communityId: props.communityId,
 				role: props.role,

--- a/core/lib/server/render/pub/renderWithPubUtils.ts
+++ b/core/lib/server/render/pub/renderWithPubUtils.ts
@@ -1,4 +1,4 @@
-import type { CommunitiesId, MembersId, PubsId, UsersId } from "db/public";
+import type { CommunitiesId, CommunityMembershipsId, PubsId, UsersId } from "db/public";
 import { CoreSchemaType } from "db/public";
 import { assert, expect } from "utils";
 
@@ -20,7 +20,7 @@ export type RenderWithPubPub = {
 
 export type RenderWithPubContext = {
 	recipient: {
-		id: MembersId;
+		id: CommunityMembershipsId;
 		user: {
 			id: UsersId;
 			firstName: string;
@@ -66,12 +66,12 @@ const getPubValue = (context: RenderWithPubContext, fieldSlug: string, rel?: str
 
 export const renderFormInviteLink = async (
 	formSlug: string,
-	memberId: MembersId,
+	memberId: CommunityMembershipsId,
 	userId: UsersId,
 	communityId: CommunitiesId,
 	pubId?: string
 ) => {
-	await addMemberToForm({ memberId, userId, communityId, slug: formSlug });
+	await addMemberToForm({ userId, communityId, slug: formSlug });
 	return createFormInviteLink({ userId, formSlug, communityId, pubId: pubId as PubsId });
 };
 
@@ -84,7 +84,7 @@ export const renderMemberFields = async ({
 	fieldSlug: string;
 	communitySlug: string;
 	attributes: string[];
-	memberId: MembersId;
+	memberId: CommunityMembershipsId;
 }) => {
 	// Make sure this field is a member type
 	const fieldIsMemberTypeQuery = autoCache(

--- a/core/lib/server/render/pub/renderWithPubUtils.ts
+++ b/core/lib/server/render/pub/renderWithPubUtils.ts
@@ -98,10 +98,10 @@ export const renderMemberFields = async ({
 
 	const userQuery = autoCache(
 		db
-			.selectFrom("members")
-			.innerJoin("users", "users.id", "members.userId")
+			.selectFrom("community_memberships")
+			.innerJoin("users", "users.id", "community_memberships.userId")
 			.select(ALLOWED_MEMBER_ATTRIBUTES)
-			.where("members.id", "=", memberId)
+			.where("community_memberships.id", "=", memberId)
 	);
 
 	const [, user] = await Promise.all([

--- a/core/lib/server/user.ts
+++ b/core/lib/server/user.ts
@@ -34,14 +34,14 @@ export const getUser = cache((userIdOrEmail: XOR<{ id: UsersId }, { email: strin
 			...SAFE_USER_SELECT,
 			jsonArrayFrom(
 				eb
-					.selectFrom("members")
+					.selectFrom("community_memberships")
 					.select((eb) => [
-						"members.id",
-						"members.userId",
-						"members.createdAt",
-						"members.updatedAt",
-						"members.role",
-						"members.communityId",
+						"community_memberships.id",
+						"community_memberships.userId",
+						"community_memberships.createdAt",
+						"community_memberships.updatedAt",
+						"community_memberships.role",
+						"community_memberships.communityId",
 						jsonObjectFrom(
 							eb
 								.selectFrom("communities")
@@ -53,11 +53,14 @@ export const getUser = cache((userIdOrEmail: XOR<{ id: UsersId }, { email: strin
 									"communities.createdAt",
 									"communities.updatedAt",
 								])
-								.whereRef("communities.id", "=", "members.communityId")
+								.whereRef(
+									"communities.id",
+									"=",
+									"community_memberships.communityId"
+								)
 						).as("community"),
 					])
-					// for some reason doing "members.userId" doesn't work
-					.whereRef("userId", "=", "users.id")
+					.whereRef("community_memberships.userId", "=", "users.id")
 			).as("memberships"),
 		])
 		.$if(Boolean(userIdOrEmail.email), (eb) =>
@@ -98,10 +101,10 @@ export const getSuggestedUsers = ({
 				eb.select((eb) => [
 					jsonObjectFrom(
 						eb
-							.selectFrom("members")
-							.selectAll("members")
-							.whereRef("members.userId", "=", "users.id")
-							.where("members.communityId", "=", communityId!)
+							.selectFrom("community_memberships")
+							.selectAll("community_memberships")
+							.whereRef("community_memberships.userId", "=", "users.id")
+							.where("community_memberships.communityId", "=", communityId!)
 					).as("member"),
 				])
 			)
@@ -142,9 +145,9 @@ export const updateUser = async (
 	// as we would need to know the result of this query in order to tag it
 	// properly, which is obviously impossible
 	const communitySlugs = await trx
-		.selectFrom("members")
+		.selectFrom("community_memberships")
 		.where("userId", "=", id)
-		.innerJoin("communities", "members.communityId", "communities.id")
+		.innerJoin("communities", "community_memberships.communityId", "communities.id")
 		.select(["communities.slug"])
 		.execute();
 

--- a/core/lib/types.ts
+++ b/core/lib/types.ts
@@ -1,6 +1,6 @@
 import type {
 	Communities,
-	Members,
+	CommunityMemberships,
 	PubFields,
 	PubFieldsId,
 	Pubs,
@@ -12,14 +12,16 @@ import type { PubValues } from "./server";
 import type { DirectAutoOutput } from "./server/cache/types";
 
 export type UserWithMemberships = Omit<Users, "passwordHash"> & {
-	memberships: Members[];
+	memberships: Omit<CommunityMemberships, "memberGroupId">[];
 };
 
 export type UserWithMember = Omit<Users, "passwordHash"> & {
-	member?: Members | null;
+	member?: Omit<CommunityMemberships, "memberGroupId"> | null;
 };
 
-export type MemberWithUser = Members & { user: Omit<Users, "passwordHash"> };
+export type MemberWithUser = Omit<CommunityMemberships, "memberGroupId"> & {
+	user: Omit<Users, "passwordHash">;
+};
 
 export type UserPostBody = Pick<Users, "firstName" | "lastName" | "email">;
 export type UserPutBody = Pick<Users, "firstName" | "lastName">;

--- a/core/prisma/exampleCommunitySeeds/unjournal.ts
+++ b/core/prisma/exampleCommunitySeeds/unjournal.ts
@@ -548,7 +548,7 @@ export default async function main(prisma: PrismaClient, communityUUID: string) 
 		},
 	});
 
-	const member = await prisma.member.create({
+	const member = await prisma.communityMembership.create({
 		data: {
 			userId: user1.id,
 			communityId: communityUUID,
@@ -611,67 +611,6 @@ export default async function main(prisma: PrismaClient, communityUUID: string) 
 				order: "hh",
 			},
 		],
-	});
-
-	await prisma.permission.create({
-		data: {
-			member: {
-				connect: { id: member.id },
-			},
-			stages: {
-				connect: [{ id: stageIds[0] }],
-			},
-			// pubs: {
-			// 	connect: [{ id: submission.id }],
-			// },
-		},
-	});
-
-	await prisma.permission.create({
-		data: {
-			memberGroup: {
-				connect: { id: memberGroup.id },
-			},
-			stages: {
-				connect: [{ id: stageIds[0] }],
-			},
-			// pubs: {
-			// 	connect: [{ id: submission.id }],
-			// },
-		},
-	});
-
-	await prisma.permission.create({
-		data: {
-			memberGroup: {
-				connect: { id: memberGroup.id },
-			},
-			stages: {
-				connect: [{ id: stageIds[1] }],
-			},
-		},
-	});
-
-	await prisma.permission.create({
-		data: {
-			memberGroup: {
-				connect: { id: memberGroup.id },
-			},
-			stages: {
-				connect: [{ id: stageIds[2] }],
-			},
-		},
-	});
-
-	await prisma.permission.create({
-		data: {
-			member: {
-				connect: { id: member.id },
-			},
-			stages: {
-				connect: [{ id: stageIds[3] }],
-			},
-		},
 	});
 
 	//  Submitted can be moved to: Consent, To Evaluate, Under Evaluation, Shelved

--- a/core/prisma/migrations/20241105184158_copy_membership_data/migration.sql
+++ b/core/prisma/migrations/20241105184158_copy_membership_data/migration.sql
@@ -1,16 +1,14 @@
--- This is an empty migration.
-
 BEGIN;
 
-INSERT INTO "community_memberships" 
-    SELECT * FROM "members" 
+INSERT INTO "community_memberships"
+    SELECT "id", "role", "communityId", "userId", "createdAt", "updatedAt" FROM "members"
     ON CONFLICT ("id") DO NOTHING;
 
 INSERT INTO "form_memberships" 
     SELECT "formId", "userId" FROM "form_to_permissions"
     JOIN "permissions"
         ON "permissions"."id" = "form_to_permissions"."permissionId"
-    JOIN "members" 
+    JOIN "members"
         ON "members"."id" = "permissions"."memberId";
 
 COMMIT;

--- a/core/prisma/migrations/20241105184158_copy_membership_data/migration.sql
+++ b/core/prisma/migrations/20241105184158_copy_membership_data/migration.sql
@@ -1,0 +1,16 @@
+-- This is an empty migration.
+
+BEGIN;
+
+INSERT INTO "community_memberships" 
+    SELECT * FROM "members" 
+    ON CONFLICT ("id") DO NOTHING;
+
+INSERT INTO "form_memberships" 
+    SELECT "formId", "userId" FROM "form_to_permissions"
+    JOIN "permissions"
+        ON "permissions"."id" = "form_to_permissions"."permissionId"
+    JOIN "members" 
+        ON "members"."id" = "permissions"."memberId";
+
+COMMIT;

--- a/core/prisma/schema.dbml
+++ b/core/prisma/schema.dbml
@@ -21,10 +21,10 @@ Table users {
   actionRuns action_runs [not null]
   ApiAccessToken api_access_tokens [not null]
   Session sessions [not null]
-  FormMembership form_memberships [not null]
-  CommunityMembership community_memberships [not null]
-  PubMembership pub_memberships [not null]
-  StageMembership stage_memberships [not null]
+  formMemberships form_memberships [not null]
+  communityMemberships community_memberships [not null]
+  pubMemberships pub_memberships [not null]
+  stageMemberships stage_memberships [not null]
 }
 
 Table sessions {
@@ -88,7 +88,7 @@ Table pubs {
   IntegrationInstanceState IntegrationInstanceState [not null]
   actionRuns action_runs [not null]
   relatedValues pub_values [not null]
-  PubMembership pub_memberships [not null]
+  members pub_memberships [not null]
 }
 
 Table pub_fields {
@@ -178,7 +178,7 @@ Table stages {
   permissions permissions [not null]
   actionInstances action_instances [not null]
   formElements form_elements [not null]
-  StageMembership stage_memberships [not null]
+  members stage_memberships [not null]
 }
 
 Table PubsInStages {

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -34,16 +34,16 @@ model User {
   passwordHash String?
 
   memberships         Member[]
-  memberGroups        MemberGroup[]
-  AuthToken           AuthToken[]
-  assignedPubs        Pub[]
-  actionRuns          ActionRun[]
-  ApiAccessToken      ApiAccessToken[]
-  Session             Session[]
-  FormMembership      FormMembership[]
-  CommunityMembership CommunityMembership[]
-  PubMembership       PubMembership[]
-  StageMembership     StageMembership[]
+  memberGroups         MemberGroup[]
+  AuthToken            AuthToken[]
+  assignedPubs         Pub[]
+  actionRuns           ActionRun[]
+  ApiAccessToken       ApiAccessToken[]
+  Session              Session[]
+  formMemberships      FormMembership[]
+  communityMemberships CommunityMembership[]
+  pubMemberships       PubMembership[]
+  stageMemberships     StageMembership[]
 
   @@map(name: "users")
 }
@@ -131,7 +131,7 @@ model Pub {
   IntegrationInstanceState IntegrationInstanceState[]
   actionRuns               ActionRun[]
   relatedValues            PubValue[]                 @relation("related_pub")
-  PubMembership            PubMembership[]
+  members                  PubMembership[]
 
   @@map(name: "pubs")
 }
@@ -251,7 +251,7 @@ model Stage {
   permissions           Permission[]
   actionInstances       ActionInstance[]
   formElements          FormElement[]
-  StageMembership       StageMembership[]
+  members               StageMembership[]
 
   @@map(name: "stages")
 }

--- a/core/prisma/seed.ts
+++ b/core/prisma/seed.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 import { makeWorkerUtils } from "graphile-worker";
 
-import type { CommunitiesId, CommunityMembershipsId, MembersId } from "db/public";
+import type { CommunitiesId, CommunityMembershipsId } from "db/public";
 import { MemberRole } from "db/public";
 import { logger } from "logger";
 
@@ -51,23 +51,11 @@ async function createUserMembers({
 	}));
 	return db
 		.with("new_users", (db) => db.insertInto("users").values(values).returningAll())
-		.with("community_membership", (db) =>
-			db.insertInto("community_memberships").values((eb) =>
-				memberships.map((membership) => ({
-					...membership,
-					id: membership.id as CommunityMembershipsId,
-					userId: eb
-						.selectFrom("new_users")
-						.select("new_users.id")
-						.where("slug", "=", slug),
-				}))
-			)
-		)
-		.insertInto("members")
+		.insertInto("community_memberships")
 		.values((eb) =>
 			memberships.map((membership) => ({
 				...membership,
-				id: membership.id as MembersId,
+				id: membership.id as CommunityMembershipsId,
 				userId: eb.selectFrom("new_users").select("new_users.id").where("slug", "=", slug),
 			}))
 		)


### PR DESCRIPTION
## Issue(s) Resolved
#718 
## High-level Explanation of PR
This is part 2 of our expand and contract migration series, to be merged only after #1 is successfully deployed.

Now that we've made sure the application is writing to the new tables (in addition to the old ones) we can copy data into the new tables and be certain that they will be in sync with the old tables as part of the migration. Since the code changes in this PR will be deployed only after the migration succeeds, we can then immediately start reading exclusively from the new tables, which is what the rest of the changes in this PR accomplish:
- There should be no more queries reading from the `members`, `form_to_permissions`, and `permissions` (writing is still ok)
- Explicit typings using the generated `Members` types have been replaced with `CommunityMemberships` equivalents