### PR TITLE
fix: allow updates to DateTime CoreSchemaType values through the API

### DIFF
--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -42,7 +42,7 @@ import { parseRichTextForPubFieldsAndRelatedPubs } from "../fields/richText";
 import { mergeSlugsWithFields } from "../fields/utils";
 import { autoCache } from "./cache/autoCache";
 import { autoRevalidate } from "./cache/autoRevalidate";
-import { NotFoundError } from "./errors";
+import { BadRequestError, NotFoundError } from "./errors";
 import { getPubFields } from "./pubFields";
 import { getPubTypeBase } from "./pubtype";
 import { SAFE_USER_SELECT } from "./user";
@@ -683,7 +683,7 @@ const validatePubValues = async <T extends { slug: string; value: unknown }>({
 		);
 	}
 
-	throw new Error(validationErrors.map(({ error }) => error).join(" "));
+	throw new BadRequestError(validationErrors.map(({ error }) => error).join(" "));
 };
 
 type AddPubRelationsInput = { value: unknown; slug: string } & XOR<

--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -21,7 +21,6 @@ import type {
 import type { Database } from "db/Database";
 import type {
 	CommunitiesId,
-	CoreSchemaType,
 	MemberRole,
 	PubFieldsId,
 	Pubs,
@@ -33,6 +32,7 @@ import type {
 	StagesId,
 	UsersId,
 } from "db/public";
+import { CoreSchemaType } from "db/public";
 import { assert, expect } from "utils";
 
 import type { MaybeHas, Prettify, XOR } from "../types";
@@ -652,6 +652,30 @@ const getFieldInfoForSlugs = async ({
 	}));
 };
 
+/**
+ * This should maybe go somewhere else
+ */
+const hydratePubValues = <T extends { slug: string; value: unknown; schemaName: CoreSchemaType }>(
+	pubValues: T[]
+) => {
+	return pubValues.map(({ value, schemaName, slug, ...rest }) => {
+		if (schemaName === CoreSchemaType.DateTime) {
+			try {
+				value = new Date(value as string);
+			} catch {
+				throw new BadRequestError(`Invalid date value for field ${slug}`);
+			}
+		}
+
+		return {
+			slug,
+			schemaName,
+			value,
+			...rest,
+		};
+	});
+};
+
 const validatePubValues = async <T extends { slug: string; value: unknown }>({
 	pubValues,
 	communityId,
@@ -671,14 +695,16 @@ const validatePubValues = async <T extends { slug: string; value: unknown }>({
 
 	const mergedPubFields = mergeSlugsWithFields(pubValues, relevantPubFields);
 
-	const validationErrors = validatePubValuesBySchemaName(mergedPubFields);
+	const hydratedPubValues = hydratePubValues(mergedPubFields);
+
+	const validationErrors = validatePubValuesBySchemaName(hydratedPubValues);
 
 	if (!validationErrors.length) {
-		return mergedPubFields;
+		return hydratedPubValues;
 	}
 
 	if (continueOnValidationError) {
-		return mergedPubFields.filter(
+		return hydratedPubValues.filter(
 			({ slug }) => !validationErrors.find(({ slug: errorSlug }) => errorSlug === slug)
 		);
 	}

--- a/core/lib/server/validateFields.ts
+++ b/core/lib/server/validateFields.ts
@@ -14,19 +14,23 @@ const validateAgainstContextEditorSchema = (value: unknown) => {
 	}
 };
 
+const createValidationError = (slug: string, schemaName: CoreSchemaType, value: unknown) => {
+	return {
+		slug,
+		error: `Field "${slug}" of type "${schemaName}" failed schema validation. Field "${slug}" of type "${schemaName}" cannot be assigned to value: ${value} of type ${typeof value}.`,
+	};
+};
+
 export const validatePubValuesBySchemaName = (
 	values: { slug: string; value: unknown; schemaName: CoreSchemaType }[]
 ) => {
 	const errors: { slug: string; error: string }[] = [];
-	for (const { slug, value, schemaName } of values) {
+	for (let { slug, value, schemaName } of values) {
 		if (schemaName === CoreSchemaType.RichText) {
 			const result = validateAgainstContextEditorSchema(value);
 
 			if (!result) {
-				errors.push({
-					slug,
-					error: `Field "${slug}" of type "${schemaName}" failed schema validation. Field "${slug}" of type "${schemaName}" cannot be assigned to value: ${value} of type ${typeof value}.`,
-				});
+				errors.push(createValidationError(slug, schemaName, value));
 			}
 			continue;
 		}
@@ -35,10 +39,7 @@ export const validatePubValuesBySchemaName = (
 		const result = Value.Check(jsonSchema, value);
 
 		if (!result) {
-			errors.push({
-				slug,
-				error: `Field "${slug}" of type "${schemaName}" failed schema validation. Field "${slug}" of type "${schemaName}" cannot be assigned to value: ${value} of type ${typeof value}.`,
-			});
+			errors.push(createValidationError(slug, schemaName, value));
 		}
 	}
 

--- a/core/lib/server/validateFields.ts
+++ b/core/lib/server/validateFields.ts
@@ -25,7 +25,7 @@ export const validatePubValuesBySchemaName = (
 			if (!result) {
 				errors.push({
 					slug,
-					error: `Field ${slug} failed schema validation. Field of type "${slug}" cannot be assigned to value: ${value} of type ${typeof value}.`,
+					error: `Field "${slug}" of type "${schemaName}" failed schema validation. Field "${slug}" of type "${schemaName}" cannot be assigned to value: ${value} of type ${typeof value}.`,
 				});
 			}
 			continue;
@@ -37,7 +37,7 @@ export const validatePubValuesBySchemaName = (
 		if (!result) {
 			errors.push({
 				slug,
-				error: `Field ${slug} failed schema validation. Field of type "${slug}" cannot be assigned to value: ${value} of type ${typeof value}.`,
+				error: `Field "${slug}" of type "${schemaName}" failed schema validation. Field "${slug}" of type "${schemaName}" cannot be assigned to value: ${value} of type ${typeof value}.`,
 			});
 		}
 	}


### PR DESCRIPTION
- **fix: throw clearer errors on validation error**
- **fix: allow you to use dates in api**

## Issue(s) Resolved

Resolves #837

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->

When passing pubfields through `validatePubFields`, i add a manual check for date fields and hydrate them.

I also made validation errors slightly more clear.

## Test Plan

1. Send an api request like
```
POST /api/v0/c/arcadia-research/site/pubs
PREFER return=representation
{ 
   "pubTypeId": <find a pubtype>,
  "values": { "arcadia-research:created-at": "2012-07-09" }
}
```

You should be able to do it!

Ideally also test for `PATCH /pubs` and `PUT/PATCH pubs/relations`, but they all use the same function so should work.

## Screenshots (if applicable)

## Notes
