### PR TITLE
Secure server actions

### DIFF
--- a/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/page.tsx
+++ b/core/app/c/(public)/[communitySlug]/public/forms/[formSlug]/fill/page.tsx
@@ -269,6 +269,7 @@ export default async function FormPage({
 								<ExternalFormWrapper
 									pub={pubForForm}
 									elements={form.elements}
+									formSlug={form.slug}
 									isUpdating={isUpdating}
 									withAutoSave={isUpdating}
 									withButtonElements

--- a/core/app/c/[communitySlug]/stages/components/Assign.tsx
+++ b/core/app/c/[communitySlug]/stages/components/Assign.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useMemo } from "react";
 
+import type { PubsId, UsersId } from "db/public";
 import { Button } from "ui/button";
 import {
 	Command,
@@ -42,7 +43,7 @@ export default function Assign(props: Props) {
 	const runAssign = useServerAction(assign);
 
 	const onAssign = useCallback(
-		async (pubId: string, userId?: string) => {
+		async (pubId: PubsId, userId?: UsersId) => {
 			const error = await runAssign(pubId, userId);
 			if (userId) {
 				const user = expect(users.find((user) => user.id === userId));
@@ -74,7 +75,7 @@ export default function Assign(props: Props) {
 		(value: string) => {
 			const userId = value === selectedUserId ? undefined : value;
 			setSelectedUserId(userId);
-			onAssign(props.pub.id, userId);
+			onAssign(props.pub.id, userId as UsersId);
 			setOpen(false);
 		},
 		[selectedUserId, props.pub.id, onAssign]

--- a/core/app/c/[communitySlug]/stages/components/Move.tsx
+++ b/core/app/c/[communitySlug]/stages/components/Move.tsx
@@ -52,7 +52,7 @@ export default function Move(props: Props) {
 	const [isMoving, startTransition] = useTransition();
 	const runMove = useServerAction(move);
 
-	const onMove = async (pubId: string, sourceStageId: string, destStageId: string) => {
+	const onMove = async (pubId: PubsId, sourceStageId: StagesId, destStageId: StagesId) => {
 		const err = await runMove(pubId, sourceStageId, destStageId);
 
 		if (isClientException(err)) {

--- a/core/app/c/[communitySlug]/stages/manage/components/panel/actionsTab/StagePanelActionEditor.tsx
+++ b/core/app/c/[communitySlug]/stages/manage/components/panel/actionsTab/StagePanelActionEditor.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from "react";
 
-import type { ActionInstances, ActionInstancesId } from "db/public";
+import type { ActionInstances, ActionInstancesId, StagesId } from "db/public";
 import { logger } from "logger";
 import { Button } from "ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "ui/collapsible";
@@ -15,16 +15,17 @@ import * as actions from "../../../actions";
 
 type Props = {
 	actionInstance: ActionInstances;
-	onDelete: (actionInstanceId: ActionInstancesId) => Promise<unknown>;
+	onDelete: (actionInstanceId: ActionInstancesId, stageId: StagesId) => Promise<unknown>;
 	communityId: string;
 	children: React.ReactNode;
+	stageId: StagesId;
 };
 
 export const StagePanelActionEditor = (props: Props) => {
 	const runOnDelete = useServerAction(props.onDelete);
 	const [isOpen, setIsOpen] = useState(false);
 	const onDeleteClick = useCallback(async () => {
-		runOnDelete(props.actionInstance.id);
+		runOnDelete(props.actionInstance.id, props.stageId);
 	}, [props.actionInstance, runOnDelete]);
 	const action = getActionByName(props.actionInstance.action);
 
@@ -51,6 +52,7 @@ export const StagePanelActionEditor = (props: Props) => {
 							onBlur={async (evt) => {
 								await actions.updateAction(
 									props.actionInstance.id as ActionInstancesId,
+									props.stageId,
 									{
 										name: evt.target.value?.trim(),
 									}

--- a/core/app/c/[communitySlug]/stages/manage/components/panel/actionsTab/StagePanelActions.tsx
+++ b/core/app/c/[communitySlug]/stages/manage/components/panel/actionsTab/StagePanelActions.tsx
@@ -53,6 +53,7 @@ const StagePanelActionsInner = async (props: PropsInner) => {
 							actionInstance={actionInstance}
 							onDelete={onDeleteAction}
 							communityId={stage.communityId}
+							stageId={props.stageId}
 						>
 							<Suspense fallback={<SkeletonCard />}>
 								<ActionConfigFormWrapper

--- a/core/app/c/[communitySlug]/stages/manage/components/panel/actionsTab/StagePanelRule.tsx
+++ b/core/app/c/[communitySlug]/stages/manage/components/panel/actionsTab/StagePanelRule.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 
-import type { Action, CommunitiesId, Event, RulesId } from "db/public";
+import type { Action, CommunitiesId, Event, RulesId, StagesId } from "db/public";
 import { Button } from "ui/button";
 import { Trash } from "ui/icon";
 
@@ -13,6 +13,7 @@ import { useServerAction } from "~/lib/serverActions";
 import { deleteRule } from "../../../actions";
 
 type Props = {
+	stageId: StagesId;
 	communityId: CommunitiesId;
 	rule: {
 		id: RulesId;
@@ -32,7 +33,7 @@ export const StagePanelRule = (props: Props) => {
 	const { rule } = props;
 	const runDeleteRule = useServerAction(deleteRule);
 	const onDeleteClick = useCallback(async () => {
-		runDeleteRule(rule.id);
+		runDeleteRule(rule.id, props.stageId);
 	}, [rule.id, props.communityId]);
 
 	return (

--- a/core/app/c/[communitySlug]/stages/manage/components/panel/actionsTab/StagePanelRuleCreator.tsx
+++ b/core/app/c/[communitySlug]/stages/manage/components/panel/actionsTab/StagePanelRuleCreator.tsx
@@ -5,7 +5,13 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-import type { Action, ActionInstances, ActionInstancesId, CommunitiesId } from "db/public";
+import type {
+	Action,
+	ActionInstances,
+	ActionInstancesId,
+	CommunitiesId,
+	StagesId,
+} from "db/public";
 import { Event } from "db/public";
 import { AutoFormObject } from "ui/auto-form";
 import { Button } from "ui/button";
@@ -27,7 +33,7 @@ import { useServerAction } from "~/lib/serverActions";
 import { addRule } from "../../../actions";
 
 type Props = {
-	// onAdd: (event: Event, actionInstanceId: ActionInstancesId) => Promise<unknown>;
+	stageId: StagesId;
 	actionInstances: ActionInstances[];
 	communityId: CommunitiesId;
 	rules: {
@@ -67,16 +73,14 @@ const schema = z.discriminatedUnion("event", [
 export type CreateRuleSchema = z.infer<typeof schema>;
 
 export const StagePanelRuleCreator = (props: Props) => {
-	// const runOnAdd = useServerAction(props.onAdd);
 	const runAddRule = useServerAction(addRule);
 	const [isOpen, setIsOpen] = useState(false);
 	const onSubmit = useCallback(
 		async (data: CreateRuleSchema) => {
 			setIsOpen(false);
-			runAddRule({ data });
-			// runOnAdd(event, actionInstanceId as ActionInstancesId);
+			runAddRule({ stageId: props.stageId, data });
 		},
-		[props.communityId] // [props.onAdd, runOnAdd]
+		[props.communityId]
 	);
 
 	const onOpenChange = useCallback((open: boolean) => {

--- a/core/app/c/[communitySlug]/stages/manage/components/panel/actionsTab/StagePanelRules.tsx
+++ b/core/app/c/[communitySlug]/stages/manage/components/panel/actionsTab/StagePanelRules.tsx
@@ -33,6 +33,7 @@ const StagePanelRulesInner = async (props: PropsInner) => {
 								<>
 									{rules.map((rule) => (
 										<StagePanelRule
+											stageId={stage.id}
 											communityId={stage.communityId as CommunitiesId}
 											rule={rule}
 											key={rule.id}
@@ -46,6 +47,7 @@ const StagePanelRulesInner = async (props: PropsInner) => {
 							)}
 						</div>
 						<StagePanelRuleCreator
+							stageId={stage.id}
 							actionInstances={actionInstances}
 							communityId={stage.communityId}
 							rules={rules}

--- a/core/app/components/ActionUI/ActionConfigForm.tsx
+++ b/core/app/components/ActionUI/ActionConfigForm.tsx
@@ -4,7 +4,7 @@ import type { z } from "zod";
 
 import { startTransition, useCallback } from "react";
 
-import type { ActionInstances, ActionInstancesId, Action as ActionName } from "db/public";
+import type { ActionInstances, ActionInstancesId, Action as ActionName, StagesId } from "db/public";
 import type { FieldConfig } from "ui/auto-form";
 import AutoForm, { AutoFormSubmit } from "ui/auto-form";
 import { toast } from "ui/use-toast";
@@ -18,6 +18,7 @@ export type Props = {
 	instance: ActionInstances;
 	communityId: string;
 	fieldConfig: FieldConfig<any>;
+	stageId: StagesId;
 };
 
 export const ActionConfigForm = (props: Props) => {
@@ -28,9 +29,13 @@ export const ActionConfigForm = (props: Props) => {
 	const onSubmit = useCallback(
 		async (values: z.infer<typeof action.config.schema>) => {
 			startTransition(async () => {
-				const result = await runUpdateAction(props.instance.id as ActionInstancesId, {
-					config: values,
-				});
+				const result = await runUpdateAction(
+					props.instance.id as ActionInstancesId,
+					props.stageId,
+					{
+						config: values,
+					}
+				);
 
 				if (result && "success" in result) {
 					toast({

--- a/core/app/components/ActionUI/ActionConfigFormWrapper.tsx
+++ b/core/app/components/ActionUI/ActionConfigFormWrapper.tsx
@@ -49,6 +49,7 @@ export const ActionConfigFormWrapper = async ({
 					communityId={stage.communityId}
 					actionName={actionInstance.action}
 					fieldConfig={resolvedFieldConfig}
+					stageId={stage.id}
 				/>
 			</TokenProvider>
 		</PubFieldProvider>

--- a/core/app/components/FormBuilder/actions.ts
+++ b/core/app/components/FormBuilder/actions.ts
@@ -9,10 +9,18 @@ import { logger } from "logger";
 import type { FormBuilderSchema } from "./types";
 import { db } from "~/kysely/database";
 import { isUniqueConstraintError } from "~/kysely/errors";
+import { getLoginData } from "~/lib/authentication/loginData";
+import { ApiError } from "~/lib/server";
 import { autoRevalidate } from "~/lib/server/cache/autoRevalidate";
 import { defineServerAction } from "~/lib/server/defineServerAction";
 
 export const saveForm = defineServerAction(async function saveForm(form: FormBuilderSchema) {
+	const loginData = await getLoginData();
+
+	if (!loginData || !loginData.user) {
+		return ApiError.NOT_LOGGED_IN;
+	}
+
 	const { elements, formId, access } = form;
 	//todo: this logic determines what, if any updates to make. that should be determined on the
 	//frontend so we can disable the save button if there are none
@@ -104,6 +112,12 @@ export const saveForm = defineServerAction(async function saveForm(form: FormBui
 });
 
 export const archiveForm = defineServerAction(async function archiveForm(id: FormsId) {
+	const loginData = await getLoginData();
+
+	if (!loginData || !loginData.user) {
+		return ApiError.NOT_LOGGED_IN;
+	}
+
 	try {
 		await autoRevalidate(
 			db.updateTable("forms").set({ isArchived: true }).where("forms.id", "=", id)
@@ -114,6 +128,12 @@ export const archiveForm = defineServerAction(async function archiveForm(id: For
 });
 
 export const restoreForm = defineServerAction(async function unarchiveForm(id: FormsId) {
+	const loginData = await getLoginData();
+
+	if (!loginData || !loginData.user) {
+		return ApiError.NOT_LOGGED_IN;
+	}
+
 	try {
 		await autoRevalidate(
 			db.updateTable("forms").set({ isArchived: false }).where("forms.id", "=", id)

--- a/core/app/components/forms/actions.ts
+++ b/core/app/components/forms/actions.ts
@@ -4,7 +4,8 @@ import type { CommunitiesId, FormsId, PubsId } from "db/public";
 import { logger } from "logger";
 
 import type { XOR } from "~/lib/types";
-import { generateSignedAssetUploadUrl } from "~/lib/server";
+import { getLoginData } from "~/lib/authentication/loginData";
+import { ApiError, generateSignedAssetUploadUrl } from "~/lib/server";
 import { findCommunityBySlug } from "~/lib/server/community";
 import { defineServerAction } from "~/lib/server/defineServerAction";
 import * as Email from "~/lib/server/email";
@@ -12,6 +13,12 @@ import { createFormInviteLink, getForm, userHasPermissionToForm } from "~/lib/se
 import { TokenFailureReason, validateTokenSafe } from "~/lib/server/token";
 
 export const upload = defineServerAction(async function upload(pubId: string, fileName: string) {
+	const loginData = await getLoginData();
+	if (!loginData || !loginData.user) {
+		return ApiError.NOT_LOGGED_IN;
+	}
+	// TODO: authorization check?
+
 	return await generateSignedAssetUploadUrl(pubId as PubsId, fileName);
 });
 

--- a/core/app/components/pubs/PubEditor/PubEditor.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditor.tsx
@@ -174,10 +174,11 @@ export async function PubEditor(props: PubEditorProps) {
 					elements={[...form.elements, ...pubOnlyElementDefinitions]}
 					parentId={"parentId" in props ? props.parentId : undefined}
 					pub={pubForForm}
+					formSlug={form.slug}
 					isUpdating={isUpdating}
 					withAutoSave={false}
 					withButtonElements={false}
-					formId={props.formId}
+					htmlFormId={props.formId}
 					stageId={currentStageId}
 				>
 					<>

--- a/core/app/components/pubs/PubEditor/PubEditorClient.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditorClient.tsx
@@ -161,7 +161,10 @@ export interface PubEditorClientProps {
 		isAutoSave: boolean;
 	}) => void;
 	stageId?: StagesId;
-	formId?: string;
+	/** Slug of the Form this editor is using */
+	formSlug: string;
+	/** ID for the HTML form */
+	htmlFormId?: string;
 	parentId?: PubsId;
 	className?: string;
 	withAutoSave?: boolean;
@@ -175,8 +178,9 @@ export const PubEditorClient = ({
 	isUpdating,
 	pub,
 	stageId,
-	formId,
+	htmlFormId,
 	parentId,
+	formSlug,
 	withAutoSave,
 	withButtonElements,
 	onSuccess,
@@ -240,6 +244,7 @@ export const PubEditorClient = ({
 					pubId: pubId,
 					pubValues,
 					stageId,
+					formSlug,
 					continueOnValidationError: autoSave,
 				});
 			} else {
@@ -326,7 +331,7 @@ export const PubEditorClient = ({
 				}
 				onSubmit={formInstance.handleSubmit(handleSubmit)}
 				className={cn("relative isolate flex flex-col gap-6", className)}
-				id={formId}
+				id={htmlFormId}
 			>
 				{children}
 				{withButtonElements ? (

--- a/core/app/components/pubs/PubEditor/actions.db.test.ts
+++ b/core/app/components/pubs/PubEditor/actions.db.test.ts
@@ -5,7 +5,8 @@ import { CoreSchemaType, MemberRole } from "db/public";
 
 import { mockServerCode } from "~/lib/__tests__/utils";
 
-const { createForEachMockedTransaction, getLoginData } = await mockServerCode();
+const { createForEachMockedTransaction, getLoginData, findCommunityBySlug } =
+	await mockServerCode();
 
 const { getTrx } = createForEachMockedTransaction();
 
@@ -86,6 +87,88 @@ describe("createPubRecursive", () => {
 				},
 			},
 			trx,
+		});
+		expect(result).toMatchObject(expected);
+	});
+});
+
+describe.only("updatePub", () => {
+	test.each([
+		{
+			name: "Needs a logged in user",
+			loginUser: undefined,
+			userRole: MemberRole.admin,
+			expected: { error: "Not logged in" },
+		},
+		{
+			name: "Needs an authorized user",
+			loginUser: { id: crypto.randomUUID() as UsersId },
+			userRole: MemberRole.contributor,
+			expected: { error: "You are not authorized to perform this action" },
+		},
+		{
+			name: "Can update if all permissions are satisfied",
+			loginUser: { id: crypto.randomUUID() as UsersId },
+			userRole: MemberRole.admin,
+			expected: [
+				{
+					value: "new title",
+				},
+			],
+		},
+	])("$name", async ({ loginUser, userRole, expected }) => {
+		const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
+		const { community, pubs, users } = await seedCommunity({
+			community: {
+				name: "test",
+				slug: "test-actions-create-pub",
+			},
+			pubFields: {
+				Title: { schemaName: CoreSchemaType.String },
+				Description: { schemaName: CoreSchemaType.String },
+			},
+			pubTypes: {
+				"Minimal Pub": {
+					Title: { isTitle: true },
+				},
+			},
+			stages: {
+				"Stage 1": {},
+			},
+			pubs: [
+				{
+					pubType: "Minimal Pub",
+					values: {
+						Title: "Some title",
+					},
+					stage: "Stage 1",
+				},
+			],
+			users: {
+				john: {
+					id: loginUser ? loginUser.id : undefined,
+					firstName: "John",
+					role: userRole,
+					password: "john-password",
+					email: "john@example.com",
+				},
+			},
+		});
+		getLoginData.mockImplementation(() => {
+			return { user: loginUser ? { id: users.john.id } : undefined };
+		});
+		findCommunityBySlug.mockImplementation(() => {
+			return community;
+		});
+
+		const { updatePub } = await import("./actions");
+
+		const result = await updatePub({
+			pubId: pubs[0].id,
+			pubValues: {
+				[`${community.slug}:title`]: "new title",
+			},
+			continueOnValidationError: false,
 		});
 		expect(result).toMatchObject(expected);
 	});

--- a/core/app/components/pubs/PubEditor/actions.db.test.ts
+++ b/core/app/components/pubs/PubEditor/actions.db.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import { CoreSchemaType, MemberRole } from "db/public";
+
+import type { ClientException } from "~/lib/serverActions";
+import { mockServerCode } from "~/lib/__tests__/utils";
+import { isClientException } from "~/lib/serverActions";
+
+const { createForEachMockedTransaction, getLoginData } = await mockServerCode();
+
+const { getTrx } = createForEachMockedTransaction();
+
+describe("createPubRecursive", () => {
+	it("Needs a logged in user", async () => {
+		const trx = getTrx();
+		getLoginData.mockImplementation(() => {
+			return undefined;
+		});
+		const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
+		const { community, pubTypes } = await seedCommunity({
+			community: {
+				name: "test",
+				slug: "test-server-pub",
+			},
+			pubFields: {
+				Title: { schemaName: CoreSchemaType.String },
+				Description: { schemaName: CoreSchemaType.String },
+			},
+			pubTypes: {
+				"Minimal Pub": {
+					Title: { isTitle: true },
+				},
+			},
+			stages: {
+				"Stage 1": {},
+			},
+			pubs: [
+				{
+					pubType: "Minimal Pub",
+					values: {
+						Title: "Some title",
+					},
+					stage: "Stage 1",
+				},
+			],
+			users: {},
+		});
+
+		const { createPubRecursive } = await import("./actions");
+
+		const result = await createPubRecursive({
+			communityId: community.id,
+			body: {
+				pubTypeId: pubTypes["Minimal Pub"].id,
+				values: {
+					[`${community.slug}:title`]: "test title",
+				},
+			},
+			trx,
+		});
+
+		expect(isClientException(result)).toBeTruthy();
+		expect((result as ClientException).error).toEqual("Not logged in");
+	});
+
+	it("Needs an authorized user", async () => {
+		const trx = getTrx();
+		const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
+		const { community, pubTypes, users } = await seedCommunity({
+			community: {
+				name: "test",
+				slug: "test-server-pub",
+			},
+			pubFields: {
+				Title: { schemaName: CoreSchemaType.String },
+				Description: { schemaName: CoreSchemaType.String },
+			},
+			pubTypes: {
+				"Minimal Pub": {
+					Title: { isTitle: true },
+				},
+			},
+			stages: {
+				"Stage 1": {},
+			},
+			pubs: [
+				{
+					pubType: "Minimal Pub",
+					values: {
+						Title: "Some title",
+					},
+					stage: "Stage 1",
+				},
+			],
+			users: {
+				john: {
+					firstName: "John",
+					role: MemberRole.contributor,
+					password: "john-password",
+					email: "john@example.com",
+				},
+			},
+		});
+		getLoginData.mockImplementation(() => {
+			return { user: { id: users.john.id } };
+		});
+
+		const { createPubRecursive } = await import("./actions");
+
+		const result = await createPubRecursive({
+			communityId: community.id,
+			body: {
+				pubTypeId: pubTypes["Minimal Pub"].id,
+				values: {
+					[`${community.slug}:title`]: "test title",
+				},
+			},
+			trx,
+		});
+
+		expect(isClientException(result)).toBeTruthy();
+		expect((result as ClientException).error).toEqual(
+			"You are not authorized to perform this action"
+		);
+	});
+
+	it("Can create if all permissions are satisfied", async () => {
+		const trx = getTrx();
+		const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
+		const { community, pubTypes, users } = await seedCommunity({
+			community: {
+				name: "test",
+				slug: "test-server-pub",
+			},
+			pubFields: {
+				Title: { schemaName: CoreSchemaType.String },
+				Description: { schemaName: CoreSchemaType.String },
+			},
+			pubTypes: {
+				"Minimal Pub": {
+					Title: { isTitle: true },
+				},
+			},
+			stages: {
+				"Stage 1": {},
+			},
+			pubs: [
+				{
+					pubType: "Minimal Pub",
+					values: {
+						Title: "Some title",
+					},
+					stage: "Stage 1",
+				},
+			],
+			users: {
+				john: {
+					firstName: "John",
+					role: MemberRole.admin,
+					password: "john-password",
+					email: "john@example.com",
+				},
+			},
+		});
+		getLoginData.mockImplementation(() => {
+			return { user: { id: users.john.id } };
+		});
+
+		const { createPubRecursive } = await import("./actions");
+
+		const result = await createPubRecursive({
+			communityId: community.id,
+			body: {
+				pubTypeId: pubTypes["Minimal Pub"].id,
+				values: {
+					[`${community.slug}:title`]: "test title",
+				},
+			},
+			trx,
+		});
+
+		expect(result).toMatchObject({
+			report: "Successfully created a new Pub",
+			success: true,
+		});
+	});
+});

--- a/core/app/components/pubs/PubEditor/actions.db.test.ts
+++ b/core/app/components/pubs/PubEditor/actions.db.test.ts
@@ -1,75 +1,44 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 
+import type { UsersId } from "db/public";
 import { CoreSchemaType, MemberRole } from "db/public";
 
-import type { ClientException } from "~/lib/serverActions";
 import { mockServerCode } from "~/lib/__tests__/utils";
-import { isClientException } from "~/lib/serverActions";
 
 const { createForEachMockedTransaction, getLoginData } = await mockServerCode();
 
 const { getTrx } = createForEachMockedTransaction();
 
 describe("createPubRecursive", () => {
-	it("Needs a logged in user", async () => {
-		const trx = getTrx();
-		getLoginData.mockImplementation(() => {
-			return undefined;
-		});
-		const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
-		const { community, pubTypes } = await seedCommunity({
-			community: {
-				name: "test",
-				slug: "test-server-pub",
+	test.each([
+		{
+			name: "Needs a logged in user",
+			loginUser: undefined,
+			userRole: MemberRole.admin,
+			expected: { error: "Not logged in" },
+		},
+		{
+			name: "Needs an authorized user",
+			loginUser: { id: crypto.randomUUID() as UsersId },
+			userRole: MemberRole.contributor,
+			expected: { error: "You are not authorized to perform this action" },
+		},
+		{
+			name: "Can create if all permissions are satisfied",
+			loginUser: { id: crypto.randomUUID() as UsersId },
+			userRole: MemberRole.admin,
+			expected: {
+				report: "Successfully created a new Pub",
+				success: true,
 			},
-			pubFields: {
-				Title: { schemaName: CoreSchemaType.String },
-				Description: { schemaName: CoreSchemaType.String },
-			},
-			pubTypes: {
-				"Minimal Pub": {
-					Title: { isTitle: true },
-				},
-			},
-			stages: {
-				"Stage 1": {},
-			},
-			pubs: [
-				{
-					pubType: "Minimal Pub",
-					values: {
-						Title: "Some title",
-					},
-					stage: "Stage 1",
-				},
-			],
-			users: {},
-		});
-
-		const { createPubRecursive } = await import("./actions");
-
-		const result = await createPubRecursive({
-			communityId: community.id,
-			body: {
-				pubTypeId: pubTypes["Minimal Pub"].id,
-				values: {
-					[`${community.slug}:title`]: "test title",
-				},
-			},
-			trx,
-		});
-
-		expect(isClientException(result)).toBeTruthy();
-		expect((result as ClientException).error).toEqual("Not logged in");
-	});
-
-	it("Needs an authorized user", async () => {
+		},
+	])("$name", async ({ loginUser, userRole, expected }) => {
 		const trx = getTrx();
 		const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
 		const { community, pubTypes, users } = await seedCommunity({
 			community: {
 				name: "test",
-				slug: "test-server-pub",
+				slug: "test-actions-create-pub",
 			},
 			pubFields: {
 				Title: { schemaName: CoreSchemaType.String },
@@ -94,15 +63,16 @@ describe("createPubRecursive", () => {
 			],
 			users: {
 				john: {
+					id: loginUser ? loginUser.id : undefined,
 					firstName: "John",
-					role: MemberRole.contributor,
+					role: userRole,
 					password: "john-password",
 					email: "john@example.com",
 				},
 			},
 		});
 		getLoginData.mockImplementation(() => {
-			return { user: { id: users.john.id } };
+			return { user: loginUser ? { id: users.john.id } : undefined };
 		});
 
 		const { createPubRecursive } = await import("./actions");
@@ -117,71 +87,6 @@ describe("createPubRecursive", () => {
 			},
 			trx,
 		});
-
-		expect(isClientException(result)).toBeTruthy();
-		expect((result as ClientException).error).toEqual(
-			"You are not authorized to perform this action"
-		);
-	});
-
-	it("Can create if all permissions are satisfied", async () => {
-		const trx = getTrx();
-		const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
-		const { community, pubTypes, users } = await seedCommunity({
-			community: {
-				name: "test",
-				slug: "test-server-pub",
-			},
-			pubFields: {
-				Title: { schemaName: CoreSchemaType.String },
-				Description: { schemaName: CoreSchemaType.String },
-			},
-			pubTypes: {
-				"Minimal Pub": {
-					Title: { isTitle: true },
-				},
-			},
-			stages: {
-				"Stage 1": {},
-			},
-			pubs: [
-				{
-					pubType: "Minimal Pub",
-					values: {
-						Title: "Some title",
-					},
-					stage: "Stage 1",
-				},
-			],
-			users: {
-				john: {
-					firstName: "John",
-					role: MemberRole.admin,
-					password: "john-password",
-					email: "john@example.com",
-				},
-			},
-		});
-		getLoginData.mockImplementation(() => {
-			return { user: { id: users.john.id } };
-		});
-
-		const { createPubRecursive } = await import("./actions");
-
-		const result = await createPubRecursive({
-			communityId: community.id,
-			body: {
-				pubTypeId: pubTypes["Minimal Pub"].id,
-				values: {
-					[`${community.slug}:title`]: "test title",
-				},
-			},
-			trx,
-		});
-
-		expect(result).toMatchObject({
-			report: "Successfully created a new Pub",
-			success: true,
-		});
+		expect(result).toMatchObject(expected);
 	});
 });

--- a/core/app/components/pubs/PubEditor/actions.db.test.ts
+++ b/core/app/components/pubs/PubEditor/actions.db.test.ts
@@ -92,7 +92,7 @@ describe("createPubRecursive", () => {
 	});
 });
 
-describe.only("updatePub", () => {
+describe("updatePub", () => {
 	test.each([
 		{
 			name: "Needs a logged in user",

--- a/core/app/components/pubs/PubEditor/actions.ts
+++ b/core/app/components/pubs/PubEditor/actions.ts
@@ -75,7 +75,7 @@ export const updatePub = defineServerAction(async function updatePub({
 		return ApiError.COMMUNITY_NOT_FOUND;
 	}
 
-	const canUpdate = userCan(
+	const canUpdate = await userCan(
 		Capabilities.updatePubValues,
 		{ type: MembershipType.pub, pubId },
 		loginData.user.id

--- a/core/app/components/pubs/PubEditor/actions.ts
+++ b/core/app/components/pubs/PubEditor/actions.ts
@@ -125,6 +125,22 @@ export const removePub = defineServerAction(async function removePub({
 
 	const { user } = loginData;
 
+	const community = await findCommunityBySlug();
+
+	if (!community) {
+		return ApiError.COMMUNITY_NOT_FOUND;
+	}
+
+	const authorized = await userCan(
+		Capabilities.deletePub,
+		{ type: MembershipType.pub, pubId },
+		loginData.user.id
+	);
+
+	if (!authorized) {
+		return ApiError.UNAUTHORIZED;
+	}
+
 	const pub = await db
 		.selectFrom("pubs")
 		.selectAll()

--- a/core/app/components/pubs/PubEditor/actions.ts
+++ b/core/app/components/pubs/PubEditor/actions.ts
@@ -78,6 +78,9 @@ export const updatePub = defineServerAction(async function updatePub({
 		return ApiError.COMMUNITY_NOT_FOUND;
 	}
 
+	/** TODO: This allows anyone who has permission to the form to update any pub with the form.
+	 * We need a way to restrict someone who is editing via an external form by pub id
+	 */
 	const canUpdateFromForm = formSlug
 		? await userHasPermissionToForm({ formSlug, userId: loginData.user.id })
 		: false;

--- a/core/lib/__tests__/utils.ts
+++ b/core/lib/__tests__/utils.ts
@@ -71,12 +71,13 @@ export class Deferred<T> {
 }
 
 export const mockServerCode = async () => {
-	const { getLoginData, testDb } = await vi.hoisted(async () => {
+	const { getLoginData, findCommunityBySlug, testDb } = await vi.hoisted(async () => {
 		const testDb = await import("./db").then((m) => m.testDb);
 
 		return {
 			testDb,
 			getLoginData: vi.fn(),
+			findCommunityBySlug: vi.fn(),
 		};
 	});
 
@@ -95,6 +96,12 @@ export const mockServerCode = async () => {
 	vi.mock("~/lib/authentication/loginData", () => {
 		return {
 			getLoginData: getLoginData,
+		};
+	});
+
+	vi.mock("~/lib/server/community", () => {
+		return {
+			findCommunityBySlug: findCommunityBySlug,
 		};
 	});
 
@@ -175,6 +182,7 @@ export const mockServerCode = async () => {
 
 	return {
 		getLoginData,
+		findCommunityBySlug,
 		beginTransaction,
 		testDb,
 		createSingleMockedTransaction,

--- a/core/lib/server/errors.ts
+++ b/core/lib/server/errors.ts
@@ -151,7 +151,7 @@ export const tsRestHandleErrors = (error: unknown, req: TsRestRequest): TsRestRe
 };
 
 export const ApiError = {
-	UNAUTHORIZED: { error: "You are not authorized to perform this action" },
+	UNAUTHORIZED: { title: "Unauthorized", error: "You are not authorized to perform this action" },
 	NOT_LOGGED_IN: { error: "Not logged in" },
 	COMMUNITY_NOT_FOUND: { error: "Community not found" },
 	PUB_NOT_FOUND: { error: "Pub not found" },

--- a/core/lib/server/errors.ts
+++ b/core/lib/server/errors.ts
@@ -149,3 +149,10 @@ export const tsRestHandleErrors = (error: unknown, req: TsRestRequest): TsRestRe
 		}
 	);
 };
+
+export const ApiError = {
+	UNAUTHORIZED: { error: "You are not authorized to perform this action" },
+	NOT_LOGGED_IN: { error: "Not logged in" },
+	COMMUNITY_NOT_FOUND: { error: "Community not found" },
+	PUB_NOT_FOUND: { error: "Pub not found" },
+};


### PR DESCRIPTION
## Issue(s) Resolved
Closes https://github.com/pubpub/platform/issues/758

## High-level Explanation of PR
All actions should now at the minimum do an authentication check that the user is logged in. 

I added authorization checks too where I could, though please check my assumptions! There were some I was not sure about, namely:

* Actions
* Rules
* Move constraints

I also haven't added the ones to the form builder yet since `userCan` does not cover the form memberships table yet, and I wasn't sure if that had to be specced out more or if there was another ticket for it?

## Test Plan

Honestly I'm not sure the best way to test it—probably make users of different roles and try out the actions? I wrote a few unit tests, and the "Inviting a new user to fill out a form" E2E test was good for testing a new user who only had access to a form.

## Screenshots (if applicable)

## Notes
