### PR TITLE
Double CPU and memory of prod core ECS task

### DIFF
--- a/infrastructure/terraform/environments/stevie/.terraform.lock.hcl
+++ b/infrastructure/terraform/environments/stevie/.terraform.lock.hcl
@@ -3,8 +3,9 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.70.0"
-  constraints = ">= 4.0.0, >= 4.40.0, >= 4.66.1, >= 5.0.0, >= 5.70.0"
+  constraints = ">= 4.0.0, >= 4.40.0, >= 4.66.1, >= 5.0.0, >= 5.27.0"
   hashes = [
+    "h1:+QN8de63DAE4QbyODwK14T9ZEKasvRwLMSItMOWoU2Q=",
     "h1:kcKscQCmMLrNMAkaL4XIqGGq4uk8vXthNRvtfersNH0=",
     "zh:09cbec93c324e6f03a866244ecb2bae71fdf1f5d3d981e858b745c90606b6b6d",
     "zh:19685d9f4c9ddcfa476a9a428c6c612be4a1b4e8e1198fbcbb76436b735284ee",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.3"
   hashes = [
+    "h1:f6jXn4MCv67kgcofx9D49qx1ZEBv8oyvwKDMPBr0A24=",
     "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
     "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/honeycombio/honeycombio" {
   constraints = ">= 0.22.0"
   hashes = [
     "h1:2T/JgeekYNwS4oXjdzduRZBcCR9lpuU/1Wo/kG4YcUA=",
+    "h1:C+6G9/8Ml8HTvduF0oXVSieXu/T3v+TGH1/vVIcwLEo=",
     "zh:09be7a66f926202a976cce5eb5fd4770aaa8202c5f4cd3611fb34288c2a3d0f5",
     "zh:128a522a0a991674b80dbc66e3859b56fd1590ecf63a2cf6323d04d8212175b9",
     "zh:18869e171aeacb7db79ba06d284ce017e4bd5afaf3baa0171a66c279cf6a2b7f",

--- a/infrastructure/terraform/modules/deployment/main.tf
+++ b/infrastructure/terraform/modules/deployment/main.tf
@@ -73,6 +73,12 @@ module "service_core" {
     ]
   }]
 
+  resources = {
+    cpu = 1024
+    memory = 2048
+    desired_count = 1
+  }
+
   configuration = {
     container_port = 3000
     environment = [


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #806 

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->

Output of `mask tf plan -n stevie`:

```tf
Terraform will perform the following actions:

  # module.deployment.module.service_core.module.ecs_service.data.aws_ecs_task_definition.this[0] will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_ecs_task_definition" "this" {
      + arn                  = (known after apply)
      + arn_without_revision = (known after apply)
      + execution_role_arn   = (known after apply)
      + family               = (known after apply)
      + id                   = (known after apply)
      + network_mode         = (known after apply)
      + revision             = (known after apply)
      + status               = (known after apply)
      + task_definition      = "stevie-core"
      + task_role_arn        = (known after apply)
    }

  # module.deployment.module.service_core.module.ecs_service.aws_ecs_task_definition.this[0] must be replaced
+/- resource "aws_ecs_task_definition" "this" {
      ~ arn                      = "arn:aws:ecs:us-east-1:246372085946:task-definition/stevie-core:142" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:246372085946:task-definition/stevie-core" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  - cpu                    = 0
                    name                   = "core"
                    # (18 unchanged attributes hidden)
                },
              ~ {
                  - cpu                    = 0
                    name                   = "migrations"
                    # (18 unchanged attributes hidden)
                },
              ~ {
                  - cpu                    = 0
                    name                   = "nginx"
                    # (16 unchanged attributes hidden)
                },
            ]
        )
      ~ cpu                      = "512" -> "1024" # forces replacement
      ~ id                       = "stevie-core" -> (known after apply)
      ~ memory                   = "1024" -> "2048" # forces replacement
      ~ revision                 = 142 -> (known after apply)
        tags                     = {
            "Environment"         = "stevie-production"
            "LogicalName"         = "core"
            "Project"             = "Pubpub-v7"
            "Shortname"           = "94a0"
            "ShortnameAnnotation" = "Shortname is calculated as first four characters of the sha1sum of the Logical Name."
        }
        # (8 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

## Test Plan

Take a look at the `tf plan` report above and make sure the changes make sense!
