### PR TITLE
dev: add large amount of seed pubs for arcadia seed 

### DIFF
--- a/core/globalSetup.ts
+++ b/core/globalSetup.ts
@@ -16,7 +16,7 @@ export const setup = async () => {
 
 	logger.info("Resetting database...");
 	const result = spawnSync(
-		"pnpm --filter core exec dotenv -e ./.env.test -e ./.env.test.local prisma migrate reset -- --preview-feature --force",
+		"MINIMAL_SEED=true pnpm --filter core exec dotenv -e ./.env.test -e ./.env.test.local prisma migrate reset -- --preview-feature --force",
 		{
 			shell: true,
 			stdio: "inherit",

--- a/core/prisma/exampleCommunitySeeds/arcadia.ts
+++ b/core/prisma/exampleCommunitySeeds/arcadia.ts
@@ -1,9 +1,137 @@
+import { faker } from "@faker-js/faker";
+
 import type { CommunitiesId } from "db/public";
 import { CoreSchemaType, MemberRole } from "db/public";
 
 import { seedCommunity } from "../seed/seedCommunity";
 
 export const seedArcadia = (communityId?: CommunitiesId) => {
+	const articleSeed = (number = 1_000, asRelation = false) =>
+		Array.from({ length: number }, (_, idx) => {
+			const pub = {
+				pubType: "Journal Article",
+				stage: "Articles",
+				values: {
+					Title: faker.lorem.sentence(),
+					"Publication Date": new Date(Date.now() - idx * 1000 * 60 * 60 * 24),
+					"Creation Date": new Date(Date.now() - idx * 1000 * 60 * 60 * 24),
+					"Last Edited": new Date(Date.now() - idx * 1000 * 60 * 60 * 24),
+					Avatar: faker.image.url(),
+					Description: faker.lorem.paragraph(),
+					Abstract: faker.lorem.paragraphs(2),
+					License: "CC-BY 4.0",
+					PubContent: "Some content",
+					DOI: "https://doi.org/10.57844/arcadia-14b2-6f27",
+					"Inline Citation Style": "Author Year",
+					"Citation Style": "APA 7",
+				},
+				// the relevant pubs are implemented as both children
+				// and related pubs for demonstration purposes
+				relatedPubs: {
+					// connections in Legacy
+					// all of the below are also added as children to make it easier to see them in the ui as of OCt 22
+					Contributors: [
+						{
+							value: "Editing & Draft Preparation",
+							alsoAsChild: true,
+							pub: {
+								pubType: "Author",
+								values: {
+									Name: faker.person.fullName(),
+									ORCiD: "https://orcid.org/0000-0000-0000-0000",
+									Affiliation: "University of Somewhere",
+								},
+							},
+						},
+					],
+					Downloads: [
+						{
+							// acting as a description of the download
+							value: "PDF Download",
+							alsoAsChild: true,
+							pub: {
+								pubType: "PDF Download",
+								// can't really add the actual file here
+								values: {},
+							},
+						},
+					],
+					Tables: [
+						{
+							value: null,
+							alsoAsChild: true,
+							pub: {
+								pubType: "Table",
+								values: {
+									Caption: "A beautiful table, about things.",
+									CSV: [],
+								},
+							},
+						},
+						{
+							value: null,
+							alsoAsChild: true,
+							pub: {
+								pubType: "Table",
+								values: {
+									Caption: "A table, about things.",
+									CSV: [],
+								},
+							},
+						},
+					],
+					Images: [
+						{
+							value: null,
+							alsoAsChild: true,
+							pub: {
+								pubType: "Pub Image",
+								values: {
+									Caption: "A beautiful image, about things.",
+								},
+							},
+						},
+					],
+					Citations: [
+						{
+							value: "Chapter 5",
+							alsoAsChild: true,
+							pub: {
+								pubType: "ExternalBook",
+								values: {
+									Title: "A Great Book",
+									DOI: "https://doi.org/10.57844/arcadia-ad7f-7a6d",
+									Year: "2022",
+								},
+							},
+						},
+						{
+							value: "pp. 35-53",
+							alsoAsChild: true,
+							pub: {
+								pubType: "ExternalJournalArticle",
+								values: {
+									Title: "A Great Journal Article",
+									DOI: "https://doi.org/10.57844/arcadia-ad7f-7a6d",
+									Year: "2022",
+								},
+							},
+						},
+					],
+				},
+			};
+
+			if (!asRelation) {
+				return pub;
+			}
+
+			return {
+				value: null,
+				alsoAsChild: true,
+				pub,
+			};
+		}) as any;
+
 	return seedCommunity(
 		{
 			community: {
@@ -548,6 +676,7 @@ export const seedArcadia = (communityId?: CommunitiesId) => {
 																	},
 																},
 															},
+															...articleSeed(1_000, true),
 														],
 													},
 												},
@@ -564,6 +693,7 @@ export const seedArcadia = (communityId?: CommunitiesId) => {
 		},
 		{
 			randomSlug: false,
+			parallelPubs: true,
 		}
 	);
 };

--- a/core/prisma/seed.ts
+++ b/core/prisma/seed.ts
@@ -75,10 +75,16 @@ async function main() {
 	});
 	await workerUtils.migrate();
 
+	// do not seed arcadia if the minimal seed flag is set
+	// this is because it will slow down ci/testing
+	// this flag is set in the `globalSetup.ts` file
+	// eslint-disable-next-line no-restricted-properties
+	const arcadiaPromise = process.env.MINIMAL_SEED ? null : seedArcadia(arcadiaId);
+
 	await Promise.all([
 		buildUnjournal(prisma, unJournalId),
 		seedCroccroc(croccrocId),
-		seedArcadia(arcadiaId),
+		arcadiaPromise,
 	]);
 
 	try {

--- a/core/prisma/seed.ts
+++ b/core/prisma/seed.ts
@@ -75,7 +75,6 @@ async function main() {
 	});
 	await workerUtils.migrate();
 
-	logger.info("build unjournal");
 	await Promise.all([
 		buildUnjournal(prisma, unJournalId),
 		seedCroccroc(croccrocId),
@@ -124,6 +123,8 @@ async function main() {
 main()
 	.then(async () => {
 		await prisma.$disconnect();
+		logger.info("Finished seeding, exiting...");
+		process.exit(0);
 	})
 	.catch(async (e) => {
 		if (!isUniqueConstraintError(e)) {


### PR DESCRIPTION
- **dev: huge seed for arcadia**
- **dev: prevent aracadia seed from running during testing**

## Issue(s) Resolved

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->
This adds 1000 pubs almost identical pubs to the Arcadia community. Each of these pubs is related to an issue, and has a lot of related pubs itself as well.

This gives us an idea of how pages will perform as the number of pubs scales (spoiler: pretty poorly).

The only change to the seed code is to parallelize the creation of pubs. I don't think it's really important in this case, as it would only affect "top level" pubs specified in the seed, but I added it because i ran into problems in different setups. Previously, I had the top level pubs be created in series st you could reference related pubs by their ID. So, if you set `parallelPubs: true` in the seed function, you should not manually specify IDs for pubs.

This can be improved by separating out the creation of related pubs from the creation of the top-level pubs, but that would take more time to do.

## Test Plan
1. Run seed script.
2. Go to eg Pubs page.
3. Weep. It's not toooooo bad for the current function, however if I replace `getPubs` in `PubList` with `getPubsWithRelationsAndChildren`, it takes like 40 seconds!!!! to finish the query if limited to 200 pubs. I don't even think it finshes for the current limit of `1000`.

## Screenshots (if applicable)

## Notes
