### PR TITLE
fix: allow adding relation fields to pubtype

### DIFF
--- a/core/app/c/[communitySlug]/types/FieldSelect.tsx
+++ b/core/app/c/[communitySlug]/types/FieldSelect.tsx
@@ -22,7 +22,8 @@ export type FieldSelectProps = {
 		fieldId: PubFieldsId,
 		name: string,
 		slug: string,
-		schemaName: CoreSchemaType | null
+		schemaName: CoreSchemaType | null,
+		isRelation?: boolean | null
 	) => void;
 	modal?: boolean;
 };
@@ -36,7 +37,7 @@ export function FieldSelect({ excludedFields, onFieldSelect, modal = false }: Fi
 	);
 	const onSelect = (fieldId: PubFieldsId) => {
 		const field = fields[fieldId];
-		onFieldSelect(fieldId, field.name, field.slug, field.schemaName);
+		onFieldSelect(fieldId, field.name, field.slug, field.schemaName, field.isRelation);
 		setOpen(false);
 	};
 

--- a/core/app/c/[communitySlug]/types/TypeBlock.tsx
+++ b/core/app/c/[communitySlug]/types/TypeBlock.tsx
@@ -30,14 +30,21 @@ const IsTitleCell = ({
 	pubField,
 	isEditing,
 	isTitle,
+	pubTypeName,
 }: {
-	pubField: { id: PubFieldsId; schemaName: CoreSchemaType | null };
+	pubField: { id: PubFieldsId; schemaName: CoreSchemaType | null; slug: string };
 	isEditing: boolean;
+	pubTypeName: string;
 	isTitle: boolean;
 }) => {
 	if (isEditing) {
 		if (pubFieldCanBeTitle(pubField)) {
-			return <RadioGroupItem value={pubField.id} />;
+			return (
+				<RadioGroupItem
+					value={pubField.id}
+					data-testid={`${pubTypeName}:${pubField.slug}-titleField`}
+				/>
+			);
 		}
 		return null;
 	}
@@ -177,6 +184,7 @@ const TypeBlock: React.FC<Props> = function ({ type, allowEditing }) {
 															pubField={field}
 															isTitle={isTitle}
 															isEditing={editing}
+															pubTypeName={type.name}
 														/>
 													</td>
 												</tr>

--- a/core/app/c/[communitySlug]/types/TypeEditor.tsx
+++ b/core/app/c/[communitySlug]/types/TypeEditor.tsx
@@ -169,7 +169,10 @@ export const TypeEditor = ({ onTypeCreation }: Props) => {
 															</Label>
 														</td>
 														<td>
-															<FormItem className="flex justify-center">
+															<FormItem
+																data-testId={`${pubField.slug}-titleField`}
+																className="flex justify-center"
+															>
 																{pubFieldCanBeTitle(pubField) ? (
 																	<>
 																		<FormControl>

--- a/core/app/c/[communitySlug]/types/TypeEditor.tsx
+++ b/core/app/c/[communitySlug]/types/TypeEditor.tsx
@@ -43,6 +43,7 @@ const schema = z.object({
 				name: z.string(),
 				slug: z.string(),
 				schemaName: z.nativeEnum(CoreSchemaType).nullable(),
+				isRelation: z.boolean().nullish(),
 			})
 		)
 		.min(1, { message: "Add at least one field" }),
@@ -68,9 +69,10 @@ export const TypeEditor = ({ onTypeCreation }: Props) => {
 		fieldId: PubFieldsId,
 		name: string,
 		slug: string,
-		schemaName: CoreSchemaType | null
+		schemaName: CoreSchemaType | null,
+		isRelation?: boolean | null
 	) => {
-		append({ fieldId, name, slug, schemaName });
+		append({ fieldId, name, slug, schemaName, isRelation });
 	};
 
 	const community = useCommunity();

--- a/core/app/c/[communitySlug]/types/page.tsx
+++ b/core/app/c/[communitySlug]/types/page.tsx
@@ -57,7 +57,6 @@ export default async function Page({
 	if (!types || !fields) {
 		return null;
 	}
-	console.log(fields);
 	return (
 		<PubFieldProvider pubFields={fields}>
 			<div className="mb-16 flex items-center justify-between">

--- a/core/app/c/[communitySlug]/types/page.tsx
+++ b/core/app/c/[communitySlug]/types/page.tsx
@@ -57,6 +57,7 @@ export default async function Page({
 	if (!types || !fields) {
 		return null;
 	}
+	console.log(fields);
 	return (
 		<PubFieldProvider pubFields={fields}>
 			<div className="mb-16 flex items-center justify-between">

--- a/core/app/c/[communitySlug]/types/page.tsx
+++ b/core/app/c/[communitySlug]/types/page.tsx
@@ -48,7 +48,10 @@ export default async function Page({
 
 	const [types, { fields }] = await Promise.all([
 		getAllPubTypesForCommunity(communitySlug).execute(),
-		getPubFields({ communityId: community.id }).executeTakeFirstOrThrow(),
+		getPubFields({
+			communityId: community.id,
+			includeRelations: true,
+		}).executeTakeFirstOrThrow(),
 	]);
 
 	if (!types || !fields) {

--- a/core/app/c/[communitySlug]/types/utils.ts
+++ b/core/app/c/[communitySlug]/types/utils.ts
@@ -1,9 +1,13 @@
 import { CoreSchemaType } from "db/public";
 
-export const pubFieldCanBeTitle = (pubField: { schemaName: CoreSchemaType | null }) => {
+export const pubFieldCanBeTitle = (pubField: {
+	schemaName: CoreSchemaType | null;
+	isRelation?: boolean | null;
+}) => {
 	return (
-		pubField.schemaName === CoreSchemaType.String ||
-		pubField.schemaName === CoreSchemaType.Email ||
-		pubField.schemaName === CoreSchemaType.URL
+		!pubField.isRelation &&
+		(pubField.schemaName === CoreSchemaType.String ||
+			pubField.schemaName === CoreSchemaType.Email ||
+			pubField.schemaName === CoreSchemaType.URL)
 	);
 };

--- a/core/playwright/externalFormInvite.spec.ts
+++ b/core/playwright/externalFormInvite.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import type { Page } from "@playwright/test";
 
 import { faker } from "@faker-js/faker";

--- a/core/playwright/fields.spec.ts
+++ b/core/playwright/fields.spec.ts
@@ -51,7 +51,7 @@ test.describe("Creating a field", () => {
 		}
 
 		// Try to create a field with the same name, should error
-		await fieldsPage.addField("String", CoreSchemaType.String, false, true);
+		await fieldsPage.addField("String", CoreSchemaType.String, false, false);
 		await expect(page.getByRole("status").filter({ hasText: "Error" })).toHaveCount(1);
 	});
 

--- a/core/playwright/fields.spec.ts
+++ b/core/playwright/fields.spec.ts
@@ -51,7 +51,7 @@ test.describe("Creating a field", () => {
 		}
 
 		// Try to create a field with the same name, should error
-		await fieldsPage.addField("String", CoreSchemaType.String, false);
+		await fieldsPage.addField("String", CoreSchemaType.String, false, true);
 		await expect(page.getByRole("status").filter({ hasText: "Error" })).toHaveCount(1);
 	});
 

--- a/core/playwright/fixtures/fields-page.ts
+++ b/core/playwright/fixtures/fields-page.ts
@@ -34,6 +34,7 @@ export class FieldsPage {
 	async addField(
 		name: string,
 		format: CoreSchemaType,
+		relation?: boolean,
 		/**
 		 * Whether to wait for the little pop up that confirms field creation
 		 * set to false for testing this function
@@ -42,8 +43,14 @@ export class FieldsPage {
 	) {
 		await this.openNewFieldModal();
 		await this.nameBox.fill(name);
+		if (relation) {
+			await this.page.getByTestId("isRelation-checkbox").click();
+		}
+
 		await this.selectFormat(format);
+
 		await this.page.getByRole("button", { name: "Create" }).click();
+
 		if (!waitForText) {
 			return;
 		}

--- a/core/playwright/fixtures/pub-types-page.ts
+++ b/core/playwright/fixtures/pub-types-page.ts
@@ -54,5 +54,8 @@ export class PubTypesPage {
 		await dialog.getByRole("button", { name: "Create type" }).click();
 
 		await dialog.waitFor({ state: "hidden" });
+
+		// check whether the new type is created
+		await this.page.getByRole("heading", { name: name }).waitFor();
 	}
 }

--- a/core/playwright/fixtures/pub-types-page.ts
+++ b/core/playwright/fixtures/pub-types-page.ts
@@ -20,7 +20,12 @@ export class PubTypesPage {
 		await this.page.getByRole("option", { name: fieldSlug }).click();
 	}
 
-	async addType(name: string, description: string, fieldSlugs?: string[]) {
+	async addType<T extends string>(
+		name: string,
+		description: string,
+		fieldSlugs?: T[],
+		title?: T
+	) {
 		await this.page.getByRole("button", { name: "Create Type", exact: true }).click();
 		const dialog = this.page.getByRole("dialog", { name: "Create Type", exact: true });
 
@@ -49,6 +54,11 @@ export class PubTypesPage {
 				const option = this.page.getByTestId(`option-${this.communitySlug}:${slug}`);
 				await option.click();
 			}
+		}
+
+		const titleField = title ?? fieldSlugs?.find((slug) => /title/.test(slug));
+		if (titleField) {
+			await this.page.getByTestId(`${this.communitySlug}:${titleField}-titleField`).click();
 		}
 
 		await dialog.getByRole("button", { name: "Create type" }).click();

--- a/core/playwright/pubType.spec.ts
+++ b/core/playwright/pubType.spec.ts
@@ -83,7 +83,7 @@ test.describe("Pub types", () => {
 		await fieldsPage.goto();
 		await fieldsPage.addField("description", CoreSchemaType.String);
 
-		const typename = "Article";
+		const typename = "Not Article";
 		const pubTypesPage = new PubTypesPage(page, COMMUNITY_SLUG);
 		await pubTypesPage.goto();
 		await pubTypesPage.addType(typename, "article", ["title", "description"], "description");

--- a/core/playwright/pubType.spec.ts
+++ b/core/playwright/pubType.spec.ts
@@ -1,0 +1,80 @@
+import type { Page } from "@playwright/test";
+
+import { expect, test } from "@playwright/test";
+
+import type { PubsId } from "db/public";
+import { CoreSchemaType } from "db/public";
+
+import { FieldsPage } from "./fixtures/fields-page";
+import { FormsEditPage } from "./fixtures/forms-edit-page";
+import { LoginPage } from "./fixtures/login-page";
+import { PubDetailsPage } from "./fixtures/pub-details-page";
+import { PubTypesPage } from "./fixtures/pub-types-page";
+import { choosePubType, PubsPage } from "./fixtures/pubs-page";
+import { StagesManagePage } from "./fixtures/stages-manage-page";
+import { createCommunity } from "./helpers";
+
+const now = new Date().getTime();
+const COMMUNITY_SLUG = `playwright-test-community-${now}`;
+
+test.describe.configure({ mode: "serial" });
+
+let page: Page;
+let pubId: PubsId;
+
+test.beforeAll(async ({ browser }) => {
+	page = await browser.newPage();
+
+	const loginPage = new LoginPage(page);
+	await loginPage.goto();
+	await loginPage.loginAndWaitForNavigation();
+
+	await createCommunity({
+		page,
+		community: { name: `test community ${now}`, slug: COMMUNITY_SLUG },
+	});
+
+	const stagesManagePage = new StagesManagePage(page, COMMUNITY_SLUG);
+	await stagesManagePage.goTo();
+	await stagesManagePage.addStage("Shelved");
+	await stagesManagePage.addStage("Submitted");
+	await stagesManagePage.addStage("Ask Author for Consent");
+	await stagesManagePage.addStage("To Evaluate");
+
+	await stagesManagePage.addMoveConstraint("Submitted", "Ask Author for Consent");
+	await stagesManagePage.addMoveConstraint("Ask Author for Consent", "To Evaluate");
+
+	const pubsPage = new PubsPage(page, COMMUNITY_SLUG);
+	await pubsPage.goTo();
+	pubId = await pubsPage.createPub({
+		stage: "Submitted",
+		values: { title: "The Activity of Snails", content: "Mostly crawling" },
+	});
+});
+
+test.afterAll(async () => {
+	await page.close();
+});
+
+test.describe("Pub types", () => {
+	test("Can create a pub type", async () => {
+		const pubTypesPage = new PubTypesPage(page, COMMUNITY_SLUG);
+		await pubTypesPage.goto();
+		await pubTypesPage.addType("Editor", "editor", ["title", "content"]);
+	});
+
+	test("Can add relation field to pub type", async () => {
+		const fieldsPage = new FieldsPage(page, COMMUNITY_SLUG);
+		await fieldsPage.goto();
+		await fieldsPage.addField("Contributor", CoreSchemaType.String, true);
+
+		const pubTypesPage = new PubTypesPage(page, COMMUNITY_SLUG);
+		await pubTypesPage.goto();
+		const typeName = "Article";
+		await pubTypesPage.addType(typeName, "article", ["title", "contributor"]);
+
+		await page.getByTestId(`edit-pubtype-${typeName}`).click();
+
+		await page.getByText(`${COMMUNITY_SLUG}:contributor`, { exact: true }).waitFor();
+	});
+});

--- a/core/playwright/pubType.spec.ts
+++ b/core/playwright/pubType.spec.ts
@@ -83,14 +83,16 @@ test.describe("Pub types", () => {
 		await fieldsPage.goto();
 		await fieldsPage.addField("description", CoreSchemaType.String);
 
+		const typename = "Article";
 		const pubTypesPage = new PubTypesPage(page, COMMUNITY_SLUG);
 		await pubTypesPage.goto();
-		await pubTypesPage.addType("Article", "article", ["title", "description"], "description");
+		await pubTypesPage.addType(typename, "article", ["title", "description"], "description");
 
-		await page.getByTestId(`edit-pubtype-Article`).click();
-		const isChecked = await page
-			.getByTestId(`Article:${COMMUNITY_SLUG}:description-titleField`)
-			.isChecked();
-		expect(isChecked).toBe(true);
+		await page.getByTestId(`edit-pubtype-${typename}`).click();
+		const checkboxLocator = page.getByTestId(
+			`${typename}:${COMMUNITY_SLUG}:description-titleField`
+		);
+
+		await expect(checkboxLocator).toBeChecked();
 	});
 });

--- a/core/playwright/pubType.spec.ts
+++ b/core/playwright/pubType.spec.ts
@@ -77,4 +77,20 @@ test.describe("Pub types", () => {
 
 		await page.getByText(`${COMMUNITY_SLUG}:contributor`, { exact: true }).waitFor();
 	});
+
+	test("Can designate a field as the title", async () => {
+		const fieldsPage = new FieldsPage(page, COMMUNITY_SLUG);
+		await fieldsPage.goto();
+		await fieldsPage.addField("description", CoreSchemaType.String);
+
+		const pubTypesPage = new PubTypesPage(page, COMMUNITY_SLUG);
+		await pubTypesPage.goto();
+		await pubTypesPage.addType("Article", "article", ["title", "description"], "description");
+
+		await page.getByTestId(`edit-pubtype-Article`).click();
+		const isChecked = await page
+			.getByTestId(`Article:${COMMUNITY_SLUG}:description-titleField`)
+			.isChecked();
+		expect(isChecked).toBe(true);
+	});
 });

--- a/packages/ui/src/pubFields/PubFieldContext.tsx
+++ b/packages/ui/src/pubFields/PubFieldContext.tsx
@@ -6,7 +6,7 @@ import type { PubFields, PubFieldsId } from "db/public";
 
 export type PubField = Pick<
 	PubFields,
-	"id" | "name" | "slug" | "schemaName" | "pubFieldSchemaId" | "isArchived"
+	"id" | "name" | "slug" | "schemaName" | "pubFieldSchemaId" | "isArchived" | "isRelation"
 >;
 export type PubFieldContext = Record<PubFieldsId, PubField>;
 


### PR DESCRIPTION
- **fix: fetch relations when trying to add pubfields**
- **fix: add pubtype page tests**
- **fix: add test for checking whether yuo can designate field as title**

## Issue(s) Resolved
Allow users to add relation field types to pub type

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->

We just weren't fetching the relationships on the PubTypes page, so i made it do that.

I also added some specific tests for pubtype creation.

In addition: you are not able to set relationship fields as the title. we should probably prevent this somewhere else too, but i'm too lazy to figure that out rn.

## Test Plan

1. Create a relation field of SchemaType string
2. Create a pub type, add that relationship field to it.
3. Observe you cannot set it as the title
4. Tada

## Screenshots (if applicable)

## Notes
