### PR TITLE
Related pubs table

### DIFF
--- a/core/app/c/[communitySlug]/pubs/[pubId]/components/RelatedPubsTable.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/components/RelatedPubsTable.tsx
@@ -13,7 +13,7 @@ import { Button } from "ui/button";
 import { Checkbox } from "ui/checkbox";
 import { DataTableColumnHeader } from "ui/data-table";
 
-import { DataTable } from "~/app/components/DataTable/v2/DataTable";
+import { DataTable } from "~/app/components/DataTable/DataTable";
 import { getPubTitle } from "~/lib/pubs";
 import { createdAtDateOptions } from "./getPubChildrenTableColumns";
 
@@ -99,7 +99,7 @@ const getRelatedPubsColumns = () => {
 const Table = ({ pubs }: { pubs: FullProcessedPub[] }) => {
 	const columns = getRelatedPubsColumns();
 
-	return <DataTable columns={columns} data={pubs} />;
+	return <DataTable columns={columns} data={pubs} hidePaginationWhenSinglePage />;
 };
 
 export const RelatedPubsTable = ({ pub }: { pub: FullProcessedPub }) => {
@@ -123,7 +123,11 @@ export const RelatedPubsTable = ({ pub }: { pub: FullProcessedPub }) => {
 		count: value.length,
 	}));
 
-	const [selected, setSelected] = useState(fields[0].slug);
+	const [selected, setSelected] = useState(fields[0]?.slug);
+
+	if (fields.length === 0) {
+		return <Table pubs={[]} />;
+	}
 
 	return (
 		<div>

--- a/core/app/c/[communitySlug]/pubs/[pubId]/components/RelatedPubsTable.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/components/RelatedPubsTable.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import type { ProcessedPub } from "contracts";
+import type { PubTypes, Stages } from "db/public";
+import { Badge } from "ui/badge";
+import { Button } from "ui/button";
+import { Checkbox } from "ui/checkbox";
+import { DataTableColumnHeader } from "ui/data-table";
+
+import { DataTable } from "~/app/components/DataTable/v2/DataTable";
+import { getPubTitle } from "~/lib/pubs";
+import { createdAtDateOptions } from "./getPubChildrenTableColumns";
+
+type FullProcessedPub = ProcessedPub<{
+	withRelatedPubs: true;
+	withChildren: true;
+	withMembers: true;
+	withPubType: true;
+	withStage: true;
+}>;
+
+const getRelatedPubsColumns = () => {
+	return [
+		{
+			id: "select",
+			header: ({ table }) => (
+				<Checkbox
+					checked={
+						table.getIsAllPageRowsSelected() ||
+						(table.getIsSomePageRowsSelected() && "indeterminate")
+					}
+					onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+					aria-label="Select all"
+				/>
+			),
+			cell: ({ row }) => (
+				<Checkbox
+					checked={row.getIsSelected()}
+					onCheckedChange={(value) => row.toggleSelected(!!value)}
+					aria-label="Select row"
+					className="mr-2 h-4 w-4"
+				/>
+			),
+			enableSorting: false,
+			enableHiding: false,
+		},
+		{
+			header: ({ column }) => <DataTableColumnHeader column={column} title="Title" />,
+			accessorKey: "title",
+			cell: ({ row }) => {
+				const pathname = usePathname();
+				const path = pathname.split("/").slice(0, 4).join("/");
+				const title = getPubTitle(row.original);
+				return (
+					<Link className="block truncate underline" href={`${path}/${row.original.id}`}>
+						{title}
+					</Link>
+				);
+			},
+		},
+		{
+			header: ({ column }) => <DataTableColumnHeader column={column} title="Pub Type" />,
+			accessorKey: "pubType",
+			cell: ({ getValue }) => {
+				const pubTypeName = getValue<PubTypes>().name;
+				return <Badge variant="outline">{pubTypeName}</Badge>;
+			},
+		},
+		{
+			header: ({ column }) => <DataTableColumnHeader column={column} title="Stage" />,
+			accessorKey: "stages",
+			cell: ({ getValue }) => {
+				const stageName = getValue<Stages>()?.name;
+				return stageName ? (
+					<Badge variant="outline">{stageName}</Badge>
+				) : (
+					<span className="text-muted-foreground">None</span>
+				);
+			},
+		},
+		{
+			header: ({ column }) => <DataTableColumnHeader column={column} title="Created At" />,
+			accessorKey: "createdAt",
+			cell: ({ getValue }) => (
+				<time dateTime={new Date().toString()} suppressHydrationWarning>
+					{new Date(getValue<string>()).toLocaleString(undefined, createdAtDateOptions)}
+				</time>
+			),
+		},
+	] as const satisfies ColumnDef<FullProcessedPub, unknown>[];
+};
+
+const Table = ({ pubs }: { pubs: FullProcessedPub[] }) => {
+	const columns = getRelatedPubsColumns();
+
+	return <DataTable columns={columns} data={pubs} />;
+};
+
+export const RelatedPubsTable = ({ pub }: { pub: FullProcessedPub }) => {
+	const groupedBySlug = useMemo(() => {
+		const grouped: Record<string, { pub: FullProcessedPub; fieldName: string }[]> = {};
+		for (const value of pub.values) {
+			const { relatedPub, fieldSlug, fieldName } = value;
+			if (relatedPub) {
+				if (!grouped[fieldSlug]) {
+					grouped[fieldSlug] = [];
+				}
+				grouped[fieldSlug].push({ pub: relatedPub, fieldName });
+			}
+		}
+		return grouped;
+	}, [pub]);
+
+	const fields = Object.entries(groupedBySlug).map(([slug, value]) => ({
+		slug,
+		name: value[0].fieldName,
+		count: value.length,
+	}));
+
+	const [selected, setSelected] = useState(fields[0].slug);
+
+	return (
+		<div>
+			<div className="flex items-center gap-2">
+				{fields.map((field) => {
+					const isSelected = selected === field.slug;
+					return (
+						<Button
+							key={field.slug}
+							onClick={() => {
+								setSelected(field.slug);
+							}}
+							variant={isSelected ? "default" : "ghost"}
+						>
+							{field.name}
+							<span className="ml-2 font-mono text-xs">{field.count}</span>
+						</Button>
+					);
+				})}
+			</div>
+			<Table pubs={groupedBySlug[selected].map((value) => value.pub)} />
+		</div>
+	);
+};

--- a/core/app/c/[communitySlug]/pubs/[pubId]/components/getPubChildrenTableColumns.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/components/getPubChildrenTableColumns.tsx
@@ -14,7 +14,7 @@ import { DataTableColumnHeader } from "ui/data-table";
 import type { ChildPubRow, ChildPubRowPubType } from "./types";
 import { UserCard } from "~/app/components/UserCard";
 
-const createdAtDateOptions = {
+export const createdAtDateOptions = {
 	month: "short",
 	day: "numeric",
 	year: "numeric",

--- a/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
@@ -135,8 +135,6 @@ export default async function Page({
 		return null;
 	}
 
-	const relatedPubs = pub.values.map((value) => value.relatedPub).filter((value) => !!value);
-
 	const { stage, children, ...slimPub } = pub;
 
 	return (

--- a/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
@@ -37,6 +37,7 @@ import {
 } from "./actions";
 import { renderPubValue } from "./components/jsonSchemaHelpers";
 import PubChildrenTableWrapper from "./components/PubChildrenTableWrapper";
+import { RelatedPubsTable } from "./components/RelatedPubsTable";
 
 export async function generateMetadata({
 	params: { pubId },
@@ -133,6 +134,8 @@ export default async function Page({
 	if (!pub) {
 		return null;
 	}
+
+	const relatedPubs = pub.values.map((value) => value.relatedPub).filter((value) => !!value);
 
 	const { stage, children, ...slimPub } = pub;
 
@@ -268,6 +271,12 @@ export default async function Page({
 					parentPubId={pub.id}
 				/>
 			</Suspense>
+			{relatedPubs ? (
+				<div>
+					<h2 className="mb-2 text-xl font-bold">Related Pubs</h2>
+					<RelatedPubsTable pub={pub} />
+				</div>
+			) : null}
 		</div>
 	);
 }

--- a/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
@@ -271,12 +271,10 @@ export default async function Page({
 					parentPubId={pub.id}
 				/>
 			</Suspense>
-			{relatedPubs ? (
-				<div>
-					<h2 className="mb-2 text-xl font-bold">Related Pubs</h2>
-					<RelatedPubsTable pub={pub} />
-				</div>
-			) : null}
+			<div>
+				<h2 className="mb-2 text-xl font-bold">Related Pubs</h2>
+				<RelatedPubsTable pub={pub} />
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## Issue(s) Resolved

Closes https://github.com/pubpub/platform/issues/777

## High-level Explanation of PR
Related pubs can now be seen on pub detail pages.

## Test Plan
Visit the journal article called "Identification of capsid-like proteins in venomous and parasitic animals" in the Arcadia seed community. You should be able to see its related pubs, grouped by relationship type.

## Screenshots (if applicable)
<img width="1419" alt="image" src="https://github.com/user-attachments/assets/85286ceb-5eaf-40d0-a963-e0046a12b0c1">

## Notes

No "actions" or "member fields" rendering yet since those would require more queries ([convo here](https://knowledgefutures.slack.com/archives/CMAQM0BNV/p1732722697668169?thread_ts=1732649416.238439&cid=CMAQM0BNV))
