### PR TITLE
Add default form when creating pub type

### DIFF
--- a/core/actions/_lib/runActionInstance.ts
+++ b/core/actions/_lib/runActionInstance.ts
@@ -11,7 +11,7 @@ import { logger } from "logger";
 import type { ActionSuccess } from "../types";
 import type { ClientException, ClientExceptionOptions } from "~/lib/serverActions";
 import { db } from "~/kysely/database";
-import { getPub, getPubCached } from "~/lib/server";
+import { getPubCached } from "~/lib/server";
 import { autoRevalidate } from "~/lib/server/cache/autoRevalidate";
 import { getActionByName } from "../api";
 import { getActionRunByName } from "./getRuns";
@@ -169,6 +169,7 @@ const _runActionInstance = async (
 				assignee: pub.assignee ?? undefined,
 				parentId: pub.parentId,
 				communityId: pub.communityId,
+				createdAt: pub.createdAt,
 			},
 			// FIXME: get rid of any
 			args: argsWithPubfields as any,

--- a/core/actions/types.ts
+++ b/core/actions/types.ts
@@ -1,14 +1,7 @@
 import type { JTDDataType } from "ajv/dist/jtd";
 import type * as z from "zod";
 
-import type {
-	Action as ActionName,
-	CommunitiesId,
-	CoreSchemaType,
-	Event,
-	PubsId,
-	StagesId,
-} from "db/public";
+import type { Action as ActionName, CommunitiesId, Event, PubsId, StagesId } from "db/public";
 import type { Dependency, FieldConfig, FieldConfigItem } from "ui/auto-form";
 import type * as Icons from "ui/icon";
 
@@ -33,6 +26,7 @@ export type ActionPub<T extends ActionPubType> = {
 		email: string;
 	};
 	communityId: CommunitiesId;
+	createdAt: Date;
 };
 
 export type RunProps<T extends Action> =

--- a/core/app/c/[communitySlug]/forms/actions.ts
+++ b/core/app/c/[communitySlug]/forms/actions.ts
@@ -28,7 +28,7 @@ export const createForm = defineServerAction(async function createForm(
 
 	try {
 		await autoRevalidate(
-			insertForm(pubTypeId, name, slug, communityId)
+			insertForm(pubTypeId, name, slug, communityId, false)
 		).executeTakeFirstOrThrow();
 	} catch (error) {
 		if (isUniqueConstraintError(error)) {

--- a/core/app/c/[communitySlug]/forms/actions.ts
+++ b/core/app/c/[communitySlug]/forms/actions.ts
@@ -110,7 +110,7 @@ export const createForm = defineServerAction(async function createForm(
 		).executeTakeFirstOrThrow();
 	} catch (error) {
 		if (isUniqueConstraintError(error)) {
-			const column = error.constraint === "forms_slug_key" ? "slug" : "name";
+			const column = error.constraint === "forms_slug_communityId_key" ? "slug" : "name";
 			return { error: `A form with this ${column} already exists. Choose a new ${column}` };
 		}
 		logger.error({ msg: "error creating form", error });

--- a/core/app/c/[communitySlug]/forms/actions.ts
+++ b/core/app/c/[communitySlug]/forms/actions.ts
@@ -1,29 +1,16 @@
 "use server";
 
 import { redirect } from "next/navigation";
-import { sql } from "kysely";
-import { componentsBySchema } from "schemas";
 
-import type { CommunitiesId, CoreSchemaType, InputComponent, PubTypesId } from "db/public";
-import { logger } from "logger";
-import { assert, expect } from "utils";
+import type { CommunitiesId, PubTypesId } from "db/public";
+import { assert } from "utils";
 
-import { db } from "~/kysely/database";
 import { isUniqueConstraintError } from "~/kysely/errors";
 import { getLoginData } from "~/lib/authentication/loginData";
 import { autoRevalidate } from "~/lib/server/cache/autoRevalidate";
 import { findCommunityBySlug } from "~/lib/server/community";
 import { defineServerAction } from "~/lib/server/defineServerAction";
-import { _getPubFields } from "~/lib/server/pubFields";
-
-const componentsBySchemaTable = Object.entries(componentsBySchema)
-	.map(([schema, components]) => {
-		const component = components[0]
-			? `'${components[0]}'::"InputComponent"`
-			: `null::"InputComponent"`;
-		return `('${schema}'::"CoreSchemaType", ${component})`;
-	})
-	.join(", ");
+import { FORM_SLUG_UNIQUE_CONSTRAINT, insertForm } from "~/lib/server/form";
 
 export const createForm = defineServerAction(async function createForm(
 	pubTypeId: PubTypesId,
@@ -41,80 +28,14 @@ export const createForm = defineServerAction(async function createForm(
 
 	try {
 		await autoRevalidate(
-			db
-				.with("components", (db) =>
-					// This lets us set an appropriate default component during creation by turning
-					// the js mapping from schemaName to InputComponent into a temporary table which
-					// can be used during the query. Without this, we would need to first query for
-					// the pubtype's fields (and their schemaNames), then determine the input
-					// components in js before inserting
-					db
-						.selectFrom(
-							sql<{
-								schema: CoreSchemaType;
-								component: InputComponent;
-							}>`(values ${sql.raw(componentsBySchemaTable)})`.as<"c">(
-								sql`c(schema, component)`
-							)
-						)
-						.selectAll("c")
-				)
-				.with("fields", () =>
-					_getPubFields({ pubTypeId, communityId })
-						.clearSelect()
-						.select((eb) => [
-							eb.ref("f.id").as("fieldId"),
-							eb.ref("f.json", "->>").key("name").as("name"),
-							eb
-								.cast<CoreSchemaType>(
-									eb.ref("f.json", "->>").key("schemaName"),
-									sql.raw('"CoreSchemaType"')
-								)
-								.as("schemaName"),
-						])
-				)
-				.with("form", (db) =>
-					db
-						.insertInto("forms")
-						.values({
-							name,
-							pubTypeId,
-							slug,
-							communityId,
-						})
-						.returning(["slug", "id"])
-				)
-
-				.insertInto("form_elements")
-				.columns(["fieldId", "formId", "label", "type", "order", "component"])
-				.expression((eb) =>
-					eb
-						.selectFrom("fields")
-						.innerJoin("form", (join) => join.onTrue())
-						.select((eb) => [
-							"fields.fieldId",
-							"form.id as formId",
-							"fields.name as label",
-							eb.val("pubfield").as("type"),
-							eb.fn
-								.agg<number>("ROW_NUMBER")
-								.over((o) => o.partitionBy("id"))
-								.as("order"),
-							eb
-								.selectFrom("components")
-								.select("component")
-								.whereRef("components.schema", "=", "fields.schemaName")
-								.as("component"),
-						])
-				)
+			insertForm(pubTypeId, name, slug, communityId)
 		).executeTakeFirstOrThrow();
 	} catch (error) {
 		if (isUniqueConstraintError(error)) {
-			const column = error.constraint === "forms_slug_communityId_key" ? "slug" : "name";
+			const column = error.constraint === FORM_SLUG_UNIQUE_CONSTRAINT ? "slug" : "name";
 			return { error: `A form with this ${column} already exists. Choose a new ${column}` };
 		}
-		logger.error({ msg: "error creating form", error });
-		return { error: "Form creation failed" };
+		return { error: "Form creation failed", cause: error };
 	}
 
 	const community = await findCommunityBySlug();

--- a/core/app/c/[communitySlug]/types/actions.ts
+++ b/core/app/c/[communitySlug]/types/actions.ts
@@ -74,7 +74,7 @@ export const removePubType = defineServerAction(async function removePubType(
 	).execute();
 });
 
-export const createPubType = defineServerAction(async function addPubType(
+export const createPubType = defineServerAction(async function createPubType(
 	name: string,
 	communityId: CommunitiesId,
 	description: string | undefined,

--- a/core/kysely/errors.ts
+++ b/core/kysely/errors.ts
@@ -1,20 +1,24 @@
 import { z } from "zod";
 
+import { databaseTableNames } from "db/table-names";
+
 const PostgresError = z.object({
 	code: z.string(),
 	detail: z.string(),
-	table: z.string(),
+	table: z.enum(databaseTableNames),
 	schema: z.string(),
 	constraint: z.string().optional(),
 });
-type PostgresError = z.infer<typeof PostgresError>;
+export type PostgresError = z.infer<typeof PostgresError>;
 
 export const isPostgresError = (error: unknown): error is PostgresError =>
 	PostgresError.safeParse(error).success;
 
 export const isUniqueConstraintError = (
 	error: unknown
-): error is PostgresError & { code: "23505" } => isPostgresError(error) && error.code === "23505";
+): error is PostgresError & { code: "23505" } => {
+	return isPostgresError(error) && error.code === "23505";
+};
 
 export const isCheckContraintError = (error: unknown): error is PostgresError & { code: "23514" } =>
 	isPostgresError(error) && error.code === "23514";

--- a/core/lib/server/form.ts
+++ b/core/lib/server/form.ts
@@ -209,6 +209,7 @@ export const insertForm = (
 	name: string,
 	slug: string,
 	communityId: CommunitiesId,
+	isDefault: boolean,
 	trx = db
 ) => {
 	return trx
@@ -251,6 +252,7 @@ export const insertForm = (
 					pubTypeId,
 					slug,
 					communityId,
+					isDefault,
 				})
 				.returning(["slug", "id"])
 		)

--- a/core/lib/server/form.ts
+++ b/core/lib/server/form.ts
@@ -2,8 +2,18 @@ import type { QueryCreator } from "kysely";
 
 import { sql } from "kysely";
 import { jsonArrayFrom } from "kysely/helpers/postgres";
+import { componentsBySchema } from "schemas";
 
-import type { CommunitiesId, FormsId, PublicSchema, PubsId, UsersId } from "db/public";
+import type {
+	CommunitiesId,
+	CoreSchemaType,
+	FormsId,
+	InputComponent,
+	PublicSchema,
+	PubsId,
+	PubTypesId,
+	UsersId,
+} from "db/public";
 import { AuthTokenType } from "db/public";
 
 import type { XOR } from "../types";
@@ -12,6 +22,7 @@ import { createMagicLink } from "../authentication/createMagicLink";
 import { autoCache } from "./cache/autoCache";
 import { autoRevalidate } from "./cache/autoRevalidate";
 import { getCommunitySlug } from "./cache/getCommunitySlug";
+import { _getPubFields } from "./pubFields";
 import { getUser } from "./user";
 
 /**
@@ -183,3 +194,89 @@ export const createFormInviteLink = async (props: FormInviteLinkProps) => {
 
 	return magicLink;
 };
+
+const componentsBySchemaTable = Object.entries(componentsBySchema)
+	.map(([schema, components]) => {
+		const component = components[0]
+			? `'${components[0]}'::"InputComponent"`
+			: `null::"InputComponent"`;
+		return `('${schema}'::"CoreSchemaType", ${component})`;
+	})
+	.join(", ");
+
+export const insertForm = (
+	pubTypeId: PubTypesId,
+	name: string,
+	slug: string,
+	communityId: CommunitiesId,
+	trx = db
+) => {
+	return trx
+		.with("components", (db) =>
+			// This lets us set an appropriate default component during creation by turning
+			// the js mapping from schemaName to InputComponent into a temporary table which
+			// can be used during the query. Without this, we would need to first query for
+			// the pubtype's fields (and their schemaNames), then determine the input
+			// components in js before inserting
+			db
+				.selectFrom(
+					sql<{
+						schema: CoreSchemaType;
+						component: InputComponent;
+					}>`(values ${sql.raw(componentsBySchemaTable)})`.as<"c">(
+						sql`c(schema, component)`
+					)
+				)
+				.selectAll("c")
+		)
+		.with("fields", () =>
+			_getPubFields({ pubTypeId, communityId })
+				.clearSelect()
+				.select((eb) => [
+					eb.ref("f.id").as("fieldId"),
+					eb.ref("f.json", "->>").key("name").as("name"),
+					eb
+						.cast<CoreSchemaType>(
+							eb.ref("f.json", "->>").key("schemaName"),
+							sql.raw('"CoreSchemaType"')
+						)
+						.as("schemaName"),
+				])
+		)
+		.with("form", (db) =>
+			db
+				.insertInto("forms")
+				.values({
+					name,
+					pubTypeId,
+					slug,
+					communityId,
+				})
+				.returning(["slug", "id"])
+		)
+
+		.insertInto("form_elements")
+		.columns(["fieldId", "formId", "label", "type", "order", "component"])
+		.expression((eb) =>
+			eb
+				.selectFrom("fields")
+				.innerJoin("form", (join) => join.onTrue())
+				.select((eb) => [
+					"fields.fieldId",
+					"form.id as formId",
+					"fields.name as label",
+					eb.val("pubfield").as("type"),
+					eb.fn
+						.agg<number>("ROW_NUMBER")
+						.over((o) => o.partitionBy("id"))
+						.as("order"),
+					eb
+						.selectFrom("components")
+						.select("component")
+						.whereRef("components.schema", "=", "fields.schemaName")
+						.as("component"),
+				])
+		);
+};
+export const FORM_NAME_UNIQUE_CONSTRAINT = "forms_name_communityId_key";
+export const FORM_SLUG_UNIQUE_CONSTRAINT = "forms_slug_communityId_key";

--- a/core/lib/server/render/pub/renderMarkdownWithPub.ts
+++ b/core/lib/server/render/pub/renderMarkdownWithPub.ts
@@ -17,6 +17,7 @@ import { visit } from "unist-util-visit";
 
 import { expect } from "utils";
 
+import { getPubTitle } from "~/lib/pubs";
 import { RenderWithPubToken } from "./renderWithPubTokens";
 import * as utils from "./renderWithPubUtils";
 
@@ -37,12 +38,19 @@ const visitValueDirective = (node: NodeMdast & Directive, context: utils.RenderW
 	const field = expect(attrs.field, "Missing field attribute in value directive");
 
 	let value: unknown;
+	let pub: utils.RenderWithPubPub;
 
 	if (attrs?.rel === "parent") {
 		const parentPub = expect(context.parentPub, "Missing parent pub");
-		value = parentPub.values[field];
+		pub = parentPub;
 	} else {
-		value = context.pub.values[field];
+		pub = context.pub;
+	}
+
+	if (field === "title") {
+		value = getPubTitle(pub);
+	} else {
+		value = pub.values[field];
 	}
 
 	assert(value !== undefined, `Missing value for ${field}`);

--- a/core/lib/server/render/pub/renderWithPubUtils.ts
+++ b/core/lib/server/render/pub/renderWithPubUtils.ts
@@ -11,6 +11,7 @@ export type RenderWithPubRel = "parent" | "self";
 export type RenderWithPubPub = {
 	id: string;
 	values: Record<string, any>;
+	createdAt: Date;
 	assignee?: {
 		firstName: string;
 		lastName: string | null;

--- a/core/prisma/migrations/20241205192106_unique_pub_type_names/migration.sql
+++ b/core/prisma/migrations/20241205192106_unique_pub_type_names/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name,communityId]` on the table `pub_types` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "pub_types_name_communityId_key" ON "pub_types"("name", "communityId");

--- a/core/prisma/migrations/20241205231134_backfill_default_forms/migration.sql
+++ b/core/prisma/migrations/20241205231134_backfill_default_forms/migration.sql
@@ -1,0 +1,85 @@
+WITH "components" AS (
+    SELECT
+        "c".*
+    FROM (
+        VALUES 
+        ('Boolean'::"CoreSchemaType", 'checkbox'::"InputComponent"),
+        ('String'::"CoreSchemaType", 'textInput'::"InputComponent"),
+        ('DateTime'::"CoreSchemaType", 'datePicker'::"InputComponent"),
+        ('Number'::"CoreSchemaType", 'textInput'::"InputComponent"),
+        ('NumericArray'::"CoreSchemaType", 'multivalueInput'::"InputComponent"),
+        ('StringArray'::"CoreSchemaType", 'multivalueInput'::"InputComponent"),
+        ('Email'::"CoreSchemaType", 'textInput'::"InputComponent"),
+        ('FileUpload'::"CoreSchemaType", 'fileUpload'::"InputComponent"),
+        ('URL'::"CoreSchemaType", 'textInput'::"InputComponent"),
+        ('MemberId'::"CoreSchemaType", 'memberSelect'::"InputComponent"),
+        ('Vector3'::"CoreSchemaType", 'confidenceInterval'::"InputComponent"),
+        ('Null'::"CoreSchemaType", NULL::"InputComponent"),
+        ('RichText'::"CoreSchemaType", 'richText'::"InputComponent")
+    ) AS c("schema", "component")
+),
+"form" AS (
+    INSERT INTO
+        "forms"(
+            "name",
+            "pubTypeId",
+            "slug",
+            "communityId",
+            "isDefault"
+        )
+    SELECT
+        "pub_types"."name" || ' Editor (Default)',
+        "pub_types"."id",
+        -- Rough equivalent to our slugify js function, adapted from https://gist.github.com/abn/779166b0c766ce67351c588489831852
+        trim(
+            BOTH '-'
+            FROM
+                regexp_replace(
+                    lower(trim("pub_types"."name")),
+                    '[^a-z0-9\\-_]+',
+                    '-',
+                    'gi'
+                )
+        ) || '-default-editor',
+        "pub_types"."communityId",
+        TRUE
+    FROM "pub_types"
+    ON CONFLICT DO NOTHING
+    RETURNING 
+        "forms"."slug",
+        "forms"."id",
+        "forms"."pubTypeId"
+),
+"title_element" AS (
+    INSERT INTO
+        "form_elements"("formId", "type", "content", "order", "element")
+    SELECT
+        "form"."id",
+        'structural',
+        '# :value{field="title"}',
+        0,
+        'p'
+    FROM
+        "form"
+)
+INSERT INTO
+    "form_elements"(
+        "fieldId",
+        "formId",
+        "label",
+        "type",
+        "order",
+        "component"
+    )
+SELECT
+    "pub_fields"."id",
+    "form"."id" AS "formId",
+    "pub_fields"."name" AS "label",
+    'pubfield' AS "type",
+    ROW_NUMBER() OVER (PARTITION BY "form"."id") + 1 AS "order",
+    "components"."component"
+FROM
+    "form"
+    INNER JOIN "_PubFieldToPubType" ON "_PubFieldToPubType"."B" = "form"."pubTypeId"
+    INNER JOIN "pub_fields" ON "pub_fields"."id" = "_PubFieldToPubType"."A"
+    INNER JOIN "components" ON "components"."schema" = "pub_fields"."schemaName";

--- a/core/prisma/schema.dbml
+++ b/core/prisma/schema.dbml
@@ -146,6 +146,10 @@ Table pub_types {
   fields _PubFieldToPubType [not null]
   pubs pubs [not null]
   Form forms [not null]
+
+  indexes {
+    (name, communityId) [unique]
+  }
 }
 
 Table _PubFieldToPubType {

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -216,6 +216,7 @@ model PubType {
   pubs   Pub[]
   Form   Form[]
 
+  @@unique([name, communityId])
   @@map(name: "pub_types")
 }
 

--- a/core/prisma/seed/seedCommunity.ts
+++ b/core/prisma/seed/seedCommunity.ts
@@ -29,8 +29,6 @@ import type {
 } from "db/public";
 import {
 	Action as ActionName,
-	ApiAccessScope,
-	ApiAccessType,
 	CoreSchemaType,
 	ElementType,
 	InputComponent,
@@ -45,6 +43,7 @@ import { db } from "~/kysely/database";
 import { createPasswordHash } from "~/lib/authentication/password";
 import { createPubRecursiveNew } from "~/lib/server";
 import { allPermissions, createApiAccessToken } from "~/lib/server/apiAccessTokens";
+import { insertForm } from "~/lib/server/form";
 import { slugifyString } from "~/lib/string";
 
 export type PubFieldsInitializer = Record<
@@ -751,6 +750,19 @@ export async function seedCommunity<
 				.returningAll()
 				.execute()
 		: [];
+
+	await Promise.all(
+		createdPubTypes.map((type) =>
+			insertForm(
+				type.id,
+				`${type.name} Editor (Default)`,
+				`${slugifyString(type.name)}-default-editor`,
+				communityId,
+				true,
+				trx
+			).execute()
+		)
+	);
 
 	const createdPubFieldToPubTypes =
 		pubTypesList.length && pubFieldsList.length


### PR DESCRIPTION
## Issue(s) Resolved
Resolves #782 
Resolves #817 
## High-level Explanation of PR
- Adds a pubtitle directive: `:value{field="title"}` which uses the old pubtitle logic for now
- Adds a unique constraint to prevent duplicate named pub types. This makes it less likely that we'll encounter unique constraint errors when creating the default form
- Updates the form insert query to add a paragraph element with the new title directive as the first form element on new forms
- Factors out and uses the form insert query to automatically create a default form whenever a new pub type is created
- Adds a migration that replicates our default form creation logic for all the existing pub types

## Test Plan
Since the migration occurs before the seed script runs, try resetting your db (or not), then manually running the migration with psql or whatever db client you use. You should see a number of forms created for the existing pub types, which you can then test!

