### PR TITLE
fix: render dates properly and unbreak actions

### DIFF
--- a/core/actions/_lib/runActionInstance.ts
+++ b/core/actions/_lib/runActionInstance.ts
@@ -16,6 +16,7 @@ import { logger } from "logger";
 import type { ActionSuccess } from "../types";
 import type { ClientException, ClientExceptionOptions } from "~/lib/serverActions";
 import { db } from "~/kysely/database";
+import { hydratePubValues } from "~/lib/fields/utils";
 import { createLastModifiedBy } from "~/lib/lastModifiedBy";
 import { getPubsWithRelatedValuesAndChildren } from "~/lib/server";
 import { autoRevalidate } from "~/lib/server/cache/autoRevalidate";
@@ -172,6 +173,8 @@ const _runActionInstance = async (
 		configFieldOverrides
 	);
 
+	const hydratedPubValues = hydratePubValues(pub.values);
+
 	const lastModifiedBy = createLastModifiedBy({
 		actionRunId: args.actionRunId,
 	});
@@ -181,7 +184,10 @@ const _runActionInstance = async (
 			// FIXME: get rid of any
 			config: configWithPubfields as any,
 			configFieldOverrides,
-			pub,
+			pub: {
+				...pub,
+				values: hydratedPubValues,
+			},
 			// FIXME: get rid of any
 			args: argsWithPubfields as any,
 			argsFieldOverrides,

--- a/core/actions/_lib/runActionInstance.ts
+++ b/core/actions/_lib/runActionInstance.ts
@@ -181,17 +181,7 @@ const _runActionInstance = async (
 			// FIXME: get rid of any
 			config: configWithPubfields as any,
 			configFieldOverrides,
-			pub: {
-				id: pub.id,
-				// FIXME: get rid of any
-				values: pub.values as any,
-				assignee: pub.assignee ?? undefined,
-				parentId: pub.parentId,
-				communityId: pub.communityId,
-				createdAt: pub.createdAt,
-				title: pub.title,
-				pubType: pub.pubType,
-			},
+			pub,
 			// FIXME: get rid of any
 			args: argsWithPubfields as any,
 			argsFieldOverrides,

--- a/core/actions/email/run.ts
+++ b/core/actions/email/run.ts
@@ -7,7 +7,10 @@ import { logger } from "logger";
 import { expect } from "utils";
 
 import type { action } from "./action";
-import type { RenderWithPubPub } from "~/lib/server/render/pub/renderWithPubUtils";
+import type {
+	RenderWithPubContext,
+	RenderWithPubPub,
+} from "~/lib/server/render/pub/renderWithPubUtils";
 import { db } from "~/kysely/database";
 import { getPubsWithRelatedValuesAndChildren } from "~/lib/server";
 import { getCommunitySlug } from "~/lib/server/cache/getCommunitySlug";
@@ -64,7 +67,7 @@ export const run = defineRun<typeof action>(async ({ pub, config, args, communit
 			recipient,
 			pub,
 			parentPub,
-		};
+		} as RenderWithPubContext;
 
 		const html = await renderMarkdownWithPub(
 			args?.body ?? config.body,

--- a/core/actions/http/run.ts
+++ b/core/actions/http/run.ts
@@ -97,7 +97,7 @@ export const run = defineRun<typeof action>(
 			<p>HTTP request ran successfully</p>
 			<p>The resulting mapping would have been:</p>
 			<div>
-${mappedOutputs.map(({ pubField, resValue }) => `<p>${pubField}: ${pub.values[pubField]} ➡️ ${resValue}</p>`).join("\n")}
+${mappedOutputs.map(({ pubField, resValue }) => `<p>${pubField}: ${pub.values.find((value) => value.fieldSlug === pubField)?.value} ➡️ ${resValue}</p>`).join("\n")}
 <span>Data</span>
 				<p>${JSON.stringify(result, null, 2)}</p>
 			</div>`,
@@ -131,7 +131,7 @@ ${mappedOutputs.map(({ pubField, resValue }) => `<p>${pubField}: ${pub.values[pu
 			success: true,
 			report: `<p>Successfully updated fields</p>
 			<div>
-${mappedOutputs.map(({ pubField, resValue }) => `<p>${pubField}: ${pub.values[pubField]} ➡️ ${resValue}</p>`).join("\n")}`,
+${mappedOutputs.map(({ pubField, resValue }) => `<p>${pubField}: ${pub.values.find((value) => value.fieldSlug === pubField)?.value} ➡️ ${resValue}</p>`).join("\n")}`,
 			data: { result },
 		};
 	}

--- a/core/actions/pushToV6/run.ts
+++ b/core/actions/pushToV6/run.ts
@@ -188,9 +188,10 @@ export const run = defineRun<typeof action>(async ({ pub, config, args, lastModi
 
 		let v6Pub: { id: string };
 
+		const v6PubId = pub.values.find((value) => value.fieldSlug === corePubFields.v6PubId.slug)
+			?.value as string;
 		// Fetch the pub if the v7 pub already had a v6 pub id
-		if (pub.values[corePubFields.v6PubId.slug]) {
-			const v6PubId = pub.values[corePubFields.v6PubId.slug] as string;
+		if (v6PubId) {
 			const v6PubResult = await getV6Pub(v6PubId, config.communitySlug, config.authToken);
 
 			if (isClientExceptionOptions(v6PubResult)) {

--- a/core/actions/types.ts
+++ b/core/actions/types.ts
@@ -1,6 +1,7 @@
 import type { JTDDataType } from "ajv/dist/jtd";
 import type * as z from "zod";
 
+import type { ProcessedPub } from "contracts";
 import type {
 	Action as ActionName,
 	ActionRunsId,
@@ -21,25 +22,29 @@ export type ActionPubType = CorePubField[];
 type ZodObjectOrWrapped = z.ZodObject<any, any> | z.ZodEffects<z.ZodObject<any, any>>;
 export type ZodObjectOrWrappedOrOptional = ZodObjectOrWrapped | z.ZodOptional<ZodObjectOrWrapped>;
 
-export type ActionPub<T extends ActionPubType> = {
-	id: PubsId;
-	parentId?: PubsId | null;
-	values: {
-		[key in T[number]["slug"]]: JTDDataType<T[number]["schema"]["schema"]>;
-	};
-	assignee?: {
-		id: string;
-		firstName: string;
-		lastName: string | null;
-		email: string;
-	};
-	communityId: CommunitiesId;
-	createdAt: Date;
-	title: string | null;
-	pubType: {
-		name: string;
-	};
-};
+export type ActionPub = ProcessedPub<{
+	withAssignee: true;
+	withPubType: true;
+	withRelatedPubs: undefined;
+}>;
+
+// export type ActionPub<T extends ActionPubType> = {
+// 	id: PubsId;
+// 	parentId?: PubsId | null;
+
+// 	assignee?: {
+// 		id: string;
+// 		firstName: string;
+// 		lastName: string | null;
+// 		email: string;
+// 	};
+// 	communityId: CommunitiesId;
+// 	createdAt: Date;
+// 	title: string | null;
+// 	pubType: {
+// 		name: string;
+// 	};
+// };
 
 export type RunProps<T extends Action> =
 	T extends Action<
@@ -50,7 +55,7 @@ export type RunProps<T extends Action> =
 		? {
 				config: C["_output"] & { pubFields: { [K in keyof C["_output"]]?: string[] } };
 				configFieldOverrides: Set<string>;
-				pub: ActionPub<P>;
+				pub: ActionPub;
 				args: A["_output"] & { pubFields: { [K in keyof A["_output"]]?: string[] } };
 				argsFieldOverrides: Set<string>;
 				stageId: StagesId;

--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -44,7 +44,7 @@ import type { MaybeHas, Prettify, XOR } from "../types";
 import type { SafeUser } from "./user";
 import { db } from "~/kysely/database";
 import { parseRichTextForPubFieldsAndRelatedPubs } from "../fields/richText";
-import { mergeSlugsWithFields } from "../fields/utils";
+import { hydratePubValues, mergeSlugsWithFields } from "../fields/utils";
 import { parseLastModifiedBy } from "../lastModifiedBy";
 import { autoCache } from "./cache/autoCache";
 import { autoRevalidate } from "./cache/autoRevalidate";
@@ -697,30 +697,6 @@ const getFieldInfoForSlugs = async ({
 		schemaName: expect(field.schemaName),
 		fieldName: field.name,
 	}));
-};
-
-/**
- * This should maybe go somewhere else
- */
-const hydratePubValues = <T extends { slug: string; value: unknown; schemaName: CoreSchemaType }>(
-	pubValues: T[]
-) => {
-	return pubValues.map(({ value, schemaName, slug, ...rest }) => {
-		if (schemaName === CoreSchemaType.DateTime) {
-			try {
-				value = new Date(value as string);
-			} catch {
-				throw new BadRequestError(`Invalid date value for field ${slug}`);
-			}
-		}
-
-		return {
-			slug,
-			schemaName,
-			value,
-			...rest,
-		};
-	});
 };
 
 const validatePubValues = async <T extends { slug: string; value: unknown }>({

--- a/core/lib/server/render/pub/renderMarkdownWithPub.ts
+++ b/core/lib/server/render/pub/renderMarkdownWithPub.ts
@@ -50,7 +50,7 @@ const visitValueDirective = (node: NodeMdast & Directive, context: utils.RenderW
 	if (field === "title") {
 		value = getPubTitle(pub);
 	} else {
-		value = pub.values[field];
+		value = pub.values.find((value) => value.fieldSlug === field)?.value;
 	}
 
 	assert(value !== undefined, `Missing value for ${field}`);

--- a/core/lib/server/render/pub/renderWithPubUtils.ts
+++ b/core/lib/server/render/pub/renderWithPubUtils.ts
@@ -15,7 +15,7 @@ export type RenderWithPubPub = {
 		fieldName: string;
 		fieldSlug: string;
 		value: unknown;
-		schemaName: string;
+		schemaName: CoreSchemaType;
 	}[];
 	createdAt: Date;
 	assignee?: {

--- a/core/lib/server/render/pub/renderWithPubUtils.ts
+++ b/core/lib/server/render/pub/renderWithPubUtils.ts
@@ -1,3 +1,4 @@
+import type { JsonValue } from "contracts";
 import type { CommunitiesId, CommunityMembershipsId, PubsId, UsersId } from "db/public";
 import { CoreSchemaType } from "db/public";
 import { assert, expect } from "utils";
@@ -10,7 +11,12 @@ export type RenderWithPubRel = "parent" | "self";
 
 export type RenderWithPubPub = {
 	id: string;
-	values: Record<string, any>;
+	values: {
+		fieldName: string;
+		fieldSlug: string;
+		value: unknown;
+		schemaName: string;
+	}[];
 	createdAt: Date;
 	assignee?: {
 		firstName: string;
@@ -65,7 +71,7 @@ const getAssignee = (context: RenderWithPubContext, rel?: string) => {
 
 const getPubValue = (context: RenderWithPubContext, fieldSlug: string, rel?: string) => {
 	const pub = getPub(context, rel);
-	const pubValue = pub.values[fieldSlug];
+	const pubValue = pub.values.find((value) => value.fieldSlug === fieldSlug);
 	return expect(pubValue, `Expected pub to have value for field "${fieldSlug}"`);
 };
 
@@ -182,7 +188,7 @@ export const renderLink = (context: RenderWithPubContext, options: LinkOptions) 
 	} else if (isLinkUrlOptions(options)) {
 		href = options.url;
 	} else if (isLinkFieldOptions(options)) {
-		href = getPubValue(context, options.field, options.rel);
+		href = getPubValue(context, options.field, options.rel).value as string;
 	} else {
 		throw new Error("Unexpected link variant");
 	}

--- a/core/prisma/exampleCommunitySeeds/croccroc.ts
+++ b/core/prisma/exampleCommunitySeeds/croccroc.ts
@@ -31,6 +31,7 @@ export async function seedCroccroc(communityId?: CommunitiesId) {
 				"ok?": { schemaName: CoreSchemaType.Boolean },
 				File: { schemaName: CoreSchemaType.FileUpload },
 				Confidence: { schemaName: CoreSchemaType.Vector3 },
+				"Published At": { schemaName: CoreSchemaType.DateTime },
 			},
 			pubTypes: {
 				Submission: {
@@ -42,6 +43,7 @@ export async function seedCroccroc(communityId?: CommunitiesId) {
 					"ok?": { isTitle: false },
 					File: { isTitle: false },
 					Confidence: { isTitle: false },
+					"Published At": { isTitle: false },
 				},
 				Evaluation: {
 					Title: { isTitle: true },
@@ -52,6 +54,7 @@ export async function seedCroccroc(communityId?: CommunitiesId) {
 					"ok?": { isTitle: false },
 					File: { isTitle: false },
 					Confidence: { isTitle: false },
+					"Published At": { isTitle: false },
 				},
 			},
 			users: {
@@ -72,19 +75,21 @@ export async function seedCroccroc(communityId?: CommunitiesId) {
 					assignee: "new",
 					pubType: "Submission",
 					values: {
-						Title: "Evaluation of Ancient Giants: Unpacking the Evolutionary History of Crocodiles from Prehistoric to Present",
+						Title: "Ancient Giants: Unpacking the Evolutionary History of Crocodiles from Prehistoric to Present",
 						Content: "New Pub 1 Content",
 						Email: "new@pubpub.org",
 						URL: "https://pubpub.org",
 						MemberID: memberId,
 						"ok?": true,
 						Confidence: [0, 0, 0],
+						"Published At": new Date(),
 					},
 					children: [
 						{
 							pubType: "Evaluation",
 							values: {
-								Title: "Evaluation of Ancient Giants: Unpacking the Evolutionary History of Crocodiles from Prehistoric to Present",
+								Title: "Evaluation of Ancient Giants",
+								"Published At": new Date(),
 							},
 						},
 					],
@@ -141,7 +146,7 @@ export async function seedCroccroc(communityId?: CommunitiesId) {
 							config: {
 								subject: "HELLO :recipientName REVIEW OUR STUFF PLEASE",
 								recipient: memberId,
-								body: `You are invited to fill in a form.\n\n\n\n:link{form="review"}`,
+								body: `You are invited to fill in a form.\n\n\n\n:link{form="review"}\n\nCurrent time: :value{field='croccroc:published-at'}`,
 							},
 							name: "Send Review email",
 						},


### PR DESCRIPTION
- **fix: make actions use correct types**
- **feat: make hydratePubValues more resuable**
- **feat: hydrate pubvalues before running action**

## Issue(s) Resolved

Resolves #760 

Also resolves another issue: bc of #823  the values that were passed to pubs changed, but the type did not change, probably breaking a bunch of actions unknowingly,
this fixes it.

## High-level Explanation of PR
<!-- Using which methods does this PR resolve the issues above? -->

Specifically i changed `runActionInstance` to fetch pubs like so

https://github.com/pubpub/platform/blob/cd32e0be1ac268b1f23b5fce4d623038854b5a3b/core/actions/_lib/runActionInstance.ts#L40-L46

but because of this `any` cast here `pubs.values` did not throw an error!

https://github.com/pubpub/platform/blob/cd32e0be1ac268b1f23b5fce4d623038854b5a3b/core/actions/_lib/runActionInstance.ts#L180-L187

extremely dangerous, bc in eg `renderMarkdownWithPub` `pub.values` was still accessed as an object, even though it's an array now!

https://github.com/pubpub/platform/blob/cd32e0be1ac268b1f23b5fce4d623038854b5a3b/core/actions/_lib/runActionInstance.ts#L180-L187

big oversight of me, apologies. also shows the dangers of using `any`!





## Test Plan
1. `pnpm reset`
2. Run default invite action in `croccroc`
3. See that date is rendered as `YYYY-MM-DD` in email instead of a raw isostring

## Screenshots (if applicable)

## Notes
