### PR TITLE
Simple load test script

### DIFF
--- a/core/.env.development
+++ b/core/.env.development
@@ -13,5 +13,6 @@ MAILGUN_SMTP_USERNAME="xxx"
 
 OTEL_SERVICE_NAME="pubpub-v7-dev" # should be shared across components but not environments
 HONEYCOMB_API_KEY="xxx"
+ARTILLERY_CLOUD_API_KEY="xxx"
 
 KYSELY_DEBUG="true"

--- a/core/docs/load-testing.md
+++ b/core/docs/load-testing.md
@@ -6,7 +6,7 @@ Firstly, [install Artillery](https://www.artillery.io/docs/get-started/get-artil
 npm install -g artillery@latest
 ```
 
-Set the environment variable `ARTILLERY_CLOUD_API_KEY` to your [Artillery Cloud API](https://app.artillery.io/login) key.
+Optional: set the environment variable `ARTILLERY_CLOUD_API_KEY` to your [Artillery Cloud API](https://app.artillery.io/login) key. This is only needed in order for the results to report to Artillery Cloud.
 
 Run the load tests against our production environment from your machine with the following command:
 

--- a/core/docs/load-testing.md
+++ b/core/docs/load-testing.md
@@ -1,0 +1,20 @@
+# Load Testing
+
+Firstly, [install Artillery](https://www.artillery.io/docs/get-started/get-artillery).
+
+```sh
+npm install -g artillery@latest
+```
+
+Set the environment variable `ARTILLERY_CLOUD_API_KEY` to your [Artillery Cloud API](https://app.artillery.io/login) key.
+
+Run the load tests against our production environment from your machine with the following command:
+
+```sh
+pnpm --filter=core load-test
+pnpm --filter=core load-test --report # send test metrics to Artillery Cloud in real time
+```
+
+This command will spawn many virtual users (vusers) that interact with the production application by performing a series of pre-configured tasks. The number of vusers starts small and slowly ramps up until the test reaches a "spike phase" which simulates a sudden and large increase in traffic.
+
+Currently each vuser visits the `/forgot` and `/login` pages before it is terminated. The tests will soon use select tests from our end-to-end test suite to simulate more realistic user behaviors.

--- a/core/load-test.yaml
+++ b/core/load-test.yaml
@@ -26,4 +26,6 @@ config:
 scenarios:
     - flow:
           - get:
+                url: "/login"
+          - get:
                 url: "/forgot"

--- a/core/load-test.yaml
+++ b/core/load-test.yaml
@@ -1,0 +1,29 @@
+config:
+    target: https://app.pubpub.org
+    phases:
+        - duration: 60
+          arrivalRate: 1
+          rampTo: 5
+          name: Warm up phase
+        - duration: 60
+          arrivalRate: 5
+          rampTo: 10
+          name: Ramp up load
+        - duration: 30
+          arrivalRate: 10
+          rampTo: 30
+          name: Spike phase
+    plugins:
+        ensure: {}
+        apdex: {}
+        metrics-by-endpoint: {}
+    apdex:
+        threshold: 100
+    ensure:
+        thresholds:
+            - http.response_time.p99: 100
+            - http.response_time.p95: 75
+scenarios:
+    - flow:
+          - get:
+                url: "/forgot"

--- a/core/package.json
+++ b/core/package.json
@@ -11,6 +11,7 @@
 		"dev": "next dev -p 3000 --turbo | pino-pretty",
 		"build": "SKIP_VALIDATION=true next build",
 		"invite-users": "dotenv -e .env.local -e .env.development  tsx scripts/invite.ts",
+		"load-test": "dotenv -e .env.local -e .env.development artillery run load-test.yaml",
 		"lint": "eslint",
 		"lint:fix": "eslint --fix",
 		"migrate-dev": "dotenv -e .env.local -e .env.development prisma migrate dev && pnpm --filter db make-kysely-types",


### PR DESCRIPTION
## Issue(s) Resolved

#744

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->

This PR introduces an npm script to the `core` package that executes a simple load test against our production environment at https://app.pubpub.org. The load test is a placeholder as it only generates traffic to "lightweight" public pages: `/login` and `/forgot`.

## Test Plan

Follow the instructions in the [load test readme](core/docs/load-testing.md). Artillery Cloud API credentials are not necessary to run the tests, the results just won't be reported to Artillery Cloud.
