### PR TITLE
dev (next 15|3): add onRequestError which allows sentry capture of deep server component errors 

### DIFF
--- a/core/instrumentation.onRequestError.ts
+++ b/core/instrumentation.onRequestError.ts
@@ -1,0 +1,3 @@
+import * as Sentry from "@sentry/nextjs";
+
+export const onRequestError = Sentry.captureRequestError;

--- a/core/instrumentation.ts
+++ b/core/instrumentation.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-restricted-properties */
+import * as Sentry from "@sentry/nextjs";
+
 import { logger } from "logger";
 
 export async function register() {
@@ -26,3 +28,5 @@ export async function register() {
 		logger.info("NEXT_RUNTIME is not `nodejs`; skipping OTEL registration.");
 	}
 }
+
+export const onRequestError = Sentry.captureRequestError;

--- a/core/instrumentation.ts
+++ b/core/instrumentation.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-properties */
-import * as Sentry from "@sentry/nextjs";
+import type { InstrumentationOnRequestError } from "next/dist/server/instrumentation/types";
 
 import { logger } from "logger";
 
@@ -29,4 +29,9 @@ export async function register() {
 	}
 }
 
-export const onRequestError = Sentry.captureRequestError;
+export const onRequestError: InstrumentationOnRequestError = async (...args) => {
+	// necessary in order to avoid OOM errors on build due to Sentry making it
+	// hard for webpack to optimize
+	const onRequestError = await import("./instrumentation.onRequestError.ts");
+	return onRequestError.onRequestError(...args);
+};


### PR DESCRIPTION
## Issue(s) Resolved
Previously, whenever an uncaptured error was thrown in a deeply nested server component (ie not at the top level of a page or layout), sentry would report this mysterious error in prod

`An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of...`



## High-level Explanation of PR

The above vague error was due to some Next limitation (https://github.com/getsentry/sentry-javascript/issues/14164#issuecomment-2454289406).

I believe the Next team worked with Sentry to fix this, by exposing a `onRequestError` export in `instumentation.ts`.

By setting that, Sentry is now able to properly report the error.

## Test Plan

1. On `main`, or the base of this PR (https://github.com/pubpub/platform/pull/875), throw an error in some deeply nested server component, eg. turn this
https://github.com/pubpub/platform/blob/8553d9b374906457e76c771aeec9a42670f8ad90/core/app/c/%5BcommunitySlug%5D/pubs/PubList.tsx#L25-L26
into this:
```ts
const PaginatedPubListInner = async (props: PaginatedPubListProps) => {
    throw new Error("some deeply nested error");
	const [count, pubs] = await Promise.all([
```
2. Run `pnpm build` and trigger the error (in the above case by going to `/pubs`)
3. Wait a minute, look at sentry (or in `#platform-alerts`. It should give an error like `An error occurred in the Server Components render`.

___

1. Switch to this branch, `pnpm i` etc etc
2. Add the same error and `pnpm build` again, and trigger the error.
3. It should now give a much clearer error

## Screenshots (if applicable)

## Notes
