### PR TITLE
pass null instead of empty string to avoid validation errors

### DIFF
--- a/core/actions/googleDriveImport/formatDriveData.ts
+++ b/core/actions/googleDriveImport/formatDriveData.ts
@@ -113,12 +113,12 @@ export const formatDriveData = async (
 						? comment.author.fullName
 						: comment.commenter
 							? comment.commenter.name
-							: "";
+							: null;
 					const commentAuthorAvatar = comment.author
 						? comment.author.avatar
 						: comment.commenter
 							? comment.commenter.avatar
-							: "";
+							: null;
 					const commentAuthorORCID =
 						comment.author && comment.author.orcid
 							? `https://orcid.org/${comment.author.orcid}`

--- a/core/actions/googleDriveImport/formatDriveData.ts
+++ b/core/actions/googleDriveImport/formatDriveData.ts
@@ -114,11 +114,12 @@ export const formatDriveData = async (
 						: comment.commenter
 							? comment.commenter.name
 							: null;
-					const commentAuthorAvatar = comment.author
-						? comment.author.avatar
-						: comment.commenter
-							? comment.commenter.avatar
-							: null;
+					const commentAuthorAvatar =
+						comment.author && comment.author.avatar
+							? comment.author.avatar
+							: comment.commenter && comment.commenter.avatar
+								? comment.commenter.avatar
+								: null;
 					const commentAuthorORCID =
 						comment.author && comment.author.orcid
 							? `https://orcid.org/${comment.author.orcid}`


### PR DESCRIPTION
## Issue(s) Resolved
Passing empty string instead of null caused validation errors where a non-string type was expected (e.g. a URL). This fixes that.

## High-level Explanation of PR

<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan

## Screenshots (if applicable)

## Notes
