### PR TITLE
Make first new versions when there's no migrated version

### DIFF
--- a/core/actions/googleDriveImport/run.ts
+++ b/core/actions/googleDriveImport/run.ts
@@ -134,7 +134,6 @@ export const run = defineRun<typeof action>(
 				)[0].value;
 
 				if (latestVersionContent !== formattedData.pubHtml) {
-					console.log("no match");
 					relations.push({
 						slug: `${communitySlug}:versions`,
 						value: null,

--- a/core/actions/googleDriveImport/run.ts
+++ b/core/actions/googleDriveImport/run.ts
@@ -134,6 +134,7 @@ export const run = defineRun<typeof action>(
 				)[0].value;
 
 				if (latestVersionContent !== formattedData.pubHtml) {
+					console.log("no match");
 					relations.push({
 						slug: `${communitySlug}:versions`,
 						value: null,
@@ -142,6 +143,21 @@ export const run = defineRun<typeof action>(
 							values: {
 								[`${communitySlug}:description`]: "",
 								//[`${communitySlug}:publication-date`]: new Date().toISOString(),
+								[`${communitySlug}:content`]: formattedData.pubHtml,
+							},
+						},
+					});
+				}
+				// If there's html but no version yet exists, create one
+			} else {
+				if (formattedData.pubHtml) {
+					relations.push({
+						slug: `${communitySlug}:versions`,
+						value: null,
+						relatedPub: {
+							pubTypeId: VersionType?.id || "",
+							values: {
+								[`${communitySlug}:description`]: "",
 								[`${communitySlug}:content`]: formattedData.pubHtml,
 							},
 						},


### PR DESCRIPTION
## Issue(s) Resolved
Previously, no new version would be created if there wasn't already a version from the legacy migration. This fixes that.

## High-level Explanation of PR
If there's no existing version, it creates one from the existing HTML.

<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan
Tested with brand new pub and also with a legacy pub, and both seem to work.

## Screenshots (if applicable)

## Notes
