### PR TITLE
feat: paginate  pubs page

### DIFF
--- a/core/app/c/[communitySlug]/pubs/PubList.tsx
+++ b/core/app/c/[communitySlug]/pubs/PubList.tsx
@@ -16,10 +16,10 @@ import type { GetPubResult } from "~/lib/server";
 import type { XOR } from "~/lib/types";
 import { BasicPagination } from "~/app/components/Pagination";
 import PubRow, { PubRowSkeleton } from "~/app/components/PubRow";
-import { getPubs, getPubsCount, getPubsWithRelatedValuesAndChildren } from "~/lib/server";
+import { getPubs, getPubsCount } from "~/lib/server";
 import { getCommunitySlug } from "~/lib/server/cache/getCommunitySlug";
 
-const PAGE_SIZE = 2;
+const PAGE_SIZE = 20;
 
 type Props = {
 	token: string | Promise<string>;
@@ -38,6 +38,7 @@ const PubListInner: React.FC<Props> = async (props) => {
 			{
 				limit: 1000,
 				onlyParents: false,
+				orderBy: "updatedAt",
 			}
 		);
 	const [allPubs, token] = await Promise.all([pubsPromiseMaybe, props.token]);
@@ -75,7 +76,7 @@ const PaginatedPubListInner = async (props: PaginatedPubListProps) => {
 		getPubsCount({ communityId: props.communityId }),
 		getPubs(
 			{ communityId: props.communityId },
-			{ limit: PAGE_SIZE, offset: (props.page - 1) * PAGE_SIZE }
+			{ limit: PAGE_SIZE, offset: (props.page - 1) * PAGE_SIZE, orderBy: "updatedAt" }
 		),
 	]);
 

--- a/core/app/c/[communitySlug]/pubs/PubList.tsx
+++ b/core/app/c/[communitySlug]/pubs/PubList.tsx
@@ -1,12 +1,25 @@
 import { Suspense } from "react";
 
 import type { CommunitiesId } from "db/public";
+import {
+	Pagination,
+	PaginationContent,
+	PaginationEllipsis,
+	PaginationItem,
+	PaginationLink,
+	PaginationNext,
+	PaginationPrevious,
+} from "ui/pagination";
 import { cn } from "utils";
 
 import type { GetPubResult } from "~/lib/server";
 import type { XOR } from "~/lib/types";
+import { BasicPagination } from "~/app/components/Pagination";
 import PubRow, { PubRowSkeleton } from "~/app/components/PubRow";
-import { getPubs } from "~/lib/server";
+import { getPubs, getPubsCount, getPubsWithRelatedValuesAndChildren } from "~/lib/server";
+import { getCommunitySlug } from "~/lib/server/cache/getCommunitySlug";
+
+const PAGE_SIZE = 2;
 
 type Props = {
 	token: string | Promise<string>;
@@ -45,6 +58,49 @@ const PubListInner: React.FC<Props> = async (props) => {
 	);
 };
 
+type PaginatedPubListProps = {
+	communityId: CommunitiesId;
+	page: number;
+	searchParams: Record<string, unknown>;
+	/**
+	 * Needs to be provided for the pagination to work
+	 *
+	 * @default `/c/${communitySlug}/pubs`
+	 */
+	basePath?: string;
+};
+
+const PaginatedPubListInner = async (props: PaginatedPubListProps) => {
+	const [count, pubs] = await Promise.all([
+		getPubsCount({ communityId: props.communityId }),
+		getPubs(
+			{ communityId: props.communityId },
+			{ limit: PAGE_SIZE, offset: (props.page - 1) * PAGE_SIZE }
+		),
+	]);
+
+	const totalPages = Math.ceil(count / PAGE_SIZE);
+
+	const communitySlug = getCommunitySlug();
+	const basePath = props.basePath ?? `/c/${communitySlug}/pubs`;
+
+	return (
+		<div className={cn("flex flex-col gap-8")}>
+			{pubs.map((pub) => {
+				return (
+					<PubRow token={""} key={pub.id} pub={pub} searchParams={props.searchParams} />
+				);
+			})}
+			<BasicPagination
+				basePath={basePath}
+				searchParams={props.searchParams}
+				page={props.page}
+				totalPages={totalPages}
+			/>
+		</div>
+	);
+};
+
 export const PubListSkeleton = ({
 	amount = 10,
 	className,
@@ -59,7 +115,7 @@ export const PubListSkeleton = ({
 	</div>
 );
 
-const PubList: React.FC<Props> = async (props) => {
+export const PubList: React.FC<Props> = async (props) => {
 	return (
 		<Suspense fallback={<PubListSkeleton />}>
 			<PubListInner {...props} />
@@ -67,4 +123,10 @@ const PubList: React.FC<Props> = async (props) => {
 	);
 };
 
-export default PubList;
+export const PaginatedPubList: React.FC<PaginatedPubListProps> = async (props) => {
+	return (
+		<Suspense fallback={<PubListSkeleton />}>
+			<PaginatedPubListInner {...props} />
+		</Suspense>
+	);
+};

--- a/core/app/c/[communitySlug]/pubs/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/page.tsx
@@ -7,13 +7,16 @@ import { getPageLoginData } from "~/lib/authentication/loginData";
 import { findCommunityBySlug } from "~/lib/server/community";
 import { createToken } from "~/lib/server/token";
 import PubHeader from "./PubHeader";
-import PubList from "./PubList";
+import { PaginatedPubList } from "./PubList";
 
 export const metadata: Metadata = {
 	title: "Pubs",
 };
 
-type Props = { params: { communitySlug: string }; searchParams: Record<string, unknown> };
+type Props = {
+	params: { communitySlug: string };
+	searchParams: Record<string, unknown> & { page?: string };
+};
 
 export default async function Page({ params, searchParams }: Props) {
 	const { user } = await getPageLoginData();
@@ -24,15 +27,24 @@ export default async function Page({ params, searchParams }: Props) {
 		return null;
 	}
 
-	const tokenPromise = createToken({
-		userId: user.id as UsersId,
-		type: AuthTokenType.generic,
-	});
+	const page = searchParams.page ? parseInt(searchParams.page) : 1;
+
+	// const tokenPromise = createToken({
+	// 	userId: user.id as UsersId,
+	// 	type: AuthTokenType.generic,
+	// });
+
+	const basePath = `/c/${community.slug}/pubs`;
 
 	return (
 		<>
 			<PubHeader communityId={community.id as CommunitiesId} searchParams={searchParams} />
-			<PubList communityId={community.id} token={tokenPromise} searchParams={searchParams} />
+			<PaginatedPubList
+				communityId={community.id}
+				searchParams={searchParams}
+				page={page}
+				basePath={basePath}
+			/>
 		</>
 	);
 }

--- a/core/app/components/Pagination.tsx
+++ b/core/app/components/Pagination.tsx
@@ -13,7 +13,15 @@ export const BasicPagination = (props: {
 	searchParams: Record<string, unknown>;
 	page: number;
 	totalPages: number;
+	/**
+	 * @default true
+	 */
+	hideIfSinglePage?: boolean;
 }) => {
+	if (props.hideIfSinglePage !== false && props.totalPages === 1) {
+		return null;
+	}
+
 	return (
 		<Pagination>
 			<PaginationContent>
@@ -21,7 +29,7 @@ export const BasicPagination = (props: {
 					<PaginationItem>
 						<PaginationPrevious
 							href={{
-								// pathname: props.basePath,
+								pathname: props.basePath,
 								query: { ...props.searchParams, page: props.page - 1 },
 							}}
 						/>
@@ -32,7 +40,7 @@ export const BasicPagination = (props: {
 					<PaginationItem>
 						<PaginationLink
 							href={{
-								// pathname: props.basePath,
+								pathname: props.basePath,
 								query: { ...props.searchParams, page: 1 },
 							}}
 						>
@@ -51,7 +59,7 @@ export const BasicPagination = (props: {
 					<PaginationItem>
 						<PaginationLink
 							href={{
-								// pathname: props.basePath,
+								pathname: props.basePath,
 								query: { ...props.searchParams, page: props.page - 1 },
 							}}
 						>
@@ -63,7 +71,7 @@ export const BasicPagination = (props: {
 				<PaginationItem>
 					<PaginationLink
 						href={{
-							// pathname: props.basePath,
+							pathname: props.basePath,
 							query: { ...props.searchParams, page: props.page },
 						}}
 						isActive
@@ -76,7 +84,7 @@ export const BasicPagination = (props: {
 					<PaginationItem>
 						<PaginationLink
 							href={{
-								// pathname: props.basePath,
+								pathname: props.basePath,
 								query: { ...props.searchParams, page: props.page + 1 },
 							}}
 						>
@@ -95,7 +103,7 @@ export const BasicPagination = (props: {
 					<PaginationItem>
 						<PaginationLink
 							href={{
-								// pathname: props.basePath,
+								pathname: props.basePath,
 								query: { ...props.searchParams, page: props.totalPages },
 							}}
 						>
@@ -108,7 +116,7 @@ export const BasicPagination = (props: {
 					<PaginationItem>
 						<PaginationNext
 							href={{
-								// pathname: props.basePath,
+								pathname: props.basePath,
 								query: { ...props.searchParams, page: props.page + 1 },
 							}}
 						/>

--- a/core/app/components/Pagination.tsx
+++ b/core/app/components/Pagination.tsx
@@ -1,0 +1,120 @@
+import {
+	Pagination,
+	PaginationContent,
+	PaginationEllipsis,
+	PaginationItem,
+	PaginationLink,
+	PaginationNext,
+	PaginationPrevious,
+} from "ui/pagination";
+
+export const BasicPagination = (props: {
+	basePath: string;
+	searchParams: Record<string, unknown>;
+	page: number;
+	totalPages: number;
+}) => {
+	return (
+		<Pagination>
+			<PaginationContent>
+				{props.page > 1 && (
+					<PaginationItem>
+						<PaginationPrevious
+							href={{
+								// pathname: props.basePath,
+								query: { ...props.searchParams, page: props.page - 1 },
+							}}
+						/>
+					</PaginationItem>
+				)}
+
+				{props.page > 2 && (
+					<PaginationItem>
+						<PaginationLink
+							href={{
+								// pathname: props.basePath,
+								query: { ...props.searchParams, page: 1 },
+							}}
+						>
+							1
+						</PaginationLink>
+					</PaginationItem>
+				)}
+
+				{props.page > 3 && (
+					<PaginationItem>
+						<PaginationEllipsis />
+					</PaginationItem>
+				)}
+
+				{props.page > 1 && (
+					<PaginationItem>
+						<PaginationLink
+							href={{
+								// pathname: props.basePath,
+								query: { ...props.searchParams, page: props.page - 1 },
+							}}
+						>
+							{props.page - 1}
+						</PaginationLink>
+					</PaginationItem>
+				)}
+
+				<PaginationItem>
+					<PaginationLink
+						href={{
+							// pathname: props.basePath,
+							query: { ...props.searchParams, page: props.page },
+						}}
+						isActive
+					>
+						{props.page}
+					</PaginationLink>
+				</PaginationItem>
+
+				{props.page < props.totalPages && (
+					<PaginationItem>
+						<PaginationLink
+							href={{
+								// pathname: props.basePath,
+								query: { ...props.searchParams, page: props.page + 1 },
+							}}
+						>
+							{props.page + 1}
+						</PaginationLink>
+					</PaginationItem>
+				)}
+
+				{props.page < props.totalPages - 2 && (
+					<PaginationItem>
+						<PaginationEllipsis />
+					</PaginationItem>
+				)}
+
+				{props.page < props.totalPages - 1 && (
+					<PaginationItem>
+						<PaginationLink
+							href={{
+								// pathname: props.basePath,
+								query: { ...props.searchParams, page: props.totalPages },
+							}}
+						>
+							{props.totalPages}
+						</PaginationLink>
+					</PaginationItem>
+				)}
+
+				{props.page < props.totalPages && (
+					<PaginationItem>
+						<PaginationNext
+							href={{
+								// pathname: props.basePath,
+								query: { ...props.searchParams, page: props.page + 1 },
+							}}
+						/>
+					</PaginationItem>
+				)}
+			</PaginationContent>
+		</Pagination>
+	);
+};

--- a/core/prisma/exampleCommunitySeeds/arcadia.ts
+++ b/core/prisma/exampleCommunitySeeds/arcadia.ts
@@ -676,7 +676,7 @@ export const seedArcadia = (communityId?: CommunitiesId) => {
 																	},
 																},
 															},
-															...articleSeed(1_000, true),
+															...articleSeed(100, true),
 														],
 													},
 												},

--- a/core/prisma/seed.ts
+++ b/core/prisma/seed.ts
@@ -71,7 +71,7 @@ async function main() {
 	// this flag is set in the `globalSetup.ts` file
 	// and in e2e.yml
 	// eslint-disable-next-line no-restricted-properties
-	const shouldSeedArcadia = Boolean(process.env.SEED_ARCADIA);
+	const shouldSeedArcadia = !Boolean(process.env.MINIMAL_SEED);
 
 	const prismaCommunityIds = [
 		unJournalId,

--- a/packages/ui/src/pagination.tsx
+++ b/packages/ui/src/pagination.tsx
@@ -31,7 +31,7 @@ PaginationItem.displayName = "PaginationItem";
 
 type PaginationLinkProps = {
 	isActive?: boolean;
-} & Pick<ButtonProps, "size"> &
+} & Partial<Pick<ButtonProps, "size">> &
 	React.ComponentProps<typeof Link>;
 
 const PaginationLink = ({ className, isActive, size = "icon", ...props }: PaginationLinkProps) => (


### PR DESCRIPTION
- **feat: add very basic pagination to pubs list**
- **fix: orderby updatedat even though that doesn't really work like you think it would**

## Issue(s) Resolved
Resolves #778. Technically the `updatedAt` does not really work as you think it would, as it only sorts by the Pubs `updatedAt`, which rarely changes. I created #809 to do this in a more intuitive way.

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->
Adds pagination to the Pubs page by creating a new component called `PaginatedPubsList`, which does the same as `PubsList`, just paginated.

Note: this also encroaches a bit on #801, as I didn't want to re add creating the token logic to this PubList if it would get taken out anyway.

I can incorporate #801 into this PR quite easily as well if needed. 

### Things left out

- Initially I also wanted to make this page use `getPubsWithRelatedValuesAndChildren` instead, but that would go beyond the scope of the ticket too much and potentially make other tickets blocked by this one (such as #799 and #800), so I opted to just keep using `getPubs`
- This also means that sorting by `updatedAt` doesn't really work, as in `getPubs` this is done by finding the `updatedAt` of the Pub itself, which rarely changes. I have put up a follow up PR that adds some DB triggers to update pub.updatedAt whenever pubValues change, an idea which i've discussed with @kalilsn previously.

## Test Plan
Ideally, after #797 is merged, go to `/c/arcadia-research/pubs`

1. See pagination
2. Do not have to wait an eternity to see all pages.




## Screenshots (if applicable)

## Notes
