### PR TITLE
fix: do not set title to null if a non-title value is updated

### DIFF
--- a/core/lib/server/pub-trigger.db.test.ts
+++ b/core/lib/server/pub-trigger.db.test.ts
@@ -305,44 +305,9 @@ describe("pub_values title trigger", () => {
 	});
 
 	it("should not update a title on a pub when a non-title pubvalue is updated", async () => {
-		const trx = getTrx();
-		const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
-		const { pubFields, pubs } = await seedCommunity(pubTriggerTestSeed);
-
-		expect(await getPubTitle(pubs[0].id, trx)).toBe("Some title");
-
-		const updateResult = await trx
-			.updateTable("pub_values")
-			.set({
-				value: JSON.stringify("new description"),
-				lastModifiedBy: createLastModifiedBy("system"),
-			})
-			.where("pubId", "=", pubs[0].id)
-			.where("fieldId", "=", pubFields.Description.id)
-			.executeTakeFirst();
-
-		expect(await getPubTitle(pubs[0].id, trx)).toBe("Some title");
-	});
-
-	it("should delete a title on a pub when a pubvalue is deleted", async () => {
-		const trx = getTrx();
-		const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
-		const { pubFields, pubs } = await seedCommunity(pubTriggerTestSeed);
-
-		expect(await getPubTitle(pubs[0].id, trx)).toBe("Some title");
-
-		const deletedPubValue = await trx
-			.deleteFrom("pub_values")
-			.where("pubId", "=", pubs[0].id)
-			.where("fieldId", "=", pubFields.Title.id)
-			.returningAll()
-			.executeTakeFirstOrThrow();
-
-		expect(await getPubTitle(pubs[0].id, trx)).toBe(null);
-	});
-
-	it("should not update a title on a pub when a non-title pubvalue is updated", async () => {
-		// purposefully not in the transaction, because for some reason it doens't work then
+		// we explictly don't want to use the rolled back transaction here
+		// for some, strange strange reason, this doesn't work then
+		// with the transaction rolled back
 		const trx = testDb;
 		const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
 		const { pubFields, pubs } = await seedCommunity(pubTriggerTestSeed, undefined, trx);
@@ -368,7 +333,24 @@ describe("pub_values title trigger", () => {
 			)
 			.executeTakeFirstOrThrow();
 
-		expect(await getPubTitle(pubs[0].id, trx)).not.toBe(null);
+		expect(await getPubTitle(pubs[0].id, trx)).toBe("Some title");
+	});
+
+	it("should delete a title on a pub when a pubvalue is deleted", async () => {
+		const trx = getTrx();
+		const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
+		const { pubFields, pubs } = await seedCommunity(pubTriggerTestSeed);
+
+		expect(await getPubTitle(pubs[0].id, trx)).toBe("Some title");
+
+		const deletedPubValue = await trx
+			.deleteFrom("pub_values")
+			.where("pubId", "=", pubs[0].id)
+			.where("fieldId", "=", pubFields.Title.id)
+			.returningAll()
+			.executeTakeFirstOrThrow();
+
+		expect(await getPubTitle(pubs[0].id, trx)).toBe(null);
 	});
 });
 

--- a/core/prisma/migrations/20241205152006_add_title_field/migration.sql
+++ b/core/prisma/migrations/20241205152006_add_title_field/migration.sql
@@ -58,11 +58,13 @@ BEGIN
     SET
         "updatedAt" = CURRENT_TIMESTAMP,
         "title" = CASE 
-            WHEN TG_OP = 'DELETE' OR tmp."value" IS NULL THEN
-                NULL
-            ELSE
-                tmp."value"
-            END
+        WHEN tmp."pubId" IS NULL THEN
+            pubs."title"
+        WHEN TG_OP = 'DELETE' OR tmp."value" IS NULL THEN
+            NULL
+        ELSE
+            tmp."value"
+        END
     FROM ( SELECT DISTINCT
             "pubId"
         FROM

--- a/core/prisma/migrations/20241205152006_add_title_field/migration.sql
+++ b/core/prisma/migrations/20241205152006_add_title_field/migration.sql
@@ -58,13 +58,11 @@ BEGIN
     SET
         "updatedAt" = CURRENT_TIMESTAMP,
         "title" = CASE 
-        WHEN tmp."pubId" IS NULL THEN
-            pubs."title"
-        WHEN TG_OP = 'DELETE' OR tmp."value" IS NULL THEN
-            NULL
-        ELSE
-            tmp."value"
-        END
+            WHEN TG_OP = 'DELETE' OR tmp."value" IS NULL THEN
+                NULL
+            ELSE
+                tmp."value"
+            END
     FROM ( SELECT DISTINCT
             "pubId"
         FROM

--- a/core/prisma/migrations/20241219131700_fix_title_update_trigger/migration.sql
+++ b/core/prisma/migrations/20241219131700_fix_title_update_trigger/migration.sql
@@ -1,0 +1,70 @@
+CREATE OR REPLACE FUNCTION update_pub_for_value_changes()
+    RETURNS TRIGGER
+    AS $$
+BEGIN
+    CREATE TEMP TABLE IF NOT EXISTS tmp_affected_pubs(
+        "pubId" text PRIMARY KEY,
+        "value" text
+    ) ON COMMIT DROP;
+    WITH tf AS (
+        SELECT DISTINCT ON (inserted_updated_deleted_rows."pubId")
+            inserted_updated_deleted_rows."pubId",
+            inserted_updated_deleted_rows."value",
+            CASE WHEN inserted_updated_deleted_rows."value" IS NULL THEN
+                TRUE
+            ELSE
+                FALSE
+            END AS is_null_value
+        FROM
+            inserted_updated_deleted_rows
+            JOIN "pubs" p ON inserted_updated_deleted_rows."pubId" = p."id"
+            JOIN "_PubFieldToPubType" pft ON pft."A" = inserted_updated_deleted_rows."fieldId"
+                AND pft."B" = p."pubTypeId"
+                AND pft."isTitle" = TRUE
+    )
+    INSERT INTO tmp_affected_pubs("pubId", "value")
+    SELECT DISTINCT
+        "pubId",
+        CASE WHEN is_null_value THEN
+            NULL
+        ELSE
+            ("value" #>> '{}')
+        END
+    FROM tf
+    -- this is to handle edge cases which mostly happen during "UPDATE"s in transactions
+    ON CONFLICT("pubId")
+        DO UPDATE SET
+            "value" = CASE WHEN EXCLUDED."value" IS NULL THEN
+                NULL
+            ELSE
+                EXCLUDED."value"
+            END;
+
+
+    -- this is to handle the actual update of the title
+    -- and to ensure that the updatedAt is updated
+    UPDATE
+        "pubs"
+    SET
+        "updatedAt" = CURRENT_TIMESTAMP,
+        "title" = CASE 
+        -- this is what's changed from the earlier function
+        WHEN tmp."pubId" IS NULL THEN
+            pubs."title"
+        WHEN TG_OP = 'DELETE' OR tmp."value" IS NULL THEN
+            NULL
+        ELSE
+            tmp."value"
+        END
+    FROM ( SELECT DISTINCT
+            "pubId"
+        FROM
+            inserted_updated_deleted_rows
+    ) AS affected
+    LEFT JOIN tmp_affected_pubs tmp ON tmp."pubId" = affected."pubId"
+    WHERE
+        "pubs"."id" = affected."pubId";
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;


### PR DESCRIPTION
- **fix: add working test that will show the unwanted behavior**
- **fix: correctly update the title if a non-pubtitle is updated**
- **fix: create a new migration instead of updating old one**
- **fix: update existing test instead of adding new test**

## Issue(s) Resolved
When updating a non-title value on a pub, it's `title` would get set to null!
@3mcd  identified this as a problem while working on #833 

I missed this because a test was not behaving properly for some reason.

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->
Basically, because i wanted to be efficient and update the `updatedAt` and `title` on query, I used a `LEFT JOIN` here in the update query (bc i wanted to update the `updatedAt` even if no title update was necessary)

https://github.com/pubpub/platform/blob/a57197798f56fc5af66b6181af8fe6f9a2f803ca/core/prisma/migrations/20241205152006_add_title_field/migration.sql#L56-L74

This caused a problem though, as that meant that this `ELSE` part of the update query

https://github.com/pubpub/platform/blob/a57197798f56fc5af66b6181af8fe6f9a2f803ca/core/prisma/migrations/20241205152006_add_title_field/migration.sql#L56-L65

would always be `null` if no title value needed to be updated!

This PR fixes that by adding this additional case that checks whether the `LEFT JOIN` even did anything (it will be null if no columns have been joined)

https://github.com/pubpub/platform/blob/a57197798f56fc5af66b6181af8fe6f9a2f803ca/core/prisma/migrations/20241219131700_fix_title_update_trigger/migration.sql#L51-L53

This way I can still update things in one query.

Maybe it's a better idea to split this query up into a bunch of CTEs anyway, that way it'll be much more legible, rather than this weird "create a temp table and then use on update query" strat i went with, but this was the most minimal change to the existing function i could think of.

## Test Plan

1. On `main`, open prisma studio with `pnpm --filter core db:studio`
2. Find some pub in the db with a non-null `title` field, and update a non-title value of that pub in the UI
3. Click the lil refresh thing in the topleft.
4. Observe that the `title` field is not `null`

----

1. First, on `main`, add this test somewhere to `pub-trigger.db.test.ts`

```ts
	it("should not update a title on a pub when a non-title pubvalue is updated", async () => {
		// we explictly don't want to use the rolled back transaction here
		// for some, strange strange reason, this doesn't work then
		// with the transaction rolled back
		const trx = testDb;
		const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
		const { pubFields, pubs } = await seedCommunity(pubTriggerTestSeed, undefined, trx);

		expect(await getPubTitle(pubs[0].id, trx)).toBe("Some title");

		await trx
			.insertInto("pub_values")
			.values({
				pubId: pubs[0].id,
				fieldId: pubFields.Description.id,
				value: JSON.stringify("new description"),
				lastModifiedBy: createLastModifiedBy("system"),
			})
			.onConflict((oc) =>
				oc
					.columns(["pubId", "fieldId"])
					.where("relatedPubId", "is", null)
					.doUpdateSet((eb) => ({
						value: eb.ref("excluded.value"),
						lastModifiedBy: createLastModifiedBy("system"),
					}))
			)
			.executeTakeFirstOrThrow();

		expect(await getPubTitle(pubs[0].id, trx)).toBe("Some title");
	});
```
2. Convince yourself that this test accurately depicts a scenario where we update a pubvalue.
3. Run test, observe that it properly fails.

----

1. Switch to this branch
2. Run `pnpm --filter core migrate-dev`. Observe that this does not trigger a reset (important, otherwise it won't apply cleanly on main)
3. Run `pnpm --filter core vitest lib/server/pub-trigger.db.test.ts` (the test above has been added)
4. Observe that the test called `should not update a title on a pub when a non-title pubvalue is updated` passes

----

1. Open prisma studio with `pnpm --filter core db:studio`
2. Find some pub in the db with a non-null `title` field, and update a non-title value of that pub in the UI
3. Click the lil refresh thing in the topleft.
4. Observe that the `title` field is not `null`






## Screenshots (if applicable)

## Notes
