### PR TITLE
Test date fields before rendering on pub page

### DIFF
--- a/core/app/c/[communitySlug]/pubs/[pubId]/components/PubValues.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/components/PubValues.tsx
@@ -127,7 +127,10 @@ const PubValue = ({ value }: { value: FullProcessedPub["values"][number] }) => {
 	}
 
 	if (value.schemaName === CoreSchemaType.DateTime) {
-		return new Date(value.value as string).toISOString().split("T")[0];
+		const date = new Date(value.value as string);
+		if (date.toString() !== "Invalid Date") {
+			return date.toISOString().split("T")[0];
+		}
 	}
 
 	const valueAsString = (value.value as JsonValue)?.toString() || "";


### PR DESCRIPTION
## Issue(s) Resolved
https://kfg.sentry.io/issues/6174244816/events/503971d6e0204d8896c8ff28536ce098/
## High-level Explanation of PR
#867 changed how we render datetime fields on the pub page, which throws errors with some of the existing date values. This PR tests that the date value is parsed correctly before attempting to render it.
