### PR TITLE
Add default column to forms

### DIFF
--- a/core/app/c/[communitySlug]/forms/[formSlug]/edit/page.tsx
+++ b/core/app/c/[communitySlug]/forms/[formSlug]/edit/page.tsx
@@ -4,14 +4,14 @@ import { notFound, redirect } from "next/navigation";
 import type { CommunitiesId } from "db/public";
 import { Capabilities } from "db/src/public/Capabilities";
 import { MembershipType } from "db/src/public/MembershipType";
-import { ClipboardPenLine } from "ui/icon";
+import { ClipboardPenLine, Info } from "ui/icon";
 import { PubFieldProvider } from "ui/pubFields";
+import { Tooltip, TooltipContent, TooltipTrigger } from "ui/tooltip";
 
 import { FormBuilder } from "~/app/components/FormBuilder/FormBuilder";
 import { SaveFormButton } from "~/app/components/FormBuilder/SaveFormButton";
 import { db } from "~/kysely/database";
 import { getPageLoginData } from "~/lib/authentication/loginData";
-import { isCommunityAdmin } from "~/lib/authentication/roles";
 import { userCan } from "~/lib/authorization/capabilities";
 import { findCommunityBySlug } from "~/lib/server/community";
 import { getForm } from "~/lib/server/form";
@@ -72,11 +72,31 @@ export default async function Page({
 	return (
 		<ContentLayout
 			title={
-				<>
-					<ClipboardPenLine size={24} strokeWidth={1} className="mr-2 text-slate-500" />{" "}
-					{form.name}
-					<EditFormTitleButton formId={form.id} name={form.name} />
-				</>
+				<div className="flex flex-col">
+					<div className="flex flex-row items-center">
+						<ClipboardPenLine
+							size={24}
+							strokeWidth={1}
+							className="mr-2 text-slate-500"
+						/>{" "}
+						{form.name}
+						<EditFormTitleButton formId={form.id} name={form.name} />
+					</div>
+					{form.isDefault && (
+						<div className="flex gap-1 text-sm font-normal">
+							Default editor for this type
+							<Tooltip>
+								<TooltipTrigger>
+									<Info size="16" />
+								</TooltipTrigger>
+								<TooltipContent>
+									This form is used as the default internal editor for all Pubs of
+									this type.
+								</TooltipContent>
+							</Tooltip>
+						</div>
+					)}
+				</div>
 			}
 			headingAction={
 				<div className="flex items-center gap-2">

--- a/core/app/c/[communitySlug]/forms/getFormTableColumns.tsx
+++ b/core/app/c/[communitySlug]/forms/getFormTableColumns.tsx
@@ -23,6 +23,7 @@ export type TableForm = {
 	pubType: string;
 	updated: Date;
 	isArchived: boolean;
+	isDefault: boolean;
 };
 
 export const getFormTableColumns = () =>
@@ -55,6 +56,13 @@ export const getFormTableColumns = () =>
 				<DataTableColumnHeader className="w-52" column={column} title="Name" />
 			),
 			accessorKey: "formName",
+		},
+		{
+			header: ({ column }) => (
+				<DataTableColumnHeader className="w-52" column={column} title="Default" />
+			),
+			accessorKey: "isDefault",
+			cell: ({ row }) => (row.original.isDefault ? "Yes" : "No"),
 		},
 		{
 			header: ({ column }) => (

--- a/core/app/c/[communitySlug]/forms/page.tsx
+++ b/core/app/c/[communitySlug]/forms/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 
-import React from "react";
 import { notFound, redirect } from "next/navigation";
 import partition from "lodash.partition";
 
@@ -53,13 +52,14 @@ export default async function Page({
 			.innerJoin("pub_types", "pub_types.id", "forms.pubTypeId")
 			.innerJoin("communities", "communities.id", "pub_types.communityId")
 			.select([
-				"forms.id as id",
-				"forms.slug as slug",
+				"forms.id",
+				"forms.slug",
 				"forms.name as formName",
 				"pub_types.name as pubType",
 				"pub_types.updatedAt", // TODO: this should be the form's updatedAt
 				"forms.isArchived",
 				"forms.slug",
+				"forms.isDefault",
 			])
 			.where("communities.slug", "=", communitySlug)
 	).execute();
@@ -68,7 +68,7 @@ export default async function Page({
 
 	const tableForms = (formList: typeof forms) =>
 		formList.map((form) => {
-			const { id, formName, pubType, updatedAt, isArchived, slug } = form;
+			const { id, formName, pubType, updatedAt, isArchived, slug, isDefault } = form;
 			return {
 				id,
 				slug,
@@ -76,6 +76,7 @@ export default async function Page({
 				pubType,
 				updated: new Date(updatedAt),
 				isArchived,
+				isDefault,
 			};
 		});
 

--- a/core/prisma/migrations/20241203035210_add_default_forms/migration.sql
+++ b/core/prisma/migrations/20241203035210_add_default_forms/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "forms" ADD COLUMN     "isDefault" BOOLEAN NOT NULL DEFAULT false;

--- a/core/prisma/schema.dbml
+++ b/core/prisma/schema.dbml
@@ -377,6 +377,7 @@ Table forms {
   elements form_elements [not null]
   isArchived Boolean [not null, default: false]
   access FormAccessType [not null, default: 'private']
+  isDefault Boolean [not null, default: false]
   members form_memberships [not null]
 
   indexes {

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -500,6 +500,7 @@ model Form {
   elements    FormElement[]
   isArchived  Boolean        @default(false)
   access      FormAccessType @default(private)
+  isDefault   Boolean        @default(false)
 
   members FormMembership[]
 

--- a/packages/db/src/public/Forms.ts
+++ b/packages/db/src/public/Forms.ts
@@ -30,6 +30,8 @@ export interface FormsTable {
 	slug: ColumnType<string, string, string>;
 
 	access: ColumnType<FormAccessType, FormAccessType | undefined, FormAccessType>;
+
+	isDefault: ColumnType<boolean, boolean | undefined, boolean>;
 }
 
 export type Forms = Selectable<FormsTable>;
@@ -48,6 +50,7 @@ export const formsSchema = z.object({
 	communityId: communitiesIdSchema,
 	slug: z.string(),
 	access: formAccessTypeSchema,
+	isDefault: z.boolean(),
 });
 
 export const formsInitializerSchema = z.object({
@@ -58,6 +61,7 @@ export const formsInitializerSchema = z.object({
 	communityId: communitiesIdSchema,
 	slug: z.string(),
 	access: formAccessTypeSchema.optional(),
+	isDefault: z.boolean().optional(),
 });
 
 export const formsMutatorSchema = z.object({
@@ -68,4 +72,5 @@ export const formsMutatorSchema = z.object({
 	communityId: communitiesIdSchema.optional(),
 	slug: z.string().optional(),
 	access: formAccessTypeSchema.optional(),
+	isDefault: z.boolean().optional(),
 });

--- a/packages/db/src/table-names.ts
+++ b/packages/db/src/table-names.ts
@@ -1012,6 +1012,14 @@ export const databaseTables = [
 				isAutoIncrementing: false,
 				hasDefaultValue: true,
 			},
+			{
+				name: "isDefault",
+				dataType: "bool",
+				dataTypeSchema: "pg_catalog",
+				isNullable: false,
+				isAutoIncrementing: false,
+				hasDefaultValue: true,
+			},
 		],
 	},
 	{


### PR DESCRIPTION
## Issue(s) Resolved
#781 
## High-level Explanation of PR
- Adds default column to database table
- Adds notice to form builder header
- Adds default column to table on forms page

## Test Plan
I tested by manually setting isDefault to true for a form in the database. You could do that too, or just trust me :)

## Screenshots (if applicable)
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/00d37b36-c13d-4f45-aa2d-c063c8b467a8">
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/473bdd02-0679-43ce-b0f8-ff19cf40c6de">
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/0c114acd-9fdf-4e19-a68e-5289ceb89d52">

## Notes
I went with `isDefault` for minor convenience since `default` is a reserved word. Also I'm very unsure about the placement of the text on the form builder page and the "Yes"/"No" in the table. Let me know if you have any suggestions!