### PR TITLE
Fix dropdown menuitem styling

### DIFF
--- a/packages/ui/src/dropdown-menu.tsx
+++ b/packages/ui/src/dropdown-menu.tsx
@@ -82,7 +82,7 @@ const DropdownMenuItem = React.forwardRef<
 	<DropdownMenuPrimitive.Item
 		ref={ref}
 		className={cn(
-			"... relative gap-2 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+			"relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-800 dark:focus:text-slate-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
 			inset && "pl-8",
 			className
 		)}


### PR DESCRIPTION
## Issue(s) Resolved
Our dropdown components were looking like 
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/9a7ecb6b-7972-48a3-a468-88ea7fce79ae">
instead of 
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/abbca036-f128-4c25-aa4a-f4542f72542a">
because of an error I made when applying a shadcn update in https://github.com/pubpub/platform/commit/97325861ec81f4964b99d96e2f59cb27f059710f#diff-c611e07f0c0ccb0a999e23be580a30ef339e4f8341df5d11dd33300ad184967fL85

## High-level Explanation of PR
I replaced the `...` with the implied content because I am a human and not a copy-paste robot.