### PR TITLE
use string or date as publication date in datacite action

### DIFF
--- a/api.http.h
+++ b/api.http.h
@@ -1,0 +1,4 @@
+GET https://app.pubpub.org/api/v0/c/arcadia/site/pubs
+Authorization: Bearer cc901fa7-8881-43de-b72e-e08afd4ab23f.poMh0j16v_4ZXrcV3AL3hQ
+Prefer: "return=representation"
+Accept: "*/*"

--- a/core/.env.development
+++ b/core/.env.development
@@ -20,4 +20,5 @@ KYSELY_DEBUG="true"
 DATACITE_REPOSITORY_ID=""
 DATACITE_PASSWORD=""
 DATACITE_API_URL="https://api.test.datacite.org"
+
 GCLOUD_KEY_FILE="xxx"

--- a/core/actions/datacite/run.ts
+++ b/core/actions/datacite/run.ts
@@ -97,7 +97,7 @@ const makeDatacitePayload = async (pub: ActionPub, config: Config): Promise<Payl
 
 	const publicationDate = pub.values.find((v) => v.fieldSlug === publicationDateFieldSlug)?.value;
 	assert(
-		typeof publicationDate === "string",
+		typeof publicationDate === "string" || publicationDate instanceof Date,
 		"The pub is missing a value corresponding to the configured publication date field override."
 	);
 

--- a/infrastructure/terraform.tfstate
+++ b/infrastructure/terraform.tfstate
@@ -1,0 +1,9 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.7",
+  "serial": 1,
+  "lineage": "1d868f24-34e5-eac5-25f2-7b0e645a0582",
+  "outputs": {},
+  "resources": [],
+  "check_results": null
+}


### PR DESCRIPTION
There is still a discrepancy between dev and prod. Pub values with a `DateTime` schema are `Date`s in prod and strings in dev. This is causing the DataCite action to fail with the error `"The pub is missing a value corresponding to the configured publication date field override."`. This is a temporary fix to get the action working.