### PR TITLE
hotfix: allow deleting empty pubvalues

### DIFF
--- a/core/lib/server/pub.db.test.ts
+++ b/core/lib/server/pub.db.test.ts
@@ -8,6 +8,7 @@ import type { UnprocessedPub } from "./pub";
 import { mockServerCode } from "~/lib/__tests__/utils";
 import { seedCommunity } from "~/prisma/seed/seedCommunity";
 import { createLastModifiedBy } from "../lastModifiedBy";
+import { removeAllPubRelationsBySlugs } from "./pub";
 
 const { createForEachMockedTransaction } = await mockServerCode();
 
@@ -1464,6 +1465,31 @@ describe("removePubRelations", () => {
 		).rejects.toThrow(
 			"Pub values contain fields that do not exist in the community: non-existent-field"
 		);
+	});
+
+	it("should not throw an error when there are no relations to remove", async () => {
+		const trx = getTrx();
+		const { removeAllPubRelationsBySlugs, createPubRecursiveNew } = await import("./pub");
+
+		const pub = await createPubRecursiveNew({
+			communityId: community.id,
+			body: {
+				pubTypeId: pubTypes["Basic Pub"].id,
+				values: {},
+			},
+			lastModifiedBy: createLastModifiedBy("system"),
+		});
+
+		expect(pub.values).toHaveLength(0);
+
+		await expect(
+			removeAllPubRelationsBySlugs({
+				pubId: pub.id,
+				communityId: community.id,
+				slugs: [pubFields["Some relation"].slug],
+				lastModifiedBy: createLastModifiedBy("system"),
+			})
+		).resolves.toEqual([]);
 	});
 });
 

--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -1000,6 +1000,10 @@ export const addDeletePubValueHistoryEntries = async ({
 }) => {
 	const parsedLastModifiedBy = parseLastModifiedBy(lastModifiedBy);
 
+	if (!pubValues.length) {
+		return;
+	}
+
 	await autoRevalidate(
 		trx.insertInto("pub_values_history").values(
 			pubValues.map((pubValue) => ({

--- a/core/prisma/exampleCommunitySeeds/arcadia.ts
+++ b/core/prisma/exampleCommunitySeeds/arcadia.ts
@@ -693,7 +693,7 @@ export const seedArcadia = (communityId?: CommunitiesId) => {
 		},
 		{
 			randomSlug: false,
-			withApiToken: "xxxxxxxxxxxxxxxx.00000000-0000-0000-0000-000000000000",
+			withApiToken: "00000000-0000-0000-0000-000000000000.xxxxxxxxxxxxxxxx.",
 			parallelPubs: true,
 		}
 	);


### PR DESCRIPTION
- **fix: make arcadiaseed accesstoken correct**
- **fix: do not error if no pubvalues are deleted**

## Issue(s) Resolved
`PUT pubs/relations` route would throw if no values existed beforehand, bc it would try remove pubvalues and then manually insert them into `pub_value_history`. there were no safeguards if there were no pubvalues to insert though, so it would try to `db.insertInto('pub_values_history').values([])`, which errors.

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan
1. Run test
2. Ideally try to `PUT` a relation but this has some haste, so just wing it.

## Screenshots (if applicable)

## Notes
