### PR TITLE
feat: add relation manipulation to api, and update get routes to return relations as well

### DIFF
--- a/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
+++ b/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
@@ -13,6 +13,7 @@ import { getStage } from "~/lib/db/queries";
 import {
 	createPubRecursiveNew,
 	deletePub,
+	doesPubExist,
 	getPubCached,
 	getPubs,
 	getPubsWithRelatedValuesAndChildren,
@@ -164,6 +165,16 @@ const handler = createNextHandler(
 					ApiAccessScope.pub,
 					ApiAccessType.write
 				);
+
+				const { exists } = await doesPubExist(
+					params.pubId as PubsId,
+					community.id as CommunitiesId
+				);
+
+				if (!exists) {
+					throw new NotFoundError(`Pub ${params.pubId} not found`);
+				}
+
 				const updatedPub = await updatePub({
 					pubValues: body,
 					pubId: params.pubId as PubsId,
@@ -202,6 +213,15 @@ const handler = createNextHandler(
 						ApiAccessScope.pub,
 						ApiAccessType.write
 					);
+
+					const { exists } = await doesPubExist(
+						params.pubId as PubsId,
+						community.id as CommunitiesId
+					);
+
+					if (!exists) {
+						throw new NotFoundError(`Pub ${params.pubId} not found`);
+					}
 
 					const { all, some } = Object.entries(body).reduce(
 						(acc, [fieldSlug, pubIds]) => {
@@ -263,6 +283,15 @@ const handler = createNextHandler(
 						ApiAccessType.write
 					);
 
+					const { exists } = await doesPubExist(
+						params.pubId as PubsId,
+						community.id as CommunitiesId
+					);
+
+					if (!exists) {
+						throw new NotFoundError(`Pub ${params.pubId} not found`);
+					}
+
 					const relations = Object.entries(body).flatMap(([slug, data]) =>
 						data.map((idOrPubInitPayload) => ({ slug, ...idOrPubInitPayload }))
 					);
@@ -292,6 +321,14 @@ const handler = createNextHandler(
 						ApiAccessType.write
 					);
 
+					const { exists } = await doesPubExist(
+						params.pubId as PubsId,
+						community.id as CommunitiesId
+					);
+
+					if (!exists) {
+						throw new NotFoundError(`Pub ${params.pubId} not found`);
+					}
 					const relations = Object.entries(body).flatMap(([slug, data]) =>
 						data.map((idOrPubInitPayload) => ({ slug, ...idOrPubInitPayload }))
 					);

--- a/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
+++ b/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
@@ -179,7 +179,15 @@ const handler = createNextHandler(
 			},
 			archive: async ({ params }) => {
 				await checkAuthorization(ApiAccessScope.pub, ApiAccessType.write);
-				await deletePub(params.pubId as PubsId);
+				const result = await deletePub(params.pubId as PubsId).executeTakeFirst();
+
+				if (result?.numDeletedRows !== BigInt(1)) {
+					return {
+						status: 404,
+						body: "Pub not found",
+					};
+				}
+
 				return {
 					status: 200,
 					body: null,

--- a/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
+++ b/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
@@ -184,6 +184,7 @@ const handler = createNextHandler(
 
 				const pub = await getPubsWithRelatedValuesAndChildren({
 					pubId: params.pubId as PubsId,
+					communityId: community.id,
 				});
 
 				return {
@@ -272,9 +273,14 @@ const handler = createNextHandler(
 						};
 					}
 
+					const pub = await getPubsWithRelatedValuesAndChildren({
+						pubId: params.pubId as PubsId,
+						communityId: community.id,
+					});
+
 					return {
 						status: 200,
-						body: null,
+						body: pub,
 					};
 				},
 				update: async ({ params, body }) => {
@@ -296,24 +302,21 @@ const handler = createNextHandler(
 						data.map((idOrPubInitPayload) => ({ slug, ...idOrPubInitPayload }))
 					);
 
-					try {
-						await upsertPubRelations({
-							pubId: params.pubId as PubsId,
-							relations,
-							communityId: community.id,
-						});
+					await upsertPubRelations({
+						pubId: params.pubId as PubsId,
+						relations,
+						communityId: community.id,
+					});
 
-						return {
-							status: 200,
-							body: null,
-						};
-					} catch (e) {
-						console.error(e);
-						return {
-							status: 400,
-							body: e.message,
-						};
-					}
+					const pub = await getPubsWithRelatedValuesAndChildren({
+						pubId: params.pubId as PubsId,
+						communityId: community.id,
+					});
+
+					return {
+						status: 200,
+						body: pub,
+					};
 				},
 				replace: async ({ params, body }) => {
 					const { community } = await checkAuthorization(
@@ -333,15 +336,20 @@ const handler = createNextHandler(
 						data.map((idOrPubInitPayload) => ({ slug, ...idOrPubInitPayload }))
 					);
 
-					const updatedPub = await replacePubRelationsBySlug({
+					await replacePubRelationsBySlug({
 						pubId: params.pubId as PubsId,
 						relations,
 						communityId: community.id,
 					});
 
+					const pub = await getPubsWithRelatedValuesAndChildren({
+						pubId: params.pubId as PubsId,
+						communityId: community.id,
+					});
+
 					return {
 						status: 200,
-						body: updatedPub,
+						body: pub,
 					};
 				},
 			},

--- a/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
+++ b/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import type { PubWithChildren } from "contracts";
 import type { CommunitiesId, PubsId, PubTypesId, StagesId } from "db/public";
 import type { ApiAccessPermission, ApiAccessPermissionConstraintsInput } from "db/types";
-import { api } from "contracts";
+import { siteApi } from "contracts";
 import { ApiAccessScope, ApiAccessType } from "db/public";
 
 import { db } from "~/kysely/database";
@@ -104,7 +104,7 @@ const checkAuthorization = async <T extends ApiAccessScope, AT extends ApiAccess
 };
 
 const handler = createNextHandler(
-	api.site,
+	siteApi,
 	{
 		pubs: {
 			get: async (req, res) => {
@@ -113,7 +113,6 @@ const handler = createNextHandler(
 
 				const pub = await getPubCached(pubId as PubsId);
 
-				res.responseHeaders.set("Access-Control-Allow-Origin", "*");
 				return {
 					status: 200,
 					body: pub,
@@ -268,7 +267,6 @@ const handler = createNextHandler(
 						data.map((idOrPubInitPayload) => ({ slug, ...idOrPubInitPayload }))
 					);
 
-					console.log("AAA", relations, community);
 					try {
 						await upsertPubRelations({
 							pubId: params.pubId as PubsId,
@@ -297,7 +295,6 @@ const handler = createNextHandler(
 					const relations = Object.entries(body).flatMap(([slug, data]) =>
 						data.map((idOrPubInitPayload) => ({ slug, ...idOrPubInitPayload }))
 					);
-					console.log("AAA", relations, community);
 
 					const updatedPub = await replacePubRelationsBySlug({
 						pubId: params.pubId as PubsId,

--- a/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
+++ b/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
@@ -117,16 +117,19 @@ const handler = createNextHandler(
 	siteApi,
 	{
 		pubs: {
-			get: async ({ params }) => {
+			get: async ({ params, query }) => {
 				const { community } = await checkAuthorization(
 					ApiAccessScope.pub,
 					ApiAccessType.read
 				);
 
-				const pub = await getPubsWithRelatedValuesAndChildren({
-					pubId: params.pubId as PubsId,
-					communityId: community.id,
-				});
+				const pub = await getPubsWithRelatedValuesAndChildren(
+					{
+						pubId: params.pubId as PubsId,
+						communityId: community.id,
+					},
+					query
+				);
 
 				return {
 					status: 200,
@@ -139,10 +142,16 @@ const handler = createNextHandler(
 					ApiAccessType.read
 				);
 
-				const pubs = await getPubsWithRelatedValuesAndChildren({
-					communityId: community.id,
-					...query,
-				});
+				const { pubTypeId, stageId, ...rest } = query;
+
+				const pubs = await getPubsWithRelatedValuesAndChildren(
+					{
+						communityId: community.id,
+						pubTypeId,
+						stageId,
+					},
+					rest
+				);
 
 				return {
 					status: 200,

--- a/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
+++ b/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
@@ -104,6 +104,15 @@ const checkAuthorization = async <T extends ApiAccessScope, AT extends ApiAccess
 	return { authorization: constraints as Exclude<typeof constraints, false>, community };
 };
 
+const shouldReturnRepresentation = () => {
+	const prefer = headers().get("Prefer");
+
+	if (prefer === "return=representation") {
+		return true;
+	}
+	return false;
+};
+
 const handler = createNextHandler(
 	siteApi,
 	{
@@ -160,6 +169,14 @@ const handler = createNextHandler(
 					body,
 				});
 
+				const returnRepresentation = shouldReturnRepresentation();
+
+				if (!returnRepresentation) {
+					return {
+						status: 204,
+					};
+				}
+
 				return {
 					status: 201,
 					body: createdPub,
@@ -187,6 +204,14 @@ const handler = createNextHandler(
 					continueOnValidationError: false,
 				});
 
+				const returnRepresentation = shouldReturnRepresentation();
+
+				if (!returnRepresentation) {
+					return {
+						status: 204,
+					};
+				}
+
 				const pub = await getPubsWithRelatedValuesAndChildren({
 					pubId: params.pubId as PubsId,
 					communityId: community.id,
@@ -210,7 +235,6 @@ const handler = createNextHandler(
 
 				return {
 					status: 200,
-					body: null,
 				};
 			},
 			relations: {
@@ -278,6 +302,14 @@ const handler = createNextHandler(
 						};
 					}
 
+					const returnRepresentation = shouldReturnRepresentation();
+
+					if (!returnRepresentation) {
+						return {
+							status: 204,
+						};
+					}
+
 					const pub = await getPubsWithRelatedValuesAndChildren({
 						pubId: params.pubId as PubsId,
 						communityId: community.id,
@@ -313,6 +345,14 @@ const handler = createNextHandler(
 						communityId: community.id,
 					});
 
+					const returnRepresentation = shouldReturnRepresentation();
+
+					if (!returnRepresentation) {
+						return {
+							status: 204,
+						};
+					}
+
 					const pub = await getPubsWithRelatedValuesAndChildren({
 						pubId: params.pubId as PubsId,
 						communityId: community.id,
@@ -346,6 +386,14 @@ const handler = createNextHandler(
 						relations,
 						communityId: community.id,
 					});
+
+					const returnRepresentation = shouldReturnRepresentation();
+
+					if (!returnRepresentation) {
+						return {
+							status: 204,
+						};
+					}
 
 					const pub = await getPubsWithRelatedValuesAndChildren({
 						pubId: params.pubId as PubsId,

--- a/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
+++ b/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
@@ -108,15 +108,14 @@ const handler = createNextHandler(
 	siteApi,
 	{
 		pubs: {
-			get: async (req, res) => {
+			get: async ({ params }) => {
 				const { community } = await checkAuthorization(
 					ApiAccessScope.pub,
 					ApiAccessType.read
 				);
-				const { pubId } = req.params;
 
 				const pub = await getPubsWithRelatedValuesAndChildren({
-					pubId: pubId as PubsId,
+					pubId: params.pubId as PubsId,
 					communityId: community.id,
 				});
 
@@ -125,7 +124,7 @@ const handler = createNextHandler(
 					body: pub,
 				};
 			},
-			getMany: async (req, args) => {
+			getMany: async ({ query }) => {
 				const { community } = await checkAuthorization(
 					ApiAccessScope.pub,
 					ApiAccessType.read
@@ -133,7 +132,7 @@ const handler = createNextHandler(
 
 				const pubs = await getPubsWithRelatedValuesAndChildren({
 					communityId: community.id,
-					...req.query,
+					...query,
 				});
 
 				return {

--- a/core/lib/authorization/capabilities.ts
+++ b/core/lib/authorization/capabilities.ts
@@ -56,7 +56,7 @@ type CapabilitiesArg = {
 	[MembershipType.form]: typeof formCapabilities;
 };
 
-type Target = PubTarget | StageTarget;
+export type Target = PubTarget | StageTarget;
 
 type PubTarget = {
 	type: MembershipType.pub;

--- a/core/lib/server/apiAccessTokens.ts
+++ b/core/lib/server/apiAccessTokens.ts
@@ -8,6 +8,7 @@ import type {
 	NewApiAccessPermissions,
 	NewApiAccessTokens,
 } from "db/public";
+import { ApiAccessScope, ApiAccessType } from "db/public";
 import { logger } from "logger";
 
 import { db } from "~/kysely/database";
@@ -145,3 +146,13 @@ export const deleteApiAccessToken = ({ id }: { id: ApiAccessTokensId }) =>
 			.deleteFrom("api_access_logs")
 			.where("accessTokenId", "=", id)
 	);
+
+/**
+ * Simple flat list of all permissions
+ */
+export const allPermissions = Object.values(ApiAccessScope).flatMap((scope) =>
+	Object.values(ApiAccessType).map((accessType) => ({
+		scope,
+		accessType,
+	}))
+);

--- a/core/lib/server/errors.ts
+++ b/core/lib/server/errors.ts
@@ -109,6 +109,18 @@ export const tsRestHandleErrors = (error: unknown, req: TsRestRequest): TsRestRe
 		return handleDatabaseErrors(error, req);
 	}
 
+	if (error instanceof NotFoundError) {
+		return TsRestResponse.fromJson(
+			{
+				status: 404,
+				body: { message: error.message },
+			},
+			{
+				status: 404,
+			}
+		);
+	}
+
 	if (error instanceof TsRestHttpError) {
 		return TsRestResponse.fromJson(
 			{

--- a/core/lib/server/pub.db.test.ts
+++ b/core/lib/server/pub.db.test.ts
@@ -332,7 +332,7 @@ describe("getPubsWithRelatedValuesAndChildren", () => {
 		const { getPubsWithRelatedValuesAndChildren } = await import("./pub");
 		const rootPubId = pub.id;
 		const pubValues = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: rootPubId },
+			{ pubId: rootPubId, communityId: community.id },
 			{ depth: 10 }
 		);
 
@@ -448,7 +448,7 @@ describe("getPubsWithRelatedValuesAndChildren", () => {
 		const rootPubId = pub.id;
 		const { getPubsWithRelatedValuesAndChildren } = await import("./pub");
 		const pubWithRelatedValuesAndChildren = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: rootPubId },
+			{ pubId: rootPubId, communityId: community.id },
 			{ depth: 10, withPubType: true }
 		);
 
@@ -520,7 +520,7 @@ describe("getPubsWithRelatedValuesAndChildren", () => {
 		expect(pubWithRelatedValuesAndChildren.length).toBe(5);
 
 		const submissionPubs = await getPubsWithRelatedValuesAndChildren(
-			{ pubTypeId: pubTypes["Basic Pub"].id },
+			{ pubTypeId: pubTypes["Basic Pub"].id, communityId: community.id },
 			{ withPubType: true, depth: 10 }
 		);
 
@@ -637,11 +637,11 @@ describe("getPubsWithRelatedValuesAndChildren", () => {
 
 		const [withCycleIncluded, withCycleExcluded] = (await Promise.all([
 			getPubsWithRelatedValuesAndChildren(
-				{ pubId: newPubId },
+				{ pubId: newPubId, communityId: community.id },
 				{ depth: 10, _debugDontNest: true }
 			),
 			getPubsWithRelatedValuesAndChildren(
-				{ pubId: newPubId },
+				{ pubId: newPubId, communityId: community.id },
 				{ depth: 10, cycle: "exclude", _debugDontNest: true }
 			),
 		])) as unknown as [UnprocessedPub[], UnprocessedPub[]];
@@ -690,7 +690,7 @@ describe("getPubsWithRelatedValuesAndChildren", () => {
 
 		const { getPubsWithRelatedValuesAndChildren } = await import("./pub");
 		const pubWithRelatedValuesAndChildren = (await getPubsWithRelatedValuesAndChildren(
-			{ pubId: newPubId },
+			{ pubId: newPubId, communityId: community.id },
 			{ depth: 10, fieldSlugs: [pubFields.Title.slug, pubFields["Some relation"].slug] }
 		)) as unknown as UnprocessedPub[];
 
@@ -746,7 +746,7 @@ describe("getPubsWithRelatedValuesAndChildren", () => {
 
 		const { getPubsWithRelatedValuesAndChildren } = await import("./pub");
 		const pubWithRelatedValuesAndChildren = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: pub.id },
+			{ pubId: pub.id, communityId: community.id },
 			{ depth: 10, withChildren: false, withRelatedPubs: false }
 		);
 
@@ -775,7 +775,7 @@ describe("getPubsWithRelatedValuesAndChildren", () => {
 		const { getPubsWithRelatedValuesAndChildren } = await import("./pub");
 
 		const pub = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: pubs[0].id },
+			{ pubId: pubs[0].id, communityId: community.id },
 			{ withStage: true }
 		);
 
@@ -819,7 +819,7 @@ describe("upsertPubRelations", () => {
 		const { getPubsWithRelatedValuesAndChildren } = await import("./pub");
 
 		const updatedPub = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: pub.id },
+			{ pubId: pub.id, communityId: community.id },
 			{ depth: 10 }
 		);
 
@@ -871,7 +871,7 @@ describe("upsertPubRelations", () => {
 
 		const { getPubsWithRelatedValuesAndChildren } = await import("./pub");
 		const updatedPub = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: pub.id },
+			{ pubId: pub.id, communityId: community.id },
 			{ depth: 10 }
 		);
 
@@ -1032,7 +1032,7 @@ describe("upsertPubRelations", () => {
 
 		const { getPubsWithRelatedValuesAndChildren } = await import("./pub");
 		const updatedPub = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: pub.id },
+			{ pubId: pub.id, communityId: community.id },
 			{ depth: 10 }
 		);
 
@@ -1100,7 +1100,7 @@ describe("upsertPubRelations", () => {
 
 		const { getPubsWithRelatedValuesAndChildren } = await import("./pub");
 		const updatedPub = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: pub.id },
+			{ pubId: pub.id, communityId: community.id },
 			{ depth: 10 }
 		);
 
@@ -1167,7 +1167,7 @@ describe("removePubRelations", () => {
 
 		// check that the pub has 2 relations
 		const pubWithRelations = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: pub.id },
+			{ pubId: pub.id, communityId: community.id },
 			{ depth: 10 }
 		);
 
@@ -1189,7 +1189,7 @@ describe("removePubRelations", () => {
 		expect(removedRelatedPubIds).toEqual([pubs[0].id]);
 
 		const updatedPub = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: pub.id },
+			{ pubId: pub.id, communityId: community.id },
 			{ depth: 10 }
 		);
 
@@ -1233,7 +1233,7 @@ describe("removePubRelations", () => {
 
 		// Verify initial state has 2 relations
 		const pubWithRelations = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: pub.id },
+			{ pubId: pub.id, communityId: community.id },
 			{ depth: 10 }
 		);
 		expect(pubWithRelations.values.filter((v) => v.relatedPub)).toHaveLength(2);
@@ -1248,7 +1248,7 @@ describe("removePubRelations", () => {
 		expect(removedRelatedPubIds.sort()).toEqual([pubs[0].id, pubs[1].id].sort());
 
 		const updatedPub = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: pub.id },
+			{ pubId: pub.id, communityId: community.id },
 			{ depth: 10 }
 		);
 
@@ -1380,7 +1380,7 @@ describe("replacePubRelationsBySlug", () => {
 		});
 
 		const updatedPub = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: pub.id },
+			{ pubId: pub.id, communityId: community.id },
 			{ depth: 10 }
 		);
 
@@ -1419,7 +1419,7 @@ describe("replacePubRelationsBySlug", () => {
 		});
 
 		const updatedPub = await getPubsWithRelatedValuesAndChildren(
-			{ pubId: pub.id },
+			{ pubId: pub.id, communityId: community.id },
 			{ depth: 10 }
 		);
 

--- a/core/lib/server/pub.db.test.ts
+++ b/core/lib/server/pub.db.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import type { PubsId, PubTypes, Stages } from "db/public";
 import { CoreSchemaType } from "db/public";
 
-import type { ProcessedPub, UnprocessedPub } from "./pub";
+import type { UnprocessedPub } from "./pub";
 import { mockServerCode } from "~/lib/__tests__/utils";
 import { seedCommunity } from "~/prisma/seed/seedCommunity";
 
@@ -1364,18 +1364,18 @@ describe("replacePubRelationsBySlug", () => {
 		// Replace relations
 		await replacePubRelationsBySlug({
 			pubId: pub.id,
-			relations: {
-				[pubFields["Some relation"].slug]: [
-					{
-						relatedPubId: newRelatedPub1.id,
-						value: "new relation value 1",
-					},
-					{
-						relatedPubId: newRelatedPub2.id,
-						value: "new relation value 2",
-					},
-				],
-			},
+			relations: [
+				{
+					slug: pubFields["Some relation"].slug,
+					relatedPubId: newRelatedPub1.id,
+					value: "new relation value 1",
+				},
+				{
+					slug: pubFields["Some relation"].slug,
+					relatedPubId: newRelatedPub2.id,
+					value: "new relation value 2",
+				},
+			],
 			communityId: community.id,
 		});
 
@@ -1387,7 +1387,7 @@ describe("replacePubRelationsBySlug", () => {
 		const relationValues = updatedPub.values.filter((v) => v.relatedPub);
 
 		expect(relationValues).toHaveLength(2);
-		expect(relationValues.map((v) => v.relatedPub.id).sort()).toEqual(
+		expect(relationValues.map((v) => v.relatedPub?.id).sort()).toEqual(
 			[newRelatedPub1.id, newRelatedPub2.id].sort()
 		);
 		expect(relationValues.map((v) => v.value).sort()).toEqual(
@@ -1414,7 +1414,7 @@ describe("replacePubRelationsBySlug", () => {
 
 		await replacePubRelationsBySlug({
 			pubId: pub.id,
-			relations: {},
+			relations: [],
 			communityId: community.id,
 		});
 
@@ -1444,14 +1444,13 @@ describe("replacePubRelationsBySlug", () => {
 		await expect(
 			replacePubRelationsBySlug({
 				pubId: pub.id,
-				relations: {
-					"non-existent-field": [
-						{
-							relatedPubId: "some-id" as PubsId,
-							value: "some value",
-						},
-					],
-				},
+				relations: [
+					{
+						slug: "non-existent-field",
+						relatedPubId: "some-id" as PubsId,
+						value: "some value",
+					},
+				],
 				communityId: community.id,
 			})
 		).rejects.toThrow(

--- a/core/lib/server/pub.db.test.ts
+++ b/core/lib/server/pub.db.test.ts
@@ -194,8 +194,8 @@ describe("createPubRecursive", () => {
 		});
 
 		expect(pub).toMatchObject({
-			values: [{ value: "test title" }],
-			relatedPubs: [
+			values: [
+				{ value: "test title" },
 				{
 					value: "test relation value",
 					relatedPub: { values: [{ value: "test relation title" }] },

--- a/core/lib/server/pub.db.test.ts
+++ b/core/lib/server/pub.db.test.ts
@@ -773,7 +773,7 @@ describe("getPubsWithRelatedValuesAndChildren", () => {
 
 		expectTypeOf(pubWithRelatedValuesAndChildren.children).toEqualTypeOf<undefined>();
 
-		expect(pubWithRelatedValuesAndChildren.children).toEqual([]);
+		expect(pubWithRelatedValuesAndChildren.children).toEqual(undefined);
 		expect(pubWithRelatedValuesAndChildren).toMatchObject({
 			values: [
 				{ value: "test title" },

--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -535,10 +535,10 @@ export const createPubRecursiveNew = async <Body extends CreatePubRequestBodyWit
 	return result as MaybeWithChildren<Body>;
 };
 
-export const deletePub = async (pubId: PubsId) =>
+export const deletePub = (pubId: PubsId) =>
 	autoRevalidate(db.deleteFrom("pubs").where("id", "=", pubId));
 
-export const getPubStage = async (pubId: PubsId) =>
+export const getPubStage = (pubId: PubsId) =>
 	autoCache(db.selectFrom("PubsInStages").select("stageId").where("pubId", "=", pubId));
 
 /**

--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -1073,20 +1073,8 @@ type PubIdOrPubTypeIdOrStageIdOrCommunityId =
 	  }
 	| {
 			pubId?: never;
-			pubTypeId: PubTypesId;
-			stageId?: never;
-			communityId: CommunitiesId;
-	  }
-	| {
-			pubId?: never;
-			pubTypeId?: never;
-			stageId: StagesId;
-			communityId: CommunitiesId;
-	  }
-	| {
-			pubId?: never;
-			pubTypeId?: never;
-			stageId?: never;
+			pubTypeId?: PubTypesId;
+			stageId?: StagesId;
 			communityId: CommunitiesId;
 	  };
 

--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -1214,9 +1214,6 @@ export async function getPubsWithRelatedValuesAndChildren<
 								.leftJoin("pub_values", "pubs.id", "pub_values.pubId")
 								.innerJoin("pub_fields", "pub_fields.id", "pub_values.fieldId")
 								.leftJoin("PubsInStages", "pubs.id", "PubsInStages.pubId")
-								.$if(Boolean(fieldSlugs), (qb) =>
-									qb.where("pub_fields.slug", "in", fieldSlugs!)
-								)
 								.select([
 									"pubs.id as pubId",
 									"pub_fields.schemaName as schemaName",

--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -1053,19 +1053,19 @@ type PubIdOrPubTypeIdOrStageIdOrCommunityId =
 			pubId: PubsId;
 			pubTypeId?: never;
 			stageId?: never;
-			communityId?: never;
+			communityId: CommunitiesId;
 	  }
 	| {
 			pubId?: never;
 			pubTypeId: PubTypesId;
 			stageId?: never;
-			communityId?: never;
+			communityId: CommunitiesId;
 	  }
 	| {
 			pubId?: never;
 			pubTypeId?: never;
 			stageId: StagesId;
-			communityId?: never;
+			communityId: CommunitiesId;
 	  }
 	| {
 			pubId?: never;
@@ -1086,16 +1086,16 @@ const DEFAULT_OPTIONS = {
 export async function getPubsWithRelatedValuesAndChildren<
 	Options extends GetPubsWithRelatedValuesAndChildrenOptions,
 >(
-	props: {
-		pubId: PubsId;
-	},
+	props: Extract<PubIdOrPubTypeIdOrStageIdOrCommunityId, { pubId: PubsId }>,
 	options?: Options
+	// if only pubId + communityId is provided, we return a single pub
 ): Promise<ProcessedPub<Options>>;
 export async function getPubsWithRelatedValuesAndChildren<
 	Options extends GetPubsWithRelatedValuesAndChildrenOptions,
 >(
 	props: Exclude<PubIdOrPubTypeIdOrStageIdOrCommunityId, { pubId: PubsId }>,
 	options?: Options
+	// if any other props are provided, we return an array of pubs
 ): Promise<ProcessedPub<Options>[]>;
 /**
  * Retrieves a pub and all its related values, children, and related pubs up to a given depth.
@@ -1257,14 +1257,12 @@ export async function getPubsWithRelatedValuesAndChildren<
 				cte
 					.selectFrom("pubs")
 					.selectAll("pubs")
+					.where("pubs.communityId", "=", props.communityId)
 					.$if(Boolean(props.pubId), (qb) => qb.where("pubs.id", "=", props.pubId!))
 					.$if(Boolean(props.stageId), (qb) =>
 						qb
 							.innerJoin("PubsInStages", "pubs.id", "PubsInStages.pubId")
 							.where("PubsInStages.stageId", "=", props.stageId!)
-					)
-					.$if(Boolean(props.communityId), (qb) =>
-						qb.where("pubs.communityId", "=", props.communityId!)
 					)
 					.$if(Boolean(props.pubTypeId), (qb) =>
 						qb.where("pubs.pubTypeId", "=", props.pubTypeId!)

--- a/core/prisma/exampleCommunitySeeds/arcadia.ts
+++ b/core/prisma/exampleCommunitySeeds/arcadia.ts
@@ -564,6 +564,7 @@ export const seedArcadia = (communityId?: CommunitiesId) => {
 		},
 		{
 			randomSlug: false,
+			withApiToken: "xxxxxxxxxxxxxxxx.00000000-0000-0000-0000-000000000000",
 		}
 	);
 };

--- a/core/prisma/seed/seedCommunity.db.test.ts
+++ b/core/prisma/seed/seedCommunity.db.test.ts
@@ -243,17 +243,12 @@ describe("seedCommunity", () => {
 						relatedPubId: authorPubId,
 						value: 0,
 					},
-				],
-				valuesBlob: null,
-				stageId: seededCommunity.stages["Stage 1"].id,
-				relatedPubs: [
 					{
 						value: 1,
 						relatedPub: {
 							pubTypeId: seededCommunity.pubTypes["Author"].id,
 						},
 					},
-
 					{
 						value: 2,
 						relatedPub: {
@@ -263,6 +258,8 @@ describe("seedCommunity", () => {
 						},
 					},
 				],
+				valuesBlob: null,
+				stageId: seededCommunity.stages["Stage 1"].id,
 			},
 			{ id: author2PubId },
 		]);

--- a/core/prisma/seed/seedCommunity.ts
+++ b/core/prisma/seed/seedCommunity.ts
@@ -11,6 +11,7 @@ import { jsonArrayFrom } from "kysely/helpers/postgres";
 import type { ProcessedPub } from "contracts";
 import type {
 	ActionInstancesId,
+	ApiAccessTokensId,
 	Communities,
 	CommunitiesId,
 	CommunityMembershipsId,
@@ -29,6 +30,8 @@ import type {
 } from "db/public";
 import {
 	Action as ActionName,
+	ApiAccessScope,
+	ApiAccessType,
 	CoreSchemaType,
 	ElementType,
 	InputComponent,
@@ -42,6 +45,7 @@ import type { actions } from "~/actions/api";
 import { db } from "~/kysely/database";
 import { createPasswordHash } from "~/lib/authentication/password";
 import { createPubRecursiveNew } from "~/lib/server";
+import { allPermissions, createApiAccessToken } from "~/lib/server/apiAccessTokens";
 import { slugifyString } from "~/lib/string";
 
 export type PubFieldsInitializer = Record<
@@ -452,6 +456,7 @@ export async function seedCommunity<
 	const SC extends StageConnectionsInitializer<S>,
 	const PI extends PubInitializer<PF, PT, U, S>[],
 	const F extends FormInitializer<PF, PT, U, S>,
+	WithApiToken extends boolean | `${string}.${string}` | undefined = undefined,
 >(
 	props: {
 		/**
@@ -667,6 +672,12 @@ export async function seedCommunity<
 		forms?: F;
 	},
 	options?: {
+		/**
+		 * Whether or not to create an API token for the community.
+		 * If a string is provided, it will be used as the id part of the token.
+		 * @default false
+		 */
+		withApiToken?: WithApiToken;
 		/**
 		 * Whether or not to add a random number to the end of slugs, helps prevent errors during testing.
 		 * @default true
@@ -1046,6 +1057,42 @@ export async function seedCommunity<
 		? await trx.insertInto("action_instances").values(possibleActions).returningAll().execute()
 		: [];
 
+	let apiToken: string | undefined = undefined;
+
+	if (options?.withApiToken) {
+		const [tokenId, tokenString] =
+			typeof options.withApiToken === "string"
+				? options.withApiToken.split(".")
+				: [crypto.randomUUID(), undefined];
+
+		const issuedById = createdMembers.find(
+			(member) => member.role === MemberRole.admin
+		)?.userId;
+
+		if (!issuedById) {
+			throw new Error(
+				"Attempting to create an API token without an admin member. You should create an admin member in the seed if you intend to be able to use the API."
+			);
+		}
+
+		const { token } = await createApiAccessToken({
+			token: {
+				name: "seed token",
+				communityId,
+				expiration: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30 * 12),
+				description: "Default seed token. Should not be used in production.",
+				issuedAt: new Date(),
+				id: tokenId as ApiAccessTokensId,
+				issuedById,
+				// @ts-expect-error - this is a predefined token
+				token: tokenString,
+			},
+			permissions: allPermissions,
+		}).executeTakeFirstOrThrow();
+
+		apiToken = token;
+	}
+
 	return {
 		community: createdCommunity,
 		pubFields: pubFieldsByName,
@@ -1057,6 +1104,11 @@ export async function seedCommunity<
 		pubs: createdPubs,
 		actions: createdActions,
 		forms: formsByName,
+		apiToken: apiToken as WithApiToken extends string
+			? `${string}.${WithApiToken}`
+			: WithApiToken extends boolean
+				? string
+				: undefined,
 	};
 }
 

--- a/core/prisma/seed/seedCommunity.ts
+++ b/core/prisma/seed/seedCommunity.ts
@@ -8,6 +8,7 @@ import type {
 import { faker } from "@faker-js/faker";
 import { jsonArrayFrom } from "kysely/helpers/postgres";
 
+import type { ProcessedPub } from "contracts";
 import type {
 	ActionInstancesId,
 	Communities,
@@ -956,7 +957,7 @@ export async function seedCommunity<
 			})
 		: [];
 
-	const createdPubs: Awaited<ReturnType<typeof createPubRecursiveNew>>[] = [];
+	const createdPubs: ProcessedPub[] = [];
 	// we do this one at a time because we allow pubs to be able to reference each other in the relatedPubs field
 	for (const input of createPubRecursiveInput) {
 		const pub = await createPubRecursiveNew(input);

--- a/packages/contracts/src/resources/site.ts
+++ b/packages/contracts/src/resources/site.ts
@@ -120,7 +120,7 @@ export const siteApi = contract.router(
 				body: z.never(),
 				path: "/pubs/:pubId",
 				responses: {
-					200: pubWithChildrenSchema,
+					200: z.null(),
 				},
 			},
 			relations: {

--- a/packages/contracts/src/resources/site.ts
+++ b/packages/contracts/src/resources/site.ts
@@ -279,6 +279,9 @@ export const siteApi = contract.router(
 			},
 			relations: {
 				update: {
+					summary: "Update pub relation fields",
+					description:
+						"Updates pub relations for the specified slugs. Only adds or modifies specified relations, leaves existing relations alone. If you want to replace all relations for a field, use PUT.",
 					method: "PATCH",
 					path: "/pubs/:pubId/relations",
 					body: upsertPubRelationsSchema,
@@ -287,6 +290,9 @@ export const siteApi = contract.router(
 					},
 				},
 				replace: {
+					summary: "Replace pub relation fields",
+					description:
+						"Replaces all pub relations for the specified slugs. If you want to add or modify relations without overwriting existing ones, use PATCH.",
 					method: "PUT",
 					path: "/pubs/:pubId/relations",
 					body: upsertPubRelationsSchema,
@@ -295,9 +301,10 @@ export const siteApi = contract.router(
 					},
 				},
 				remove: {
-					method: "DELETE",
+					summary: "Remove pub relation fields",
 					description:
-						"Removes pub relations by slug. Provide a dictionary with field slugs as keys and arrays of pubIds to remove as values. Use '*' to remove all relations for a given field slug.",
+						"Removes related pubs from the specified pubfields. Provide a dictionary with field slugs as keys and arrays of pubIds to remove as values. Use '*' to remove all relations for a given field slug.\n Note: This endpoint does not remove the related pubs themselves, only the relations.",
+					method: "DELETE",
 					path: "/pubs/:pubId/relations",
 					body: z.record(z.union([z.literal("*"), z.array(pubsIdSchema)])),
 					responses: {

--- a/packages/contracts/src/resources/site.ts
+++ b/packages/contracts/src/resources/site.ts
@@ -117,10 +117,11 @@ export const siteApi = contract.router(
 			},
 			archive: {
 				method: "DELETE",
-				body: z.never(),
+				body: z.never().nullish(),
 				path: "/pubs/:pubId",
 				responses: {
 					200: z.null(),
+					404: z.literal("Pub not found"),
 				},
 			},
 			relations: {

--- a/packages/contracts/src/resources/site.ts
+++ b/packages/contracts/src/resources/site.ts
@@ -54,6 +54,18 @@ const pubWithChildrenSchema: z.ZodType<PubWithChildren> = pubsSchema.and(
 	})
 );
 
+const upsertPubRelationsSchema = z.record(
+	z.array(
+		z.union([
+			z.object({
+				value: jsonSchema,
+				pub: CreatePubRequestBodyWithNullsNew,
+			}),
+			z.object({ value: jsonSchema, pubId: pubsIdSchema }),
+		])
+	)
+);
+
 export const siteApi = contract.router(
 	{
 		pubs: {
@@ -93,6 +105,50 @@ export const siteApi = contract.router(
 				body: CreatePubRequestBodyWithNullsNew,
 				responses: {
 					201: pubWithChildrenSchema,
+				},
+			},
+			update: {
+				method: "PATCH",
+				path: "/pubs/:pubId",
+				body: z.record(jsonSchema),
+				responses: {
+					200: pubWithChildrenSchema,
+				},
+			},
+			archive: {
+				method: "DELETE",
+				body: z.never(),
+				path: "/pubs/:pubId",
+				responses: {
+					200: pubWithChildrenSchema,
+				},
+			},
+			relations: {
+				update: {
+					method: "PATCH",
+					path: "/pubs/:pubId/relations",
+					body: upsertPubRelationsSchema,
+					responses: {
+						200: pubWithChildrenSchema,
+					},
+				},
+				replace: {
+					method: "PUT",
+					path: "/pubs/:pubId/relations",
+					body: upsertPubRelationsSchema,
+					responses: {
+						200: pubWithChildrenSchema,
+					},
+				},
+				remove: {
+					method: "DELETE",
+					description:
+						"Removes pub relations by slug. Provide a dictionary with field slugs as keys and arrays of pubIds to remove as values. Use '*' to remove all relations for a given field slug.",
+					path: "/pubs/:pubId/relations",
+					body: z.record(z.union([z.literal("*"), z.array(pubsIdSchema)])),
+					responses: {
+						200: pubWithChildrenSchema,
+					},
 				},
 			},
 		},

--- a/packages/contracts/src/resources/site.ts
+++ b/packages/contracts/src/resources/site.ts
@@ -229,18 +229,33 @@ const preferRepresentationHeaderSchema = z.object({
 		.default("return=minimal"),
 });
 
-const getPubQuerySchema = z.object({
-	depth: z
-		.number()
-		.default(2)
-		.describe(
-			"The depth to which to fetch children and related pubs. Defaults to 2, which means to fetch the top level pub and its children."
-		),
-	withChildren: z.boolean().default(true).describe("Whether to fetch children."),
-	withRelatedPubs: z.boolean().default(true).describe("Whether to fetch related pubs."),
-	withPubType: z.boolean().default(false).describe("Whether to fetch the pub type."),
-	withStage: z.boolean().default(false).describe("Whether to fetch the stage."),
-});
+const getPubQuerySchema = z
+	.object({
+		depth: z
+			.number()
+			.int()
+			.positive()
+			.default(2)
+			.describe(
+				"The depth to which to fetch children and related pubs. Defaults to 2, which means to fetch the top level pub and its children."
+			),
+		withChildren: z.boolean().default(false).describe("Whether to fetch children."),
+		withRelatedPubs: z
+			.boolean()
+			.default(false)
+			.describe("Whether to include related pubs with the values"),
+		withPubType: z.boolean().default(false).describe("Whether to fetch the pub type."),
+		withStage: z.boolean().default(false).describe("Whether to fetch the stage."),
+		fieldSlugs: z
+			.array(z.string())
+			// this is necessary bc the query parser doesn't handle single string values as arrays
+			.or(z.string().transform((slug) => [slug]))
+			.optional()
+			.describe(
+				"Which field values to include in the response. Useful if you have very large pubs or want to save on bandwidth."
+			),
+	})
+	.passthrough();
 
 export const siteApi = contract.router(
 	{

--- a/packages/contracts/src/resources/site.ts
+++ b/packages/contracts/src/resources/site.ts
@@ -219,6 +219,16 @@ const processedPubSchema: z.ZodType<NonGenericProcessedPub> = z.object({
 	children: z.lazy(() => z.array(processedPubSchema)).optional(),
 });
 
+const preferRepresentationHeaderSchema = z.object({
+	Prefer: z
+		.enum(["return=representation", "return=minimal"])
+		.describe(
+			"Whether to return the full representation of the updated resource. Defaults to `return=representation`, which will return the updated resource. If you want to avoid returning the updated resource, set this to `return=minimal`. This saves bandwidth, and is usually slightly faster."
+		)
+		.optional()
+		.default("return=minimal"),
+});
+
 export const siteApi = contract.router(
 	{
 		pubs: {
@@ -252,28 +262,37 @@ export const siteApi = contract.router(
 				},
 			},
 			create: {
+				summary: "Creates a pub",
+				description: "Creates a pub.",
 				method: "POST",
 				path: "/pubs",
-				summary: "Creates a pub",
+				headers: preferRepresentationHeaderSchema,
 				body: CreatePubRequestBodyWithNullsNew,
 				responses: {
 					201: processedPubSchema,
+					204: z.never().optional(),
 				},
 			},
 			update: {
+				summary: "Updates a pub",
+				description: "Updates a pubs values.",
 				method: "PATCH",
 				path: "/pubs/:pubId",
+				headers: preferRepresentationHeaderSchema,
 				body: z.record(jsonSchema),
 				responses: {
 					200: processedPubSchema,
+					204: z.never().optional(),
 				},
 			},
 			archive: {
+				summary: "Archives a pub",
+				description: "Archives a pub by ID.",
 				method: "DELETE",
 				body: z.never().nullish(),
 				path: "/pubs/:pubId",
 				responses: {
-					200: z.null(),
+					204: z.never().optional(),
 					404: z.literal("Pub not found"),
 				},
 			},
@@ -284,9 +303,11 @@ export const siteApi = contract.router(
 						"Updates pub relations for the specified slugs. Only adds or modifies specified relations, leaves existing relations alone. If you want to replace all relations for a field, use PUT.",
 					method: "PATCH",
 					path: "/pubs/:pubId/relations",
+					headers: preferRepresentationHeaderSchema,
 					body: upsertPubRelationsSchema,
 					responses: {
 						200: processedPubSchema,
+						204: z.never().optional(),
 					},
 				},
 				replace: {
@@ -295,9 +316,11 @@ export const siteApi = contract.router(
 						"Replaces all pub relations for the specified slugs. If you want to add or modify relations without overwriting existing ones, use PATCH.",
 					method: "PUT",
 					path: "/pubs/:pubId/relations",
+					headers: preferRepresentationHeaderSchema,
 					body: upsertPubRelationsSchema,
 					responses: {
 						200: processedPubSchema,
+						204: z.never().optional(),
 					},
 				},
 				remove: {
@@ -306,9 +329,11 @@ export const siteApi = contract.router(
 						"Removes related pubs from the specified pubfields. Provide a dictionary with field slugs as keys and arrays of pubIds to remove as values. Use '*' to remove all relations for a given field slug.\n Note: This endpoint does not remove the related pubs themselves, only the relations.",
 					method: "DELETE",
 					path: "/pubs/:pubId/relations",
+					headers: preferRepresentationHeaderSchema,
 					body: z.record(z.union([z.literal("*"), z.array(pubsIdSchema)])),
 					responses: {
 						200: processedPubSchema,
+						204: z.never().optional(),
 					},
 				},
 			},

--- a/packages/contracts/src/resources/site.ts
+++ b/packages/contracts/src/resources/site.ts
@@ -229,6 +229,19 @@ const preferRepresentationHeaderSchema = z.object({
 		.default("return=minimal"),
 });
 
+const getPubQuerySchema = z.object({
+	depth: z
+		.number()
+		.default(2)
+		.describe(
+			"The depth to which to fetch children and related pubs. Defaults to 2, which means to fetch the top level pub and its children."
+		),
+	withChildren: z.boolean().default(true).describe("Whether to fetch children."),
+	withRelatedPubs: z.boolean().default(true).describe("Whether to fetch related pubs."),
+	withPubType: z.boolean().default(false).describe("Whether to fetch the pub type."),
+	withStage: z.boolean().default(false).describe("Whether to fetch the stage."),
+});
+
 export const siteApi = contract.router(
 	{
 		pubs: {
@@ -241,6 +254,7 @@ export const siteApi = contract.router(
 				pathParams: z.object({
 					pubId: z.string().uuid(),
 				}),
+				query: getPubQuerySchema,
 				responses: {
 					200: processedPubSchema,
 				},
@@ -251,7 +265,9 @@ export const siteApi = contract.router(
 				summary: "Gets a list of pubs",
 				description:
 					"Get a list of pubs by ID. This endpoint is used by the PubPub site builder to get a list of pubs.",
-				query: z.object({
+				query: getPubQuerySchema.extend({
+					pubTypeId: pubTypesIdSchema.optional().describe("Filter by pub type ID."),
+					stageId: stagesIdSchema.optional().describe("Filter by stage ID."),
 					limit: z.number().default(10).optional(),
 					offset: z.number().default(0).optional(),
 					orderBy: z.enum(["createdAt", "updatedAt"]).optional(),

--- a/packages/contracts/src/resources/site.ts
+++ b/packages/contracts/src/resources/site.ts
@@ -435,7 +435,10 @@ export const siteApi = contract.router(
 	{
 		pathPrefix: "/api/v0/c/:communitySlug/site",
 		baseHeaders: z.object({
-			authorization: z.string().regex(/^Bearer /),
+			authorization: z
+				.string()
+				.regex(/^Bearer /)
+				.optional(),
 		}),
 	}
 );

--- a/packages/contracts/src/resources/site.ts
+++ b/packages/contracts/src/resources/site.ts
@@ -183,7 +183,7 @@ export type ProcessedPub<Options extends MaybePubOptions = {}> = ProcessedPubBas
 	MaybePubStage<Options> &
 	MaybePubPubType<Options>;
 
-interface NonGenericProcessedPub extends ProcessedPubBase {
+export interface NonGenericProcessedPub extends ProcessedPubBase {
 	stage?: Stages;
 	pubType?: PubTypes;
 	children?: NonGenericProcessedPub[];

--- a/packages/contracts/src/resources/site.ts
+++ b/packages/contracts/src/resources/site.ts
@@ -283,7 +283,7 @@ export const siteApi = contract.router(
 				query: getPubQuerySchema.extend({
 					pubTypeId: pubTypesIdSchema.optional().describe("Filter by pub type ID."),
 					stageId: stagesIdSchema.optional().describe("Filter by stage ID."),
-					limit: z.number().default(10).optional(),
+					limit: z.number().default(10),
 					offset: z.number().default(0).optional(),
 					orderBy: z.enum(["createdAt", "updatedAt"]).optional(),
 					orderDirection: z.enum(["asc", "desc"]).optional(),
@@ -390,7 +390,7 @@ export const siteApi = contract.router(
 				description:
 					"Get a list of pub types by ID. This endpoint is used by the PubPub site builder to get a list of pub types.",
 				query: z.object({
-					limit: z.number().default(10).optional(),
+					limit: z.number().default(10),
 					offset: z.number().default(0).optional(),
 					orderBy: z.enum(["createdAt", "updatedAt"]).optional(),
 					orderDirection: z.enum(["asc", "desc"]).optional(),
@@ -421,7 +421,7 @@ export const siteApi = contract.router(
 				description:
 					"Get a list of stages by ID. This endpoint is used by the PubPub site builder to get a list of stages.",
 				query: z.object({
-					limit: z.number().default(10).optional(),
+					limit: z.number().default(10),
 					offset: z.number().default(0).optional(),
 					orderBy: z.enum(["createdAt", "updatedAt"]).optional(),
 					orderDirection: z.enum(["asc", "desc"]).optional(),

--- a/packages/contracts/src/resources/site.ts
+++ b/packages/contracts/src/resources/site.ts
@@ -59,9 +59,9 @@ const upsertPubRelationsSchema = z.record(
 		z.union([
 			z.object({
 				value: jsonSchema,
-				pub: CreatePubRequestBodyWithNullsNew,
+				relatedPub: CreatePubRequestBodyWithNullsNew,
 			}),
-			z.object({ value: jsonSchema, pubId: pubsIdSchema }),
+			z.object({ value: jsonSchema, relatedPubId: pubsIdSchema }),
 		])
 	)
 );


### PR DESCRIPTION
- **feat: add rough sketch for new pub api routes**
- **feat: add basic way to update and delete pub**
- **fix: refine updating and removing slightly such that they work**
- **feat: make upsert relation work sort of**
- **chore: small cleanup**
- **fix: move processedpubtype to contracts, replace output schema with processedpubschema for all pub operations**
- **refactor: do not make update functions check for pub existence, move resp to caller**
- **refactor: make communityId mandatory for getPubsWithRelatedValuesAndChildren**
- **fix: return full pub from relation routes**
- **chore: add descriptions to existing relation endpoints**
- **refactor: change the output type of createPubRecursiveNew to be ProcessedPub, to match what is returned by getPubWithChildren etc**
- **chore: clean up some function args**
- **feat: add prefer header**
- **feat: make it possible to filter pubs by stage and pubtype, and add correct query parameters to get pub endpoints**
- **fix: make withChildren work properly**
- **feat: allow generation of custom api access token for easier testing**
- **feat: allow api to filter response of top level pubs to certain fieldslugs**

## Issue(s) Resolved
Resolves #738. I discussed this with @allisonking, as she probably did not have enough time to get to it this sprint, and it would be a small thing to add for me.
Resolves #739 

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->

> [!NOTE] Open qs
> - [ ] Should we return all children and relations by default? It does so currently, but that can get quite hairy, especially bc they cannot be paginated yet.

This PR adds endpoints for 
- `updatePub` at `PATCH /pubs/<pubId>`
- `removePub` at `DELETE /pubs/<pubId>`
- `upsertPubRelations` at `PATCH /pubs/<pubId>/relations`
- `replacePubRelations` at `PUT /pubs/<pubId>/relations`
- `removePubRelations` and `removeAllPubRelationsBySlugs` at `DELETE /pubs/<pubId>/relations`

It also updates the old `GET /pubs` and `GET /pubs/<pubId>` endpoints to use the new `getPubsWithchildrenAndRelations` function, and to accept more query parameters.

Additionally, it:
- Adds support for the `Prefer` header on update endpoints. Setting `Prefer: return=minimal` will not return anything for `PUT/PATCH/POST` routes. This makes the request somewhat faster and saves bandwith. (i just learned about this and thought it would be neat to implement, can be removed)

I also fixed/changed some things for `getPubsWithRelationsAndChildren`:
- `withChildren` and `withRelatedPubs` now work properly (they were inversed, ie `withRelatedPubs: false` would disable fetching of children, and vice versa)
- filtering by fieldSlugs only applies to the top level pub now. I think this is more realistic behavior. We should probably implement more sophisticated filtering at some point, maybe look at how eg [Strapi handles that](https://docs.strapi.io/dev-docs/api/rest/populate-select#population)
- You can now filter by both stage _and_ pubType, previously it would only be one or the other
- You now _have_ to provide a communityId. this does mean you cannot look at other communities' pubs anymore, but I think this is largely intended behavior. We should revisit this once we want cross-community communication. 

Misc:
- I added a way to generate api access tokens to the seed script. This makes it easier to test out the api locally, as you don't have to generate a token yourself every single time.
- I changed the output of `createPubRecursiveNew` to match `getPubsWithChildrenAndRelatedPubs`.

> [!WARNING] Breaking changes
> The `get` endpoints now return the values as an array instead of an object! This is mostly to make my life slightly easier.
> I checkd with @isTravis about this, but @gabestein you might also rely on this being the case.
> 
> I do think this is important and we should make a firm decision here about what this should be in the future.



## Test Plan
This will not be fun, apologies. For now I think it's most important that fetching pubs works, and updating them and their relations. Whether super specific query parameters work as intended is less important (@isTravis please feel free to disagree!).

1. `pnpm reset`. then `pnpm dev`. You can now use `xxxxxxxxxxxxxxxx.00000000-0000-0000-0000-000000000000` as a token for `arcadia-research`
2. Try at least these requests (tip: add `| jq` at the end to get a nicer view of the result (do `brew install jq` if you don't have it yet))
  - Get all pubs (check that at most 10 pubs are returned)
```sh
curl 'http://localhost:3000/api/v0/c/arcadia-research/site/pubs' --header 'Authorization: Bearer xxxxxxxxxxxxxxxx.00000000-0000-0000-0000-000000000000'
```
3. Try to find the Journal Article pub by finding its id through the UI, or by first finding the id of the journal article pubtype like something like this (yes, would be good to be able to search by name through the ui) (even better would be to give pub types slugs)
```sh
curl  'http://localhost:3000/api/v0/c/arcadia-research/site/pub-types?limit=1000'  --header 'Authorization: Bearer xxxxxxxxxxxxxxxx.00000000-0000-0000-0000-000000000000' \
        | jq '.[] | select(.name == "Journal Article") | .id'
```

You could then find the journal article pub like

```sh
curl  'http://localhost:3000/api/v0/c/arcadia-research/site/pubs?pubTypeId=<pubTypeId>'  --header 'Authorization: Bearer xxxxxxxxxxxxxxxx.00000000-0000-0000-0000-000000000000' | jq '.[0].id'
```

Finally, get the journal article pub.
```sh
curl 'http://localhost:3000/api/v0/c/arcadia-research/site/pubs/<pubId>' --header 'Authorization: Bearer xxxxxxxxxxxxxxxx.00000000-0000-0000-0000-000000000000'
```

Check that only one pub is returned, dand that is has a lot of children and relations.
It should have some eg a tag

4. Try to add a tag to the journal article through the api
   a. First find the Tag pubtypes id. you can do that like this with `jq`
```sh
curl \
         --url http://localhost:3000/api/v0/c/arcadia-research/site/pub-types \
         --header 'Authorization: Bearer xxxxxxxxxxxxxxxx.00000000-0000-0000-0000-0000000
00000' \
        | jq '.[] | select(.name == "Tag") | .id'
```
  b.  Then, using the id of the journal article pub above, try to create a new related pub. (technically you can do this for any pub ofc)
```sh
curl --request PATCH \
  --url http://localhost:3000/api/v0/c/arcadia-research/site/pubs/<journal article pub id>/relations \
  --header 'Authorization: Bearer xxxxxxxxxxxxxxxx.00000000-0000-0000-0000-000000000000' \
  --header 'Prefer: return=representation' \
  --data '{
  "arcadia-research:tag": [{ "value": null, "relatedPub": {
    "pubTypeId": "35d468eb-169c-40eb-afb0-6ecacce156b4",
    "values":{"arcadia-research:title": "Wow, a new tag"}
  } }]
}'
```
Then, check the number of tags returned through the api (we don't have a way to view relationships in the ui yet)

```sh
curl --url 'http://localhost:3000/api/v0/c/arcadia-research/site/pubs/<journal article pub id>?fieldSlugs=arcadia-research:tag' --header  'Authorization: Bearer xxxxxxxxxxxxxxxx.00000000-0000-0000-0000-000000000000' | jq
```
You shuold see at least two tags! Go to the `/pubs` page, you should see two `Tag` pubs.

5. try the same as above, but with `--request PUT` instead. This will replace all the tags instead (it won't delete the tags though, just their relations to this pub)
```sh
curl --request PUT \
  --url http://localhost:3000/api/v0/c/arcadia-research/site/pubs/<journal article pub id>/relations \
  --header 'Authorization: Bearer xxxxxxxxxxxxxxxx.00000000-0000-0000-0000-000000000000' \
  --header 'Prefer: return=representation' \
  --data '{
  "arcadia-research:tag": [{ "value": null, "relatedPub": {
    "pubTypeId": "35d468eb-169c-40eb-afb0-6ecacce156b4",
    "values":{"arcadia-research:title": "Wow, a new tag"}
  } }]
}'
```
if you now `GET` the pub again, you shuold see there's only one tag!

6. You should be able to just delete the tags
```sh
curl --request DELETE \
         --url http://localhost:3000/api/v0/c/arcadia-research/site/pubs/d460d438-4ed4-49ca-aea9-9bf2c52ef0ec/relations \
         --header 'Authorization: Bearer xxxxxxxxxxxxxxxx.00000000-0000-0000-0000-000000000000' \
         --header 'Prefer: return=representation' #this makes sure we get a full thing returned \
         --header 'user-agent: Keyrunner' \
         --data '{
     "arcadia-research:tag": "*" 
   }' | jq
```

in the return value you should not be able to see any `arcadia-research:tag` values anymore.

## Screenshots (if applicable)

## Notes
