### PR TITLE
Explicitly specify alpine version in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@
 # https://docs.docker.com/go/dockerfile-reference/
 
 ARG NODE_VERSION=22.13.1
+ARG ALPINE_VERSION=3.20
 
 ARG PACKAGE
 ARG PORT=3000
@@ -14,7 +15,7 @@ ARG PNPM_VERSION=9.10.0
 
 ################################################################################
 # Use node image for base image for all stages.
-FROM node:${NODE_VERSION}-alpine as base
+FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} as base
 
 # these are necessary to be able to use them inside of `base`
 ARG BASE_IMAGE


### PR DESCRIPTION
## Issue(s) Resolved
The most recent ECS task deployment failed because the containers running our new node version don't seem to be able to run prisma migrate because they're missing openssl. See these logs
https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/stevie-ecs-cluster-production/services/stevie-core/tasks/3813ad323b9d400086b5bc0d1181e8e7/logs?region=us-east-1

It turns out this is because moving from the image tag `node:20.17.0-alpine` to `node:22.13.1-alpine` also moved us from alpine `3.20.3` to `3.21.2`, which opens us up to [this prisma issue](https://github.com/prisma/prisma/issues/25817#issuecomment-2538544254) because libssl is installed in a different directory. We can probably also fix this by upgrading prisma now, but we should pin the underlying OS version anyways.

## Test Plan
See if the deployment succeeds
