### PR TITLE
Redirect non-members to /settings 

### DIFF
--- a/core/app/c/[communitySlug]/CommunitySwitcher.tsx
+++ b/core/app/c/[communitySlug]/CommunitySwitcher.tsx
@@ -8,11 +8,11 @@ import {
 	DropdownMenuTrigger,
 } from "ui/dropdown-menu";
 
-import type { AvailableCommunitiesData, CommunityData } from "~/lib/server/community";
+import type { CommunityData } from "~/lib/server/community";
 
 type Props = {
 	community: NonNullable<CommunityData>;
-	availableCommunities: NonNullable<AvailableCommunitiesData>;
+	availableCommunities: NonNullable<CommunityData>[];
 };
 
 const CommunitySwitcher: React.FC<Props> = function ({ community, availableCommunities }) {

--- a/core/app/c/[communitySlug]/SideNav.tsx
+++ b/core/app/c/[communitySlug]/SideNav.tsx
@@ -4,7 +4,7 @@ import { Button } from "ui/button";
 import { Activity, FormInput, Menu, RefreshCw, Settings, ToyBrick } from "ui/icon";
 import { Sheet, SheetContent, SheetTrigger } from "ui/sheet";
 
-import type { AvailableCommunitiesData, CommunityData } from "~/lib/server/community";
+import type { CommunityData } from "~/lib/server/community";
 import { getLoginData } from "~/lib/authentication/loginData";
 import { userCan } from "~/lib/authorization/capabilities";
 import CommunitySwitcher from "./CommunitySwitcher";
@@ -13,7 +13,7 @@ import NavLink from "./NavLink";
 
 type Props = {
 	community: NonNullable<CommunityData>;
-	availableCommunities: NonNullable<AvailableCommunitiesData>;
+	availableCommunities: NonNullable<CommunityData>[];
 };
 
 const Links = ({

--- a/core/app/c/[communitySlug]/layout.tsx
+++ b/core/app/c/[communitySlug]/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 
-import { notFound } from "next/navigation";
+import { redirect } from "next/navigation";
 
 import { CommunityProvider } from "~/app/components/providers/CommunityProvider";
 import { getLoginData } from "~/lib/authentication/loginData";
@@ -35,12 +35,12 @@ export default async function MainLayout({ children, params }: Props) {
 
 	const role = getCommunityRole(user, community);
 
-	if (role === "contributor") {
-		// TODO: figure something out for this
-		notFound();
+	if (role === "contributor" || !role) {
+		// TODO: allow contributors to view /c/* pages after we implement membership and
+		// role-based authorization checks
+		redirect("/settings");
 	}
 
-	// const availableCommunities = await getAvailableCommunities(user.id as UsersId);
 	const availableCommunities = user?.memberships.map((m) => m.community) ?? [];
 
 	return (

--- a/core/lib/server/community.ts
+++ b/core/lib/server/community.ts
@@ -1,6 +1,6 @@
 import { cache } from "react";
 
-import type { PubsId, UsersId } from "db/public";
+import type { PubsId } from "db/public";
 
 import { db } from "~/kysely/database";
 import { createCacheTag } from "./cache/cacheTags";
@@ -44,15 +44,3 @@ export const findCommunityByPubId = memoize(
 );
 
 export type CommunityData = Awaited<ReturnType<typeof findCommunityByPubId>>;
-
-// TODO: cache this
-export const getAvailableCommunities = async (userId: UsersId) => {
-	return await db
-		.selectFrom("community_memberships")
-		.where("community_memberships.userId", "=", userId)
-		.innerJoin("communities", "communities.id", "community_memberships.communityId")
-		.selectAll("communities")
-		.execute();
-};
-
-export type AvailableCommunitiesData = Awaited<ReturnType<typeof getAvailableCommunities>>;

--- a/core/playwright/externalFormInvite.spec.ts
+++ b/core/playwright/externalFormInvite.spec.ts
@@ -141,5 +141,18 @@ test.describe("Inviting a new user to fill out a form", () => {
 		await newPage.getByRole("button", { name: "Submit", exact: true }).click();
 
 		await newPage.getByText("Form Successfully Submitted").waitFor();
+
+		// Test authorization for new contributor
+		const pubsPage = new PubsPage(newPage, COMMUNITY_SLUG);
+		await pubsPage.goTo();
+		// User should be redirected to user settings page when viewing the pubs page in the
+		// community they are a contributor of
+		// This should fail/change we implement pub visibility checks
+		expect(await newPage.url()).toMatch(/\/settings$/);
+
+		// Make sure they can't view the pubs page in other communities
+		const unauthorizedPubsPage = new PubsPage(newPage, "croccroc");
+		await unauthorizedPubsPage.goTo();
+		expect(await newPage.url()).toMatch(/\/settings$/);
 	});
 });


### PR DESCRIPTION
## Issue(s) Resolved
Resolves #807 
## High-level Explanation of PR
Previously when a user visited a community page (`/c/*`) we would return 404 if they were a contributor of that community. Now we send them to `/settings`, which should be a better experience since that page is always usable by any user. We also now handle the case where you are not a member of the community at all.

This should also slightly improve the UX in #743 since those users will be sent to the settings page instead of our nonexistent 404 page. The links to communities on that page will just redirect them back to settings for now, but once we implement the rest of our auth checks, we can remove that. 

## Test Plan
There's an e2e test but to test manually:
- As Jill Admin:
    - Visit the community members page
    - Remove none@pubpub.org
    - Logout
- Login as `none@pubpub.org` / `pubpub-none`
- Manually enter the URL for the pubs or stages page of the community you've removed none@ from
- You should be redirected to settings. If you try this procedure on main, or with a contributor user in prod, you will be able to see the page