### PR TITLE
use login playwright flow as load test

### DIFF
--- a/core/load-test-flows.ts
+++ b/core/load-test-flows.ts
@@ -1,0 +1,13 @@
+/* eslint-disable no-restricted-properties */
+
+import type { Page } from "@playwright/test";
+
+import * as loginFlows from "./playwright/login.flows";
+
+export async function loginFlow(page: Page) {
+	await loginFlows.login(
+		page,
+		process.env.LOAD_TEST_USER_EMAIL,
+		process.env.LOAD_TEST_USER_PASSWORD
+	);
+}

--- a/core/load-test.yaml
+++ b/core/load-test.yaml
@@ -5,6 +5,11 @@ config:
         playwright: {}
     # Path to JavaScript file that defines Playwright test functions
     processor: "./load-test-flows.ts"
+    phases:
+        - duration: 60
+          arrivalRate: 1
+          rampTo: 2
+          name: Warm up phase
 scenarios:
     - engine: playwright
       testFunction: "loginFlow"

--- a/core/load-test.yaml
+++ b/core/load-test.yaml
@@ -1,18 +1,25 @@
 config:
     target: https://app.pubpub.org
+    engines:
+        playwright: {}
+    processor: "./load-test-flows.ts"
     phases:
         - duration: 60
           arrivalRate: 1
-          rampTo: 5
+          rampTo: 2
           name: Warm up phase
-        - duration: 60
-          arrivalRate: 5
-          rampTo: 10
-          name: Ramp up load
-        - duration: 30
-          arrivalRate: 10
-          rampTo: 30
-          name: Spike phase
+        # - duration: 60
+        #   arrivalRate: 1
+        #   rampTo: 5
+        #   name: Warm up phase
+        # - duration: 60
+        #   arrivalRate: 5
+        #   rampTo: 10
+        #   name: Ramp up load
+        # - duration: 30
+        #   arrivalRate: 10
+        #   rampTo: 30
+        #   name: Spike phase
     plugins:
         ensure: {}
         apdex: {}
@@ -24,8 +31,5 @@ config:
             - http.response_time.p99: 100
             - http.response_time.p95: 75
 scenarios:
-    - flow:
-          - get:
-                url: "/login"
-          - get:
-                url: "/forgot"
+    - engine: playwright
+      testFunction: "loginFlow"

--- a/core/load-test.yaml
+++ b/core/load-test.yaml
@@ -1,35 +1,10 @@
 config:
     target: https://app.pubpub.org
+    # Load the Playwright engine:
     engines:
         playwright: {}
+    # Path to JavaScript file that defines Playwright test functions
     processor: "./load-test-flows.ts"
-    phases:
-        - duration: 60
-          arrivalRate: 1
-          rampTo: 2
-          name: Warm up phase
-        # - duration: 60
-        #   arrivalRate: 1
-        #   rampTo: 5
-        #   name: Warm up phase
-        # - duration: 60
-        #   arrivalRate: 5
-        #   rampTo: 10
-        #   name: Ramp up load
-        # - duration: 30
-        #   arrivalRate: 10
-        #   rampTo: 30
-        #   name: Spike phase
-    plugins:
-        ensure: {}
-        apdex: {}
-        metrics-by-endpoint: {}
-    apdex:
-        threshold: 100
-    ensure:
-        thresholds:
-            - http.response_time.p99: 100
-            - http.response_time.p95: 75
 scenarios:
     - engine: playwright
       testFunction: "loginFlow"

--- a/core/package.json
+++ b/core/package.json
@@ -150,6 +150,7 @@
 		"jsdom": "^25.0.1",
 		"kanel": "^3.8.2",
 		"kanel-kysely": "^0.4.0",
+		"playwright": "^1.48.2",
 		"postcss": "catalog:",
 		"prisma": "^5.2.0",
 		"prisma-dbml-generator": "^0.12.0",

--- a/core/package.json
+++ b/core/package.json
@@ -150,7 +150,6 @@
 		"jsdom": "^25.0.1",
 		"kanel": "^3.8.2",
 		"kanel-kysely": "^0.4.0",
-		"playwright": "^1.48.2",
 		"postcss": "catalog:",
 		"prisma": "^5.2.0",
 		"prisma-dbml-generator": "^0.12.0",

--- a/core/playwright/externalFormCreatePub.spec.ts
+++ b/core/playwright/externalFormCreatePub.spec.ts
@@ -7,7 +7,8 @@ import { CoreSchemaType } from "db/public";
 import { FieldsPage } from "./fixtures/fields-page";
 import { FormsEditPage } from "./fixtures/forms-edit-page";
 import { FormsPage } from "./fixtures/forms-page";
-import { createCommunity, login } from "./helpers";
+import { LoginPage } from "./fixtures/login-page";
+import { createCommunity } from "./helpers";
 
 const now = new Date().getTime();
 const COMMUNITY_SLUG = `playwright-test-community-${now}`;
@@ -19,7 +20,11 @@ let page: Page;
 
 test.beforeAll(async ({ browser }) => {
 	page = await browser.newPage();
-	await login({ page });
+
+	const loginPage = new LoginPage(page);
+	await loginPage.goto();
+	await loginPage.loginAndWaitForNavigation();
+
 	await createCommunity({
 		page,
 		community: { name: `test community ${now}`, slug: COMMUNITY_SLUG },

--- a/core/playwright/externalFormInvite.spec.ts
+++ b/core/playwright/externalFormInvite.spec.ts
@@ -2,16 +2,17 @@
 import type { Page } from "@playwright/test";
 
 import { faker } from "@faker-js/faker";
-import { errors, expect, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import type { PubsId } from "db/public";
 import { Action } from "db/public";
 
 import { FormsPage } from "./fixtures/forms-page";
+import { LoginPage } from "./fixtures/login-page";
 import { PubDetailsPage } from "./fixtures/pub-details-page";
 import { PubsPage } from "./fixtures/pubs-page";
 import { StagesManagePage } from "./fixtures/stages-manage-page";
-import { createCommunity, inbucketClient, login } from "./helpers";
+import { createCommunity, inbucketClient } from "./helpers";
 
 const now = new Date().getTime();
 const COMMUNITY_SLUG = `playwright-test-community-${now}`;
@@ -28,7 +29,11 @@ let pubId: PubsId;
 
 test.beforeAll(async ({ browser }) => {
 	page = await browser.newPage();
-	await login({ page });
+
+	const loginPage = new LoginPage(page);
+	await loginPage.goto();
+	await loginPage.loginAndWaitForNavigation();
+
 	await createCommunity({
 		page,
 		community: { name: `test community ${now}`, slug: COMMUNITY_SLUG },

--- a/core/playwright/externalFormWithPubId.spec.ts
+++ b/core/playwright/externalFormWithPubId.spec.ts
@@ -5,8 +5,9 @@ import { expect, test } from "@playwright/test";
 import { FieldsPage } from "./fixtures/fields-page";
 import { FormsEditPage } from "./fixtures/forms-edit-page";
 import { FormsPage } from "./fixtures/forms-page";
+import { LoginPage } from "./fixtures/login-page";
 import { PubsPage } from "./fixtures/pubs-page";
-import { createCommunity, login } from "./helpers";
+import { createCommunity } from "./helpers";
 
 const now = new Date().getTime();
 const COMMUNITY_SLUG = `playwright-test-community-${now}`;
@@ -18,7 +19,11 @@ let page: Page;
 
 test.beforeAll(async ({ browser }) => {
 	page = await browser.newPage();
-	await login({ page });
+
+	const loginPage = new LoginPage(page);
+	await loginPage.goto();
+	await loginPage.loginAndWaitForNavigation();
+
 	await createCommunity({
 		page,
 		community: { name: `test community ${now}`, slug: COMMUNITY_SLUG },

--- a/core/playwright/fields.spec.ts
+++ b/core/playwright/fields.spec.ts
@@ -5,7 +5,8 @@ import { expect, test } from "@playwright/test";
 import { CoreSchemaType } from "db/public";
 
 import { FieldsPage } from "./fixtures/fields-page";
-import { createCommunity, login } from "./helpers";
+import { LoginPage } from "./fixtures/login-page";
+import { createCommunity } from "./helpers";
 
 const now = new Date().getTime();
 const COMMUNITY_SLUG = `playwright-test-community-${now}`;
@@ -17,7 +18,11 @@ let page: Page;
 test.beforeAll(async ({ browser }) => {
 	test.setTimeout(30_000);
 	page = await browser.newPage();
-	await login({ page });
+
+	const loginPage = new LoginPage(page);
+	await loginPage.goto();
+	await loginPage.loginAndWaitForNavigation();
+
 	await createCommunity({
 		page,
 		community: { name: `test community ${now}`, slug: COMMUNITY_SLUG },

--- a/core/playwright/fixtures/login-page.ts
+++ b/core/playwright/fixtures/login-page.ts
@@ -1,0 +1,21 @@
+import type { Page } from "@playwright/test";
+
+export class LoginPage {
+	constructor(public readonly page: Page) {}
+
+	async goto() {
+		await this.page.goto("/login");
+	}
+
+	async login(email = "all@pubpub.org", password = "pubpub-all") {
+		await this.page.getByLabel("email").fill(email);
+		await this.page.getByRole("textbox", { name: "password" }).fill(password);
+		await this.page.getByRole("button", { name: "Sign in" }).click();
+		await this.page.waitForURL(/.*\/c\/\w+\/stages.*/);
+	}
+
+	async loginAndWaitForNavigation(email = "all@pubpub.org", password = "pubpub-all") {
+		await this.login(email, password);
+		await this.page.waitForURL(/.*\/c\/\w+\/stages.*/);
+	}
+}

--- a/core/playwright/fixtures/login-page.ts
+++ b/core/playwright/fixtures/login-page.ts
@@ -11,7 +11,6 @@ export class LoginPage {
 		await this.page.getByLabel("email").fill(email);
 		await this.page.getByRole("textbox", { name: "password" }).fill(password);
 		await this.page.getByRole("button", { name: "Sign in" }).click();
-		await this.page.waitForURL(/.*\/c\/\w+\/stages.*/);
 	}
 
 	async loginAndWaitForNavigation(email = "all@pubpub.org", password = "pubpub-all") {

--- a/core/playwright/formBuilder.spec.ts
+++ b/core/playwright/formBuilder.spec.ts
@@ -7,7 +7,8 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 import { FormsPage } from "./fixtures/forms-page";
-import { createCommunity, login } from "./helpers";
+import { LoginPage } from "./fixtures/login-page";
+import { createCommunity } from "./helpers";
 
 test.describe.configure({ mode: "serial" });
 
@@ -20,7 +21,11 @@ let page: Page;
 
 test.beforeAll(async ({ browser }) => {
 	page = await browser.newPage();
-	await login({ page });
+
+	const loginPage = new LoginPage(page);
+	await loginPage.goto();
+	await loginPage.loginAndWaitForNavigation();
+
 	await createCommunity({
 		page,
 		community: { name: `test community ${now}`, slug: COMMUNITY_SLUG },

--- a/core/playwright/helpers.ts
+++ b/core/playwright/helpers.ts
@@ -3,19 +3,10 @@ import type { Page } from "@playwright/test";
 
 import { CoreSchemaType } from "db/public";
 
-import { env } from "~/lib/env/env.mjs";
 import { CommunityPage } from "./fixtures/community-page";
 import { FieldsPage } from "./fixtures/fields-page";
 import { PubTypesPage } from "./fixtures/pub-types-page";
 import { InbucketClient } from "./inbucketClient";
-
-export const login = async ({ page }: { page: Page }) => {
-	await page.goto("/login");
-	await page.getByLabel("email").fill("all@pubpub.org");
-	await page.getByRole("textbox", { name: "password" }).fill("pubpub-all");
-	await page.getByRole("button", { name: "Sign in" }).click();
-	await page.waitForURL(/\/c\/\w+\/stages/);
-};
 
 export const createCommunity = async ({
 	page,

--- a/core/playwright/login.flows.ts
+++ b/core/playwright/login.flows.ts
@@ -1,0 +1,12 @@
+import type { Page } from "@playwright/test";
+
+import { expect } from "@playwright/test";
+
+export const login = async (page: Page, email = "new@pubpub.org", password = "pubpub-new") => {
+	await page.goto("/login");
+	await page.getByLabel("email").fill(email);
+	await page.getByRole("textbox", { name: "password" }).fill(password);
+	await page.getByRole("button", { name: "Sign in" }).click();
+	await page.waitForURL(/.*\/c\/\w+\/stages.*/);
+	await expect(page.getByRole("link", { name: "Workflows" })).toBeVisible();
+};

--- a/core/playwright/login.flows.ts
+++ b/core/playwright/login.flows.ts
@@ -1,12 +1,9 @@
 import type { Page } from "@playwright/test";
 
-import { expect } from "@playwright/test";
+import { LoginPage } from "./fixtures/login-page";
 
-export const login = async (page: Page, email = "new@pubpub.org", password = "pubpub-new") => {
-	await page.goto("/login");
-	await page.getByLabel("email").fill(email);
-	await page.getByRole("textbox", { name: "password" }).fill(password);
-	await page.getByRole("button", { name: "Sign in" }).click();
-	await page.waitForURL(/.*\/c\/\w+\/stages.*/);
-	await expect(page.getByRole("link", { name: "Workflows" })).toBeVisible();
+export const login = async (page: Page, email = "all@pubpub.org", password = "pubpub-all") => {
+	const loginPage = new LoginPage(page);
+	await loginPage.goto();
+	await loginPage.loginAndWaitForNavigation(email, password);
 };

--- a/core/playwright/login.spec.ts
+++ b/core/playwright/login.spec.ts
@@ -3,6 +3,7 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 import { inbucketClient } from "./helpers";
+import * as flows from "./login.flows";
 
 const authFile = "playwright/.auth/user.json";
 
@@ -17,22 +18,13 @@ test.describe("general auth", () => {
 	});
 });
 
-const loginAsNew = async (page: Page) => {
-	await page.goto("/login");
-	await page.getByLabel("email").fill("new@pubpub.org");
-	await page.getByRole("textbox", { name: "password" }).fill("pubpub-new");
-	await page.getByRole("button", { name: "Sign in" }).click();
-	await page.waitForURL(/.*\/c\/\w+\/stages.*/);
-	await expect(page.getByRole("link", { name: "Workflows" })).toBeVisible();
-};
-
 test.describe("Auth with lucia", () => {
 	test("Login as a lucia user", async ({ page }) => {
-		await loginAsNew(page);
+		await flows.login(page);
 	});
 
 	test("Logout as a lucia user", async ({ page }) => {
-		await loginAsNew(page);
+		await flows.login(page);
 
 		const cookies = await page.context().cookies();
 		expect(cookies.find((cookie) => cookie.name === "auth_session")).toBeTruthy();

--- a/core/playwright/login.spec.ts
+++ b/core/playwright/login.spec.ts
@@ -15,13 +15,15 @@ test.describe("general auth", () => {
 
 test.describe("Auth with lucia", () => {
 	test("Login as a lucia user", async ({ page }) => {
-		await loginFlows.login(page, "new@pubpub.org", "pubpub-new");
+		const loginPage = new LoginPage(page);
+		await loginPage.goto();
+		await loginPage.loginAndWaitForNavigation("new@pubpub.org", "pubpub-new");
 	});
 
 	test("Logout as a lucia user", async ({ page }) => {
 		const loginPage = new LoginPage(page);
 		await loginPage.goto();
-		await loginPage.login("new@pubpub.org", "pubpub-new");
+		await loginPage.loginAndWaitForNavigation("new@pubpub.org", "pubpub-new");
 
 		const cookies = await page.context().cookies();
 		expect(cookies.find((cookie) => cookie.name === "auth_session")).toBeTruthy();

--- a/core/playwright/login.spec.ts
+++ b/core/playwright/login.spec.ts
@@ -1,30 +1,27 @@
-import type { Page } from "@playwright/test";
-
 import { expect, test } from "@playwright/test";
 
+import { LoginPage } from "./fixtures/login-page";
 import { inbucketClient } from "./helpers";
-import * as flows from "./login.flows";
-
-const authFile = "playwright/.auth/user.json";
+import * as loginFlows from "./login.flows";
 
 test.describe("general auth", () => {
 	test("Login with invalid credentials", async ({ page }) => {
-		await page.goto("/login");
-		await page.getByLabel("email").fill("all@pubpub.org");
-		await page.getByRole("textbox", { name: "password" }).fill("pubpub-all-wrong");
-		await page.getByRole("button", { name: "Sign in" }).click();
-
+		const loginPage = new LoginPage(page);
+		await loginPage.goto();
+		await loginPage.login("all@pubpub.org", "pubpub-all-wrong");
 		await page.getByText("Incorrect email or password", { exact: true }).waitFor();
 	});
 });
 
 test.describe("Auth with lucia", () => {
 	test("Login as a lucia user", async ({ page }) => {
-		await flows.login(page);
+		await loginFlows.login(page, "new@pubpub.org", "pubpub-new");
 	});
 
 	test("Logout as a lucia user", async ({ page }) => {
-		await flows.login(page);
+		const loginPage = new LoginPage(page);
+		await loginPage.goto();
+		await loginPage.login("new@pubpub.org", "pubpub-new");
 
 		const cookies = await page.context().cookies();
 		expect(cookies.find((cookie) => cookie.name === "auth_session")).toBeTruthy();

--- a/core/playwright/member.spec.ts
+++ b/core/playwright/member.spec.ts
@@ -3,8 +3,9 @@ import type { Page } from "@playwright/test";
 import { faker } from "@faker-js/faker";
 import { expect, test } from "@playwright/test";
 
+import { LoginPage } from "./fixtures/login-page";
 import { MembersPage } from "./fixtures/member-page";
-import { createCommunity, inbucketClient, login } from "./helpers";
+import { createCommunity, inbucketClient } from "./helpers";
 
 const now = new Date().getTime();
 const COMMUNITY_SLUG = `playwright-test-community-${now}`;
@@ -15,7 +16,11 @@ let page: Page;
 
 test.beforeAll(async ({ browser }) => {
 	page = await browser.newPage();
-	await login({ page });
+
+	const loginPage = new LoginPage(page);
+	await loginPage.goto();
+	await loginPage.loginAndWaitForNavigation();
+
 	await createCommunity({
 		page,
 		community: { name: `test community ${now}`, slug: COMMUNITY_SLUG },

--- a/core/playwright/pub.spec.ts
+++ b/core/playwright/pub.spec.ts
@@ -6,11 +6,12 @@ import type { PubsId } from "db/public";
 import { CoreSchemaType } from "db/public";
 
 import { FieldsPage } from "./fixtures/fields-page";
+import { LoginPage } from "./fixtures/login-page";
 import { PubDetailsPage } from "./fixtures/pub-details-page";
 import { PubTypesPage } from "./fixtures/pub-types-page";
 import { PubsPage } from "./fixtures/pubs-page";
 import { StagesManagePage } from "./fixtures/stages-manage-page";
-import { createCommunity, login } from "./helpers";
+import { createCommunity } from "./helpers";
 
 const now = new Date().getTime();
 const COMMUNITY_SLUG = `playwright-test-community-${now}`;
@@ -22,7 +23,11 @@ let pubId: PubsId;
 
 test.beforeAll(async ({ browser }) => {
 	page = await browser.newPage();
-	await login({ page });
+
+	const loginPage = new LoginPage(page);
+	await loginPage.goto();
+	await loginPage.loginAndWaitForNavigation();
+
 	await createCommunity({
 		page,
 		community: { name: `test community ${now}`, slug: COMMUNITY_SLUG },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,6 +531,12 @@ importers:
       kanel-kysely:
         specifier: ^0.4.0
         version: 0.4.0
+      playwright:
+        specifier: ^1.48.2
+        version: 1.48.2
+      playwright-core:
+        specifier: ^1.48.2
+        version: 1.48.2
       postcss:
         specifier: 'catalog:'
         version: 8.4.45
@@ -7474,7 +7480,7 @@ packages:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+    resolution: {integrity: sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -7781,7 +7787,7 @@ packages:
     resolution: {integrity: sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==}
 
   concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -10984,8 +10990,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.48.2:
+    resolution: {integrity: sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright@1.48.0:
     resolution: {integrity: sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.48.2:
+    resolution: {integrity: sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -25436,9 +25452,17 @@ snapshots:
 
   playwright-core@1.48.0: {}
 
+  playwright-core@1.48.2: {}
+
   playwright@1.48.0:
     dependencies:
       playwright-core: 1.48.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.48.2:
+    dependencies:
+      playwright-core: 1.48.2
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ catalogs:
       version: 14.2.9
     postcss:
       specifier: ^8.4.27
-      version: 8.4.45
+      version: 8.4.47
     prettier:
       specifier: ^3.3.3
       version: 3.3.3
@@ -56,7 +56,7 @@ catalogs:
       version: 2.5.2
     tailwindcss:
       specifier: ^3.4.10
-      version: 3.4.10
+      version: 3.4.13
     tsx:
       specifier: ^4.19.0
       version: 4.19.0
@@ -467,7 +467,7 @@ importers:
         version: link:../config/prettier
       '@tailwindcss/forms':
         specifier: ^0.5.6
-        version: 0.5.9(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)))
+        version: 0.5.9(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)))
       '@testing-library/react':
         specifier: ^16.0.1
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.0(react@18.3.1))(react@18.3.1)
@@ -512,7 +512,7 @@ importers:
         version: 4.3.1(vite@5.4.3(@types/node@20.16.5)(terser@5.34.1))
       autoprefixer:
         specifier: ^10.4.14
-        version: 10.4.20(postcss@8.4.45)
+        version: 10.4.20(postcss@8.4.47)
       csv-parse:
         specifier: ^5.5.2
         version: 5.5.6
@@ -531,15 +531,9 @@ importers:
       kanel-kysely:
         specifier: ^0.4.0
         version: 0.4.0
-      playwright:
-        specifier: ^1.48.2
-        version: 1.48.2
-      playwright-core:
-        specifier: ^1.48.2
-        version: 1.48.2
       postcss:
         specifier: 'catalog:'
-        version: 8.4.45
+        version: 8.4.47
       prisma:
         specifier: ^5.2.0
         version: 5.19.1
@@ -548,7 +542,7 @@ importers:
         version: 0.12.0
       tailwindcss:
         specifier: 'catalog:'
-        version: 3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2))
+        version: 3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2))
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)
@@ -642,7 +636,7 @@ importers:
         version: link:../../config/prettier
       '@tailwindcss/typography':
         specifier: ^0.5.10
-        version: 0.5.15(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)))
+        version: 0.5.15(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)))
       '@types/node':
         specifier: 'catalog:'
         version: 20.16.5
@@ -651,16 +645,16 @@ importers:
         version: 18.3.5
       autoprefixer:
         specifier: ^10.4.14
-        version: 10.4.20(postcss@8.4.45)
+        version: 10.4.20(postcss@8.4.47)
       logger:
         specifier: workspace:*
         version: link:../../packages/logger
       postcss:
         specifier: 'catalog:'
-        version: 8.4.45
+        version: 8.4.47
       tailwindcss:
         specifier: 'catalog:'
-        version: 3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2))
+        version: 3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2))
       tsconfig:
         specifier: workspace:*
         version: link:../../config/tsconfig
@@ -738,13 +732,13 @@ importers:
         version: 18.3.5
       autoprefixer:
         specifier: ^10.4.14
-        version: 10.4.20(postcss@8.4.45)
+        version: 10.4.20(postcss@8.4.47)
       postcss:
         specifier: 'catalog:'
-        version: 8.4.45
+        version: 8.4.47
       tailwindcss:
         specifier: 'catalog:'
-        version: 3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2))
+        version: 3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2))
       tsconfig:
         specifier: workspace:*
         version: link:../../config/tsconfig
@@ -910,10 +904,10 @@ importers:
         version: 8.3.4(storybook@8.3.4)
       '@tailwindcss/forms':
         specifier: ^0.5.9
-        version: 0.5.9(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)))
+        version: 0.5.9(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)))
       '@tailwindcss/typography':
         specifier: ^0.5.10
-        version: 0.5.15(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)))
+        version: 0.5.15(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)))
       '@types/node':
         specifier: ^20
         version: 20.16.5
@@ -940,7 +934,7 @@ importers:
         version: 8.3.4
       tailwindcss:
         specifier: 'catalog:'
-        version: 3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2))
+        version: 3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2))
       tsconfig:
         specifier: workspace:*
         version: link:../../config/tsconfig
@@ -1276,7 +1270,7 @@ importers:
         version: 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tailwindcss/typography':
         specifier: ^0.5.10
-        version: 0.5.15(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2)))
+        version: 0.5.15(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2)))
       '@tanstack/react-table':
         specifier: ^8.13.2
         version: 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1336,7 +1330,7 @@ importers:
         version: 2.5.2
       tailwindcss-animate:
         specifier: ^1.0.6
-        version: 1.0.7(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2)))
+        version: 1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2)))
       utils:
         specifier: workspace:*
         version: link:../utils
@@ -1355,7 +1349,7 @@ importers:
         version: 9.10.0(jiti@1.21.6)
       postcss:
         specifier: 'catalog:'
-        version: 8.4.45
+        version: 8.4.47
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -1364,7 +1358,7 @@ importers:
         version: 7.53.0(react@18.3.1)
       tailwindcss:
         specifier: 'catalog:'
-        version: 3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2))
+        version: 3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2))
       tsconfig:
         specifier: workspace:*
         version: link:../../config/tsconfig
@@ -6721,9 +6715,6 @@ packages:
   '@types/node@20.16.5':
     resolution: {integrity: sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==}
 
-  '@types/node@22.5.4':
-    resolution: {integrity: sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==}
-
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
@@ -7125,6 +7116,7 @@ packages:
 
   acorn-import-assertions@1.9.0:
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
+    deprecated: package has been renamed to acorn-import-attributes
     peerDependencies:
       acorn: ^8
 
@@ -10990,18 +10982,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.48.2:
-    resolution: {integrity: sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright@1.48.0:
     resolution: {integrity: sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.48.2:
-    resolution: {integrity: sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -11056,10 +11038,6 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.4.45:
-    resolution: {integrity: sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.4.47:
@@ -12262,11 +12240,6 @@ packages:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders'
-
-  tailwindcss@3.4.10:
-    resolution: {integrity: sha512-KWZkVPm7yJRhdu4SRSl9d4AK2wM3a50UsvgHZO7xY77NQr2V+fIrEuoDGQcbvswWvFGbS2f6e+jC/6WJm1Dl0w==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
 
   tailwindcss@3.4.13:
     resolution: {integrity: sha512-KqjHOJKogOUt5Bs752ykCeiwvi0fKVkr5oqsFNt/8px/tA8scFPIlkygsf6jXrfCqGHz7VflA6+yytWuM+XhFw==}
@@ -19820,26 +19793,26 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.2
 
-  '@tailwindcss/forms@0.5.9(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)))':
+  '@tailwindcss/forms@0.5.9(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2))
+      tailwindcss: 3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2))
 
-  '@tailwindcss/typography@0.5.15(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)))':
+  '@tailwindcss/typography@0.5.15(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)))':
     dependencies:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2))
+      tailwindcss: 3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2))
 
-  '@tailwindcss/typography@0.5.15(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2)))':
+  '@tailwindcss/typography@0.5.15(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2)))':
     dependencies:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2))
+      tailwindcss: 3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2))
 
   '@tanstack/react-table@8.20.5(react-dom@18.3.0(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -20282,7 +20255,7 @@ snapshots:
 
   '@types/jsonwebtoken@9.0.6':
     dependencies:
-      '@types/node': 22.5.4
+      '@types/node': 20.16.5
 
   '@types/keygrip@1.0.6': {}
 
@@ -20351,17 +20324,13 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
-  '@types/node@22.5.4':
-    dependencies:
-      undici-types: 6.19.8
-
   '@types/node@22.7.5':
     dependencies:
       undici-types: 6.19.8
 
   '@types/nodemailer@6.4.15':
     dependencies:
-      '@types/node': 22.5.4
+      '@types/node': 20.16.5
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -20383,7 +20352,7 @@ snapshots:
 
   '@types/pg@8.11.8':
     dependencies:
-      '@types/node': 22.5.4
+      '@types/node': 20.16.5
       pg-protocol: 1.6.1
       pg-types: 4.0.2
 
@@ -21133,16 +21102,6 @@ snapshots:
   at-least-node@1.0.0: {}
 
   atomic-sleep@1.0.0: {}
-
-  autoprefixer@10.4.20(postcss@8.4.45):
-    dependencies:
-      browserslist: 4.23.3
-      caniuse-lite: 1.0.30001660
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
-      picocolors: 1.1.0
-      postcss: 8.4.45
-      postcss-value-parser: 4.2.0
 
   autoprefixer@10.4.20(postcss@8.4.47):
     dependencies:
@@ -24860,7 +24819,7 @@ snapshots:
       '@next/env': 14.2.9
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001660
+      caniuse-lite: 1.0.30001667
       graceful-fs: 4.2.11
       postcss: 8.4.31
       react: 18.3.1
@@ -24887,7 +24846,7 @@ snapshots:
       '@next/env': 14.2.9
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001660
+      caniuse-lite: 1.0.30001667
       graceful-fs: 4.2.11
       postcss: 8.4.31
       react: 18.3.1
@@ -25452,17 +25411,9 @@ snapshots:
 
   playwright-core@1.48.0: {}
 
-  playwright-core@1.48.2: {}
-
   playwright@1.48.0:
     dependencies:
       playwright-core: 1.48.0
-    optionalDependencies:
-      fsevents: 2.3.2
-
-  playwright@1.48.2:
-    dependencies:
-      playwright-core: 1.48.2
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -25518,12 +25469,6 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.1.0
-      source-map-js: 1.2.1
-
-  postcss@8.4.45:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.1.0
@@ -27013,11 +26958,11 @@ snapshots:
 
   tailwind-merge@2.5.2: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2))):
     dependencies:
-      tailwindcss: 3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2))
+      tailwindcss: 3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2))
 
-  tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)):
+  tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -27037,33 +26982,6 @@ snapshots:
       postcss-import: 15.1.0(postcss@8.4.47)
       postcss-js: 4.0.1(postcss@8.4.47)
       postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@20.16.5)(typescript@5.6.2))
-      postcss-nested: 6.2.0(postcss@8.4.47)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.8
-      sucrase: 3.35.0
-    transitivePeerDependencies:
-      - ts-node
-
-  tailwindcss@3.4.10(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2)):
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.2
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.6
-      lilconfig: 2.1.0
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.0
-      postcss: 8.4.47
-      postcss-import: 15.1.0(postcss@8.4.47)
-      postcss-js: 4.0.1(postcss@8.4.47)
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.7.24(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.2))
       postcss-nested: 6.2.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -27842,7 +27760,7 @@ snapshots:
   vite@5.4.3(@types/node@20.16.5)(terser@5.34.1):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.45
+      postcss: 8.4.47
       rollup: 4.21.2
     optionalDependencies:
       '@types/node': 20.16.5
@@ -27852,7 +27770,7 @@ snapshots:
   vite@5.4.3(@types/node@22.7.5)(terser@5.34.1):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.45
+      postcss: 8.4.47
       rollup: 4.21.2
     optionalDependencies:
       '@types/node': 22.7.5


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #745

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->

This PR extracts a function used by the login-related end-to-end tests for reuse as a load testing virtual user scenario.

While technically this does not reuse a complete end-to-end test for load testing, it does confirm that we can use playwright as a load test engine and introduces a pattern that enables us to share playwright tests between our end-to-end and load test suites.

I have also simplified the load test configuration for now just to make the config file as easy to understand as possible!

## Test Plan

- Run the tests using the instructions in the [load testing readme](https://github.com/pubpub/platform/blob/main/core/docs/load-testing.md)
- Watch the tests fail!
- Optionally, remove the `phases` property from the `load-test.yaml` file. Run the tests and watch them pass!