### PR TITLE
Make login redirect work again and remove login notice

### DIFF
--- a/core/app/(user)/communities/page.tsx
+++ b/core/app/(user)/communities/page.tsx
@@ -1,17 +1,12 @@
-import React from "react";
-
 import type { TableCommunity } from "./getCommunityTableColumns";
 import { db } from "~/kysely/database";
-import { getLoginData } from "~/lib/authentication/loginData";
+import { getPageLoginData } from "~/lib/authentication/loginData";
 import { AddCommunity } from "./AddCommunityDialog";
 import { CommunityTable } from "./CommunityTable";
 
 export default async function Page() {
-	const { user } = await getLoginData();
+	const { user } = await getPageLoginData();
 
-	if (!user) {
-		return null;
-	}
 	if (!user.isSuperAdmin) {
 		return null;
 	}

--- a/core/app/(user)/login/page.tsx
+++ b/core/app/(user)/login/page.tsx
@@ -1,10 +1,7 @@
-import { headers } from "next/headers";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { getLoginData } from "~/lib/authentication/loginData";
 import LoginForm from "./LoginForm";
-import { Notice } from "./Notice";
 
 export default async function Login({
 	searchParams,
@@ -14,7 +11,7 @@ export default async function Login({
 	};
 }) {
 	const { user } = await getLoginData();
-	// if user and no commuhnmitiy, redirect to settings
+
 	if (user?.id) {
 		const firstSlug = user.memberships[0]?.community?.slug;
 
@@ -28,25 +25,6 @@ export default async function Login({
 	return (
 		<div className="mx-auto max-w-sm">
 			<LoginForm />
-			<Notice
-				variant={searchParams.error ? "destructive" : "default"}
-				title={searchParams.error ? "Error" : "Login system update"}
-				description={
-					searchParams?.error || (
-						<p>
-							We've migrated our login system. If you have trouble logging in, you
-							need to reset your password.{" "}
-							<Link
-								href="/forgot"
-								className="font-medium underline underline-offset-4"
-							>
-								Click here
-							</Link>{" "}
-							and we'll send you a password reset email.
-						</p>
-					)
-				}
-			/>
 			{/* <div className="text-gray-600 text-center mt-6">
 				Don't have an account?{" "}
 				<Link

--- a/core/app/(user)/settings/page.tsx
+++ b/core/app/(user)/settings/page.tsx
@@ -1,20 +1,16 @@
 import Link from "next/link";
-import { notFound } from "next/navigation";
 
 import { Avatar, AvatarFallback, AvatarImage } from "ui/avatar";
 import { Button } from "ui/button";
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "ui/card";
 
 import LogoutButton from "~/app/components/LogoutButton";
-import { getLoginData } from "~/lib/authentication/loginData";
+import { getPageLoginData } from "~/lib/authentication/loginData";
 import { ResetPasswordButton } from "./ResetPasswordButton";
 import { UserInfoForm } from "./UserInfoForm";
 
 export default async function Page() {
-	const { user } = await getLoginData();
-	if (!user) {
-		return notFound();
-	}
+	const { user } = await getPageLoginData();
 
 	return (
 		<main className="flex min-h-[calc(100vh_-_theme(spacing.16))] flex-1 flex-col gap-4 p-4 md:gap-8 md:p-10">

--- a/core/app/c/[communitySlug]/layout.tsx
+++ b/core/app/c/[communitySlug]/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { CommunityProvider } from "~/app/components/providers/CommunityProvider";
-import { getLoginData } from "~/lib/authentication/loginData";
+import { getPageLoginData } from "~/lib/authentication/loginData";
 import { getCommunityRole } from "~/lib/authentication/roles";
 import { findCommunityBySlug } from "~/lib/server/community";
 import SideNav from "./SideNav";
@@ -26,7 +26,7 @@ export async function generateMetadata({
 }
 
 export default async function MainLayout({ children, params }: Props) {
-	const { user } = await getLoginData();
+	const { user } = await getPageLoginData();
 
 	const community = await findCommunityBySlug(params.communitySlug);
 	if (!community) {

--- a/core/app/page.tsx
+++ b/core/app/page.tsx
@@ -1,9 +1,9 @@
 import { redirect } from "next/navigation";
 
-import { getLoginData } from "~/lib/authentication/loginData";
+import { getPageLoginData } from "~/lib/authentication/loginData";
 
 export default async function Page() {
-	const { user } = await getLoginData();
+	const { user } = await getPageLoginData();
 
 	// if user and no commuhnmitiy, redirect to settings
 	if (!user) {


### PR DESCRIPTION
## Issue(s) Resolved
Non-logged in users were always being sent to `https://app.pubpub.org/settings` which returns the next default error page - a significantly worse experience than before. Now they should get redirected to /login with the appropriate redirect param.

I also deleted the lucia migration notice because it's been a while!
## High-level Explanation of PR
I made sure to use `getPageLoginData` anywhere that we'd like a login redirect to happen for unauthenticated users!

## Test Plan
Visit localhost:3000/c/unjournal/stages locally without being logged in. You should be redirected to the login page