### PR TITLE
Fix: pubs with no discussions

### DIFF
--- a/core/actions/googleDriveImport/formatDriveData.ts
+++ b/core/actions/googleDriveImport/formatDriveData.ts
@@ -119,11 +119,12 @@ export const formatDriveData = async (
 						: comment.commenter
 							? comment.commenter.avatar
 							: "";
-					const commentAuthorORCID = comment.author
-						? comment.author.orcid
-						: comment.commenter
-							? comment.commenter.orcid
-							: "";
+					const commentAuthorORCID =
+						comment.author && comment.author.orcid
+							? `https://orcid.org/${comment.author.orcid}`
+							: comment.commenter && comment.commenter.orcid
+								? `https://orcid.org/${comment.commenter.orcid}`
+								: null;
 					const commentObject: any = {
 						id: comment.id,
 						values: {
@@ -134,7 +135,7 @@ export const formatDriveData = async (
 							[`${communitySlug}:content`]: comment.text,
 							[`${communitySlug}:publication-date`]: comment.createdAt,
 							[`${communitySlug}:full-name`]: commentAuthorName,
-							[`${communitySlug}:orcid`]: `https://orcid.org/${commentAuthorORCID}`,
+							[`${communitySlug}:orcid`]: commentAuthorORCID,
 							[`${communitySlug}:avatar`]: commentAuthorAvatar,
 							[`${communitySlug}:is-closed`]: discussion.isClosed,
 							[`${communitySlug}:parent-id`]:

--- a/core/actions/googleDriveImport/formatDriveData.ts
+++ b/core/actions/googleDriveImport/formatDriveData.ts
@@ -108,6 +108,22 @@ export const formatDriveData = async (
 					if (index === 0) {
 						firstCommentId = comment.id;
 					}
+					// we apparently can't assume the comment.author exists, sometimes it's comment.commenter
+					const commentAuthorName = comment.author
+						? comment.author.fullName
+						: comment.commenter
+							? comment.commenter.name
+							: "";
+					const commentAuthorAvatar = comment.author
+						? comment.author.avatar
+						: comment.commenter
+							? comment.commenter.avatar
+							: "";
+					const commentAuthorORCID = comment.author
+						? comment.author.orcid
+						: comment.commenter
+							? comment.commenter.orcid
+							: "";
 					const commentObject: any = {
 						id: comment.id,
 						values: {
@@ -117,9 +133,9 @@ export const formatDriveData = async (
 									: undefined,
 							[`${communitySlug}:content`]: comment.text,
 							[`${communitySlug}:publication-date`]: comment.createdAt,
-							[`${communitySlug}:full-name`]: comment.author.fullName,
-							[`${communitySlug}:orcid`]: `https://orcid.org/${comment.author.orcid}`,
-							[`${communitySlug}:avatar`]: comment.author.avatar,
+							[`${communitySlug}:full-name`]: commentAuthorName,
+							[`${communitySlug}:orcid`]: `https://orcid.org/${commentAuthorORCID}`,
+							[`${communitySlug}:avatar`]: commentAuthorAvatar,
 							[`${communitySlug}:is-closed`]: discussion.isClosed,
 							[`${communitySlug}:parent-id`]:
 								index !== 0 ? firstCommentId : undefined,

--- a/core/actions/googleDriveImport/run.ts
+++ b/core/actions/googleDriveImport/run.ts
@@ -40,8 +40,11 @@ export const run = defineRun<typeof action>(
 
 			// Check for legacy discussion IDs on platform
 			const legacyDiscussionIds = formattedData.discussions.map((pub) => pub.id);
-			const { pubs: existingPubs } = await doPubsExist(legacyDiscussionIds, communityId);
-			const existingDiscussionPubIds = existingPubs.map((pub) => pub.id);
+			const existingDiscussionPubIds: any[] = [];
+			if (legacyDiscussionIds.length > 0) {
+				const { pubs: existingPubs } = await doPubsExist(legacyDiscussionIds, communityId);
+				existingPubs.forEach((pub) => existingDiscussionPubIds.push(pub.id));
+			}
 
 			// Versions don't have IDs so we compare timestamps
 			const existingVersionDates = pub.values


### PR DESCRIPTION
## Issue(s) Resolved
Fixes three errors:
1. Where we would send a bad query if a legacy pub had no discussions.
2. Where we assumed a discussion always had a `comment.author`, but in cases with anonymous comments it has a `comment.commenter`.
3. We were passing in an undefined ORCID url even if the user didn't have an ORCID

<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan
### Discussions Issue
- Import a pub with no discussions and make sure versions show up
- Import a pub with discussions and make sure they show up
- Repeat both and make sure both work as expected.

### Comments and ORCID Issue
- Import a pub with anonymous `comment.commenter` discussions.
- Make sure it loads
- Make sure any users with ORCIDs and avatars have them passed in

## Screenshots (if applicable)

## Notes
