### PR TITLE
fix: missing await

### DIFF
--- a/core/app/c/[communitySlug]/stages/manage/components/panel/StagePanelPubs.tsx
+++ b/core/app/c/[communitySlug]/stages/manage/components/panel/StagePanelPubs.tsx
@@ -25,7 +25,7 @@ const StagePanelPubsInner = async (props: PropsInner) => {
 		getStageActions(props.stageId).execute(),
 		getStage(props.stageId, props.userId).executeTakeFirst(),
 	]);
-	const communitySlug = getCommunitySlug();
+	const communitySlug = await getCommunitySlug();
 
 	if (!stage) {
 		throw new Error("Stage not found");


### PR DESCRIPTION
Quick fix to get the Pubs panel on the stage management page working again.