### PR TITLE
Specify target columns in migration

### DIFF
--- a/core/prisma/migrations/20241105184158_copy_membership_data/migration.sql
+++ b/core/prisma/migrations/20241105184158_copy_membership_data/migration.sql
@@ -1,10 +1,10 @@
 BEGIN;
 
-INSERT INTO "community_memberships"
+INSERT INTO "community_memberships" ("id", "role", "communityId", "userId", "createdAt", "updatedAt")
     SELECT "id", "role", "communityId", "userId", "createdAt", "updatedAt" FROM "members"
     ON CONFLICT ("id") DO NOTHING;
 
-INSERT INTO "form_memberships" 
+INSERT INTO "form_memberships" ("formId", "userId")
     SELECT "formId", "userId" FROM "form_to_permissions"
     JOIN "permissions"
         ON "permissions"."id" = "form_to_permissions"."permissionId"


### PR DESCRIPTION
## Issue(s) Resolved
Failed migration from #755 
## High-level Explanation of PR
The previous migration failed to apply because the tables it was copying didn't contain the same number of columns as the target tables. In cases where the source data has fewer columns than the target table, Postgres defaults to inserting the columns in order, leaving the extra columns at the end null.  So for the first query, because there's no `members."memberGroup"` column, the returned data ended up partially in the wrong columns. To fix that, we just explicitly specify the target table columns that we want to insert data into as well.

## Test Plan

Mark the old migration as failed, then deploy this ¯\\\_(ツ)\_/¯
 