### PR TITLE
RFC: pubOp for creating and updating pubs more easily

### DIFF
--- a/core/actions/_lib/runActionInstance.db.test.ts
+++ b/core/actions/_lib/runActionInstance.db.test.ts
@@ -10,7 +10,7 @@ const { getTrx, rollback, commit } = createForEachMockedTransaction();
 
 const pubTriggerTestSeed = async () => {
 	const slugName = `test-server-pub-${new Date().toISOString()}`;
-	const { createSeed } = await import("~/prisma/seed/seedCommunity");
+	const { createSeed } = await import("~/prisma/seed/createSeed");
 
 	return createSeed({
 		community: {

--- a/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
+++ b/core/app/api/v0/c/[communitySlug]/site/[...ts-rest]/route.ts
@@ -373,7 +373,7 @@ const handler = createNextHandler(
 				};
 			},
 			archive: async ({ params }) => {
-				const { lastModifiedBy } = await checkAuthorization({
+				const { lastModifiedBy, community } = await checkAuthorization({
 					token: { scope: ApiAccessScope.pub, type: ApiAccessType.write },
 					cookies: {
 						capability: Capabilities.deletePub,
@@ -383,6 +383,7 @@ const handler = createNextHandler(
 
 				const result = await deletePub({
 					pubId: params.pubId as PubsId,
+					communityId: community.id,
 					lastModifiedBy,
 				});
 

--- a/core/app/components/pubs/PubEditor/actions.ts
+++ b/core/app/components/pubs/PubEditor/actions.ts
@@ -178,7 +178,7 @@ export const removePub = defineServerAction(async function removePub({ pubId }: 
 	}
 
 	try {
-		await deletePub({ pubId, lastModifiedBy });
+		await deletePub({ pubId, lastModifiedBy, communityId: community.id });
 
 		return {
 			success: true,

--- a/core/lib/__tests__/globalSetup.ts
+++ b/core/lib/__tests__/globalSetup.ts
@@ -7,7 +7,10 @@ import { logger } from "logger";
 
 export const setup = async () => {
 	config({
-		path: ["./.env.test", "./.env.test.local"],
+		path: [
+			new URL("../../.env.test", import.meta.url).pathname,
+			new URL("../../.env.test.local", import.meta.url).pathname,
+		],
 	});
 
 	if (process.env.SKIP_RESET) {

--- a/core/lib/__tests__/matchers.ts
+++ b/core/lib/__tests__/matchers.ts
@@ -1,0 +1,67 @@
+import { expect } from "vitest";
+
+import type { ProcessedPub } from "contracts";
+import type { PubsId } from "db/public";
+
+import type { db } from "~/kysely/database";
+
+expect.extend({
+	async toExist(received: PubsId | ProcessedPub, expected?: typeof db) {
+		if (typeof received !== "string") {
+			throw new Error("toExist() can only be called with a PubsId");
+		}
+		const { getPlainPub } = await import("../server/pub");
+
+		const pub = await getPlainPub(received, expected).executeTakeFirst();
+		const pass = Boolean(pub && pub.id === received);
+		const { isNot } = this;
+
+		return {
+			pass,
+			message: () =>
+				pass
+					? `Expected pub with ID ${received} ${isNot ? "not" : ""} to exist, and it does ${isNot ? "not" : ""}`
+					: `Expected pub with ID ${received} ${isNot ? "not to" : "to"} exist, but it does not`,
+		};
+	},
+
+	toHaveValues(
+		received: PubsId | ProcessedPub,
+		expected: Partial<ProcessedPub["values"][number]>[]
+	) {
+		if (typeof received === "string") {
+			throw new Error("toHaveValues() can only be called with a ProcessedPub");
+		}
+
+		const pub = received;
+		const sortedPubValues = [...pub.values].sort((a, b) =>
+			(a.value as string).localeCompare(b.value as string)
+		);
+
+		const expectedLength = expected.length;
+		const receivedLength = sortedPubValues.length;
+
+		const isNot = this.isNot;
+		if (!isNot && !this.equals(expectedLength, receivedLength)) {
+			return {
+				pass: false,
+				message: () =>
+					`Expected pub to have ${expectedLength} values, but it has ${receivedLength}`,
+			};
+		}
+
+		// equiv. to .toMatchObject
+		const pass = this.equals(sortedPubValues, expected, [
+			this.utils.iterableEquality,
+			this.utils.subsetEquality,
+		]);
+
+		return {
+			pass,
+			message: () =>
+				pass
+					? `Expected pub ${isNot ? "not" : ""} to have values ${JSON.stringify(expected)}, and it does ${isNot ? "not" : ""}`
+					: `Expected pub ${isNot ? "not to" : "to"} match values ${this.utils.diff(sortedPubValues, expected)}`,
+		};
+	},
+});

--- a/core/lib/__tests__/matchers.ts
+++ b/core/lib/__tests__/matchers.ts
@@ -17,10 +17,7 @@ const deepSortValues = (pub: ProcessedPub): ProcessedPub => {
 };
 
 expect.extend({
-	async toExist(received: PubsId | ProcessedPub, expected?: typeof db) {
-		if (typeof received !== "string") {
-			throw new Error("toExist() can only be called with a PubsId");
-		}
+	async toExist(received: PubsId, expected?: typeof db) {
 		const { getPlainPub } = await import("../server/pub");
 
 		const pub = await getPlainPub(received, expected).executeTakeFirst();
@@ -36,14 +33,7 @@ expect.extend({
 		};
 	},
 
-	toHaveValues(
-		received: PubsId | ProcessedPub,
-		expected: Partial<ProcessedPub["values"][number]>[]
-	) {
-		if (typeof received === "string") {
-			throw new Error("toHaveValues() can only be called with a ProcessedPub");
-		}
-
+	toHaveValues(received: ProcessedPub, expected: Partial<ProcessedPub["values"][number]>[]) {
 		const pub = received;
 		const sortedPubValues = deepSortValues(pub);
 

--- a/core/lib/__tests__/matchers.ts
+++ b/core/lib/__tests__/matchers.ts
@@ -19,9 +19,9 @@ expect.extend({
 		return {
 			pass,
 			message: () =>
-				pass
-					? `Expected pub with ID ${received} ${isNot ? "not" : ""} to exist, and it does ${isNot ? "not" : ""}`
-					: `Expected pub with ID ${received} ${isNot ? "not to" : "to"} exist, but it does not`,
+				isNot
+					? `Expected pub with ID ${received} not to exist, but it ${pass ? "does" : "does not"}`
+					: `Expected pub with ID ${received} to exist, but it ${pass ? "does" : "does not"}`,
 		};
 	},
 

--- a/core/lib/server/pub-capabilities.db.test.ts
+++ b/core/lib/server/pub-capabilities.db.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import { CoreSchemaType, MemberRole } from "db/public";
 
-import type { Seed } from "~/prisma/seed/seedCommunity";
+import { createSeed } from "~/prisma/seed/createSeed";
 import { mockServerCode } from "../__tests__/utils";
 
 await mockServerCode();
 
-const seed = {
+const seed = createSeed({
 	community: {
 		name: "test-pub-capabilities",
 		slug: "test-pub-capabilities",
@@ -97,7 +97,7 @@ const seed = {
 			},
 		},
 	],
-} as Seed;
+});
 
 describe("getPubsWithRelatedValuesAndChildren capabilities", () => {
 	it("should restrict pubs by visibility", async () => {

--- a/core/lib/server/pub-op.db.test.ts
+++ b/core/lib/server/pub-op.db.test.ts
@@ -1178,13 +1178,6 @@ describe("PubOp stage", () => {
 			.setStage(seededCommunity.stages["Stage 2"].id)
 			.execute();
 
-		const stages = await trx
-			.selectFrom("PubsInStages")
-			.selectAll()
-			.where("pubId", "=", pub.id)
-			.execute();
-		console.log(stages);
-
-		// expect(stages).toEqual([{ pubId: pub.id, stageId: seededCommunity.stages["Stage 2"].id }]);
+		expect(updatedPub.stageId).toEqual(seededCommunity.stages["Stage 2"].id);
 	});
 });

--- a/core/lib/server/pub-op.db.test.ts
+++ b/core/lib/server/pub-op.db.test.ts
@@ -176,11 +176,7 @@ describe("PubOp", () => {
 			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.connect(
-				seededCommunity.pubFields["Some relation"].slug,
-				pub.id,
-				"test relations value"
-			)
+			.relate(seededCommunity.pubFields["Some relation"].slug, "test relations value", pub.id)
 			.execute();
 
 		await expect(pub2.id).toExist();
@@ -200,23 +196,23 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Main Pub")
-			.connect(
+			.relate(
 				seededCommunity.pubFields["Some relation"].slug,
+				"the first related pub",
 				PubOp.create({
 					communityId: seededCommunity.community.id,
 					pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 					lastModifiedBy: createLastModifiedBy("system"),
-				}).set(seededCommunity.pubFields["Title"].slug, "Related Pub 1"),
-				"the first related pub"
+				}).set(seededCommunity.pubFields["Title"].slug, "Related Pub 1")
 			)
-			.connect(
+			.relate(
 				seededCommunity.pubFields["Another relation"].slug,
+				"the second related pub",
 				PubOp.create({
 					communityId: seededCommunity.community.id,
 					pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 					lastModifiedBy: createLastModifiedBy("system"),
-				}).set(seededCommunity.pubFields["Title"].slug, "Related Pub 2"),
-				"the second related pub"
+				}).set(seededCommunity.pubFields["Title"].slug, "Related Pub 2")
 			);
 
 		const result = await mainPub.execute();
@@ -243,14 +239,15 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Level 1")
-			.connect(
+			.relate(
 				seededCommunity.pubFields["Another relation"].slug,
+				"the second related pub",
+
 				PubOp.create({
 					communityId: seededCommunity.community.id,
 					pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 					lastModifiedBy: createLastModifiedBy("system"),
-				}).set(seededCommunity.pubFields["Title"].slug, "Level 2"),
-				"the second related pub"
+				}).set(seededCommunity.pubFields["Title"].slug, "Level 2")
 			);
 
 		const mainPub = PubOp.create({
@@ -259,10 +256,10 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Root")
-			.connect(
+			.relate(
 				seededCommunity.pubFields["Some relation"].slug,
-				relatedPub,
-				"the first related pub"
+				"the first related pub",
+				relatedPub
 			);
 
 		const result = await mainPub.execute();
@@ -306,19 +303,19 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Main Pub")
-			.connect(
+			.relate(
 				seededCommunity.pubFields["Some relation"].slug,
-				existingPub.id,
-				"the first related pub"
+				"the first related pub",
+				existingPub.id
 			)
-			.connect(
+			.relate(
 				seededCommunity.pubFields["Another relation"].slug,
+				"the second related pub",
 				PubOp.create({
 					communityId: seededCommunity.community.id,
 					pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 					lastModifiedBy: createLastModifiedBy("system"),
-				}).set(seededCommunity.pubFields["Title"].slug, "New Related Pub"),
-				"the second related pub"
+				}).set(seededCommunity.pubFields["Title"].slug, "New Related Pub")
 			);
 
 		const result = await mainPub.execute();
@@ -368,16 +365,12 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Pub 2")
-			.connect(
-				seededCommunity.pubFields["Some relation"].slug,
-				pub1,
-				"the first related pub"
-			);
+			.relate(seededCommunity.pubFields["Some relation"].slug, "the first related pub", pub1);
 
-		pub1.connect(
+		pub1.relate(
 			seededCommunity.pubFields["Another relation"].slug,
-			pub2,
-			"the second related pub"
+			"the second related pub",
+			pub2
 		);
 
 		const result = await pub1.execute();
@@ -429,7 +422,7 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Pub 2")
-			.connect(seededCommunity.pubFields["Some relation"].slug, pub1.id, "initial value")
+			.relate(seededCommunity.pubFields["Some relation"].slug, "initial value", pub1.id)
 			.execute();
 
 		const updatedPub = await PubOp.upsert(pub2.id, {
@@ -437,7 +430,7 @@ describe("PubOp", () => {
 			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.connect(seededCommunity.pubFields["Some relation"].slug, pub1.id, "updated value")
+			.relate(seededCommunity.pubFields["Some relation"].slug, "updated value", pub1.id)
 			.execute();
 
 		expect(updatedPub).toHaveValues([
@@ -457,14 +450,15 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Pub 1")
-			.connect(
+			.relate(
 				seededCommunity.pubFields["Some relation"].slug,
+				"relation",
+
 				PubOp.create({
 					communityId: seededCommunity.community.id,
 					pubTypeId: seededCommunity.pubTypes["Minimal Pub"].id,
 					lastModifiedBy: createLastModifiedBy("system"),
-				}).set(seededCommunity.pubFields["Title"].slug, "Pub 2"),
-				"relation"
+				}).set(seededCommunity.pubFields["Title"].slug, "Pub 2")
 			)
 			.execute();
 
@@ -486,8 +480,7 @@ describe("PubOp", () => {
 });
 
 describe("relation management", () => {
-	it("should disconnect a specific relation", async () => {
-		// Create two pubs to relate
+	it("should disrelate a specific relation", async () => {
 		const pub1 = await PubOp.create({
 			communityId: seededCommunity.community.id,
 			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
@@ -502,15 +495,15 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Pub 2")
-			.connect(seededCommunity.pubFields["Some relation"].slug, pub1.id, "initial value")
+			.relate(seededCommunity.pubFields["Some relation"].slug, "initial value", pub1.id)
 			.execute();
 
-		// Disconnect the relation
+		// disrelate the relation
 		const updatedPub = await PubOp.update(pub2.id, {
 			communityId: seededCommunity.community.id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.disconnect(seededCommunity.pubFields["Some relation"].slug, pub1.id)
+			.unrelate(seededCommunity.pubFields["Some relation"].slug, pub1.id)
 			.execute();
 
 		expect(updatedPub).toHaveValues([
@@ -518,8 +511,7 @@ describe("relation management", () => {
 		]);
 	});
 
-	it("should delete orphaned pubs when disconnecting relations", async () => {
-		// Create a pub that will become orphaned
+	it("should delete orphaned pubs when disrelateing relations", async () => {
 		const orphanedPub = await PubOp.create({
 			communityId: seededCommunity.community.id,
 			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
@@ -528,26 +520,25 @@ describe("relation management", () => {
 			.set(seededCommunity.pubFields["Title"].slug, "Soon to be orphaned")
 			.execute();
 
-		// Create a pub that relates to it
 		const mainPub = await PubOp.create({
 			communityId: seededCommunity.community.id,
 			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Main pub")
-			.connect(
+			.relate(
 				seededCommunity.pubFields["Some relation"].slug,
-				orphanedPub.id,
-				"only relation"
+				"only relation",
+				orphanedPub.id
 			)
 			.execute();
 
-		// Disconnect with deleteOrphaned option
+		// disrelate with deleteOrphaned option
 		await PubOp.update(mainPub.id, {
 			communityId: seededCommunity.community.id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.disconnect(seededCommunity.pubFields["Some relation"].slug, orphanedPub.id, {
+			.unrelate(seededCommunity.pubFields["Some relation"].slug, orphanedPub.id, {
 				deleteOrphaned: true,
 			})
 			.execute();
@@ -556,41 +547,50 @@ describe("relation management", () => {
 	});
 
 	it("should clear all relations for a specific field", async () => {
-		// Create multiple related pubs
-		const related1 = PubOp.create({
+		const related1Id = crypto.randomUUID() as PubsId;
+		const related2Id = crypto.randomUUID() as PubsId;
+
+		const related1 = PubOp.createWithId(related1Id, {
 			communityId: seededCommunity.community.id,
 			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		}).set(seededCommunity.pubFields["Title"].slug, "Related 1");
 
-		const related2 = PubOp.create({
+		const related2 = PubOp.createWithId(related2Id, {
 			communityId: seededCommunity.community.id,
 			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		}).set(seededCommunity.pubFields["Title"].slug, "Related 2");
 
-		// Create main pub with multiple relations
 		const mainPub = await PubOp.create({
 			communityId: seededCommunity.community.id,
 			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Main pub")
-			.connect(seededCommunity.pubFields["Some relation"].slug, related1, "relation 1")
-			.connect(seededCommunity.pubFields["Some relation"].slug, related2, "relation 2")
+			.relate(seededCommunity.pubFields["Some relation"].slug, "relation 1", related1)
+			.relate(seededCommunity.pubFields["Some relation"].slug, "relation 2", related2)
 			.execute();
 
-		// Clear all relations for the field
+		await expect(related1Id).toExist();
+		await expect(related2Id).toExist();
+
+		// clear all relations for the field
 		const updatedPub = await PubOp.update(mainPub.id, {
 			communityId: seededCommunity.community.id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.clearRelationsForField(seededCommunity.pubFields["Some relation"].slug)
+			.unrelate(seededCommunity.pubFields["Some relation"].slug, "*", {
+				deleteOrphaned: true,
+			})
 			.execute();
 
 		expect(updatedPub).toHaveValues([
 			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Main pub" },
 		]);
+
+		await expect(related1Id).not.toExist();
+		await expect(related2Id).not.toExist();
 	});
 
 	it("should override existing relations when using override option", async () => {
@@ -614,8 +614,8 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Main pub")
-			.connect(seededCommunity.pubFields["Some relation"].slug, related1, "relation 1")
-			.connect(seededCommunity.pubFields["Some relation"].slug, related2, "relation 2")
+			.relate(seededCommunity.pubFields["Some relation"].slug, "relation 1", related1)
+			.relate(seededCommunity.pubFields["Some relation"].slug, "relation 2", related2)
 			.execute();
 
 		const relatedPub1 = mainPub.values.find((v) => v.value === "relation 1")?.relatedPubId;
@@ -639,7 +639,7 @@ describe("relation management", () => {
 			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.connect(seededCommunity.pubFields["Some relation"].slug, related3.id, "new relation", {
+			.relate(seededCommunity.pubFields["Some relation"].slug, "new relation", related3.id, {
 				override: true,
 			})
 			.execute();
@@ -659,7 +659,6 @@ describe("relation management", () => {
 	});
 
 	it("should handle multiple override relations for the same field", async () => {
-		// Create related pubs
 		const related1 = await PubOp.create({
 			communityId: seededCommunity.community.id,
 			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
@@ -676,14 +675,13 @@ describe("relation management", () => {
 			.set(seededCommunity.pubFields["Title"].slug, "Related 2")
 			.execute();
 
-		// Create main pub and set multiple relations with override
 		const mainPub = await PubOp.create({
 			communityId: seededCommunity.community.id,
 			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Main pub")
-			.connect(seededCommunity.pubFields["Some relation"].slug, related1.id, "relation 1", {
+			.relate(seededCommunity.pubFields["Some relation"].slug, "relation 1", related1.id, {
 				override: true,
 			})
 			.execute();
@@ -692,17 +690,17 @@ describe("relation management", () => {
 			communityId: seededCommunity.community.id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.connect(seededCommunity.pubFields["Some relation"].slug, related2.id, "relation 2", {
+			.relate(seededCommunity.pubFields["Some relation"].slug, "relation 2", related2.id, {
 				override: true,
 			})
-			.connect(
+			.relate(
 				seededCommunity.pubFields["Some relation"].slug,
+				"relation 3",
 				PubOp.create({
 					communityId: seededCommunity.community.id,
 					pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 					lastModifiedBy: createLastModifiedBy("system"),
 				}),
-				"relation 3",
 				{ override: true }
 			)
 			.execute();
@@ -741,7 +739,7 @@ describe("relation management", () => {
 			const pubK = "55555555-0000-0000-0000-000000000000" as PubsId;
 			const pubL = "66666666-0000-0000-0000-000000000000" as PubsId;
 
-			// Create the graph structure:
+			// create the graph structure:
 			//          A          J
 			//       /     \       |
 			//     /        \      |
@@ -753,7 +751,7 @@ describe("relation management", () => {
 			//                 /  \
 			//                K --> L
 
-			// Create leaf nodes first
+			// create leaf nodes first
 			const pubL_op = PubOp.createWithId(pubL, {
 				communityId: seededCommunity.community.id,
 				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
@@ -768,7 +766,7 @@ describe("relation management", () => {
 				trx,
 			})
 				.set(seededCommunity.pubFields["Title"].slug, "K")
-				.connect(seededCommunity.pubFields["Some relation"].slug, pubL_op, "to L");
+				.relate(seededCommunity.pubFields["Some relation"].slug, "to L", pubL_op);
 
 			const pubF_op = PubOp.createWithId(pubF, {
 				communityId: seededCommunity.community.id,
@@ -784,8 +782,8 @@ describe("relation management", () => {
 				trx,
 			})
 				.set(seededCommunity.pubFields["Title"].slug, "H")
-				.connect(seededCommunity.pubFields["Some relation"].slug, pubK_op, "to K")
-				.connect(seededCommunity.pubFields["Some relation"].slug, pubL_op, "to L");
+				.relate(seededCommunity.pubFields["Some relation"].slug, "to K", pubK_op)
+				.relate(seededCommunity.pubFields["Some relation"].slug, "to L", pubL_op);
 
 			const pubE_op = PubOp.createWithId(pubE, {
 				communityId: seededCommunity.community.id,
@@ -794,7 +792,7 @@ describe("relation management", () => {
 				trx,
 			})
 				.set(seededCommunity.pubFields["Title"].slug, "E")
-				.connect(seededCommunity.pubFields["Some relation"].slug, pubF_op, "to F");
+				.relate(seededCommunity.pubFields["Some relation"].slug, "to F", pubF_op);
 
 			const pubG_op = PubOp.createWithId(pubG, {
 				communityId: seededCommunity.community.id,
@@ -803,7 +801,7 @@ describe("relation management", () => {
 				trx,
 			})
 				.set(seededCommunity.pubFields["Title"].slug, "G")
-				.connect(seededCommunity.pubFields["Some relation"].slug, pubE_op, "to E");
+				.relate(seededCommunity.pubFields["Some relation"].slug, "to E", pubE_op);
 
 			const pubD_op = PubOp.createWithId(pubD, {
 				communityId: seededCommunity.community.id,
@@ -812,7 +810,7 @@ describe("relation management", () => {
 				trx,
 			})
 				.set(seededCommunity.pubFields["Title"].slug, "D")
-				.connect(seededCommunity.pubFields["Some relation"].slug, pubH_op, "to H");
+				.relate(seededCommunity.pubFields["Some relation"].slug, "to H", pubH_op);
 
 			const pubI_op = PubOp.createWithId(pubI, {
 				communityId: seededCommunity.community.id,
@@ -829,7 +827,7 @@ describe("relation management", () => {
 				trx,
 			})
 				.set(seededCommunity.pubFields["Title"].slug, "B")
-				.connect(seededCommunity.pubFields["Some relation"].slug, pubG_op, "to G");
+				.relate(seededCommunity.pubFields["Some relation"].slug, "to G", pubG_op);
 
 			const pubC_op = PubOp.createWithId(pubC, {
 				communityId: seededCommunity.community.id,
@@ -838,11 +836,11 @@ describe("relation management", () => {
 				trx,
 			})
 				.set(seededCommunity.pubFields["Title"].slug, "C")
-				.connect(seededCommunity.pubFields["Some relation"].slug, pubI_op, "to I")
-				.connect(seededCommunity.pubFields["Some relation"].slug, pubD_op, "to D")
-				.connect(seededCommunity.pubFields["Some relation"].slug, pubE_op, "to E");
+				.relate(seededCommunity.pubFields["Some relation"].slug, "to I", pubI_op)
+				.relate(seededCommunity.pubFields["Some relation"].slug, "to D", pubD_op)
+				.relate(seededCommunity.pubFields["Some relation"].slug, "to E", pubE_op);
 
-			// Create root
+			// create root and J
 			const rootPub = await PubOp.createWithId(pubA, {
 				communityId: seededCommunity.community.id,
 				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
@@ -850,8 +848,8 @@ describe("relation management", () => {
 				trx,
 			})
 				.set(seededCommunity.pubFields["Title"].slug, "A")
-				.connect(seededCommunity.pubFields["Some relation"].slug, pubB_op, "to B")
-				.connect(seededCommunity.pubFields["Some relation"].slug, pubC_op, "to C")
+				.relate(seededCommunity.pubFields["Some relation"].slug, "to B", pubB_op)
+				.relate(seededCommunity.pubFields["Some relation"].slug, "to C", pubC_op)
 				.execute();
 
 			const pubJ_op = await PubOp.createWithId(pubJ, {
@@ -861,7 +859,7 @@ describe("relation management", () => {
 				trx,
 			})
 				.set(seededCommunity.pubFields["Title"].slug, "J")
-				.connect(seededCommunity.pubFields["Some relation"].slug, pubI, "to I")
+				.relate(seededCommunity.pubFields["Some relation"].slug, "to I", pubI)
 				.execute();
 
 			const { getPubsWithRelatedValuesAndChildren } = await import("~/lib/server/pub");
@@ -970,7 +968,7 @@ describe("relation management", () => {
 				},
 			]);
 
-			// Now disconnect C from A, which should
+			// Now we disrelate C from A, which should
 			//  orphan everything from D down,
 			// but should not orphan I, bc J still points to it
 			// and should not orphan G, bc B still points to it
@@ -993,22 +991,22 @@ describe("relation management", () => {
 				lastModifiedBy: createLastModifiedBy("system"),
 				trx,
 			})
-				.disconnect(seededCommunity.pubFields["Some relation"].slug, pubC, {
+				.unrelate(seededCommunity.pubFields["Some relation"].slug, pubC, {
 					deleteOrphaned: true,
 				})
 				.execute();
 
-			// Verify deletions
+			// verify deletions
 			await expect(pubA, "A should exist").toExist(trx);
 			await expect(pubB, "B should exist").toExist(trx);
 			await expect(pubC, "C should not exist").not.toExist(trx);
 			await expect(pubD, "D should not exist").not.toExist(trx);
-			await expect(pubE, "E should exist").toExist(trx); // Still connected through G
-			await expect(pubF, "F should exist").toExist(trx);
-			await expect(pubG, "G should exist").toExist(trx);
+			await expect(pubE, "E should exist").toExist(trx); // still relateed through G
+			await expect(pubF, "F should exist").toExist(trx); // still relateed through E
+			await expect(pubG, "G should exist").toExist(trx); // not relateed to C at all
 			await expect(pubH, "H should not exist").not.toExist(trx);
-			await expect(pubI, "I should exist").toExist(trx); // Still connected through J
-			await expect(pubJ, "J should exist").toExist(trx);
+			await expect(pubI, "I should exist").toExist(trx); // still relateed through J
+			await expect(pubJ, "J should exist").toExist(trx); // not relateed to C at all
 			await expect(pubK, "K should not exist").not.toExist(trx);
 			await expect(pubL, "L should not exist").not.toExist(trx);
 		} catch (e) {
@@ -1041,24 +1039,24 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Main")
-			.connect(seededCommunity.pubFields["Some relation"].slug, related1.id, "relation1")
-			.connect(seededCommunity.pubFields["Another relation"].slug, related2.id, "relation2")
+			.relate(seededCommunity.pubFields["Some relation"].slug, "relation1", related1.id)
+			.relate(seededCommunity.pubFields["Another relation"].slug, "relation2", related2.id)
 			.execute();
 
-		// Clear one field with deleteOrphaned and one without
+		// clear one field with deleteOrphaned and one without
 		await PubOp.update(mainPub.id, {
 			communityId: seededCommunity.community.id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.clearRelationsForField(seededCommunity.pubFields["Some relation"].slug, {
+			.unrelate(seededCommunity.pubFields["Some relation"].slug, "*", {
 				deleteOrphaned: true,
 			})
-			.clearRelationsForField(seededCommunity.pubFields["Another relation"].slug)
+			.unrelate(seededCommunity.pubFields["Another relation"].slug, "*")
 			.execute();
 
-		// Related1 should be deleted (orphaned with deleteOrphaned: true)
+		// related1 should be deleted (orphaned with deleteOrphaned: true)
 		await expect(related1.id).not.toExist();
-		// Related2 should still exist (orphaned but deleteOrphaned not set)
+		// related2 should still exist (orphaned but deleteOrphaned not set)
 		await expect(related2.id).toExist();
 	});
 
@@ -1086,8 +1084,8 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Main")
-			.connect(seededCommunity.pubFields["Some relation"].slug, toKeep.id, "keep")
-			.connect(seededCommunity.pubFields["Another relation"].slug, toDelete.id, "delete")
+			.relate(seededCommunity.pubFields["Some relation"].slug, "keep", toKeep.id)
+			.relate(seededCommunity.pubFields["Another relation"].slug, "delete", toDelete.id)
 			.execute();
 
 		// Override relations with different deleteOrphaned flags
@@ -1101,10 +1099,10 @@ describe("relation management", () => {
 			communityId: seededCommunity.community.id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.connect(seededCommunity.pubFields["Some relation"].slug, newRelation, "new", {
+			.relate(seededCommunity.pubFields["Some relation"].slug, "new", newRelation, {
 				override: true,
 			})
-			.connect(seededCommunity.pubFields["Another relation"].slug, newRelation, "also new", {
+			.relate(seededCommunity.pubFields["Another relation"].slug, "also new", newRelation, {
 				override: true,
 				deleteOrphaned: true,
 			})
@@ -1114,6 +1112,38 @@ describe("relation management", () => {
 		await expect(toKeep.id).toExist();
 		// toDelete should be deleted (override with deleteOrphaned)
 		await expect(toDelete.id).not.toExist();
+	});
+
+	/**
+	 * this is so you do not need to keep specifying the communityId, pubTypeId, etc.
+	 * when creating nested PubOps
+	 */
+	it("should be able to do PubOps inline in a relate", async () => {
+		const pub = await PubOp.create({
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+		})
+			.set(seededCommunity.pubFields["Title"].slug, "Test")
+			.relate(seededCommunity.pubFields["Some relation"].slug, "relation1", (pubOp) =>
+				pubOp
+					.create({ pubTypeId: seededCommunity.pubTypes["Minimal Pub"].id })
+					.set(seededCommunity.pubFields["Title"].slug, "Relation 1")
+			)
+			.execute();
+
+		expect(pub).toHaveValues([
+			{
+				fieldSlug: seededCommunity.pubFields["Some relation"].slug,
+				value: "relation1",
+				relatedPub: {
+					values: [
+						{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Relation 1" },
+					],
+				},
+			},
+			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Test" },
+		]);
 	});
 });
 

--- a/core/lib/server/pub-op.db.test.ts
+++ b/core/lib/server/pub-op.db.test.ts
@@ -1,15 +1,18 @@
-import { describe, expect, expectTypeOf, it, vitest } from "vitest";
+import { beforeAll, beforeEach, describe, expect, expectTypeOf, it, vitest } from "vitest";
 
 import type { PubsId, PubTypes, Stages } from "db/public";
 import { CoreSchemaType, MemberRole } from "db/public";
 
+import type { CommunitySeedOutput } from "~/prisma/seed/createSeed";
+import type { seedCommunity } from "~/prisma/seed/seedCommunity";
 import { mockServerCode } from "~/lib/__tests__/utils";
 import { createLastModifiedBy } from "../lastModifiedBy";
 import { PubOp } from "./pub-op";
 
-const { createSeed, seedCommunity } = await import("~/prisma/seed/seedCommunity");
+const { createSeed } = await import("~/prisma/seed/createSeed");
 
 const { createForEachMockedTransaction } = await mockServerCode();
+const { getTrx, rollback, commit } = createForEachMockedTransaction();
 
 const seed = createSeed({
 	community: {
@@ -84,14 +87,19 @@ const seed = createSeed({
 	],
 });
 
-const { community, pubFields, pubTypes, stages, pubs, users } = await seedCommunity(seed);
+let seededCommunity: CommunitySeedOutput<typeof seed>;
+
+beforeAll(async () => {
+	const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
+	seededCommunity = await seedCommunity(seed);
+});
 
 describe("PubOp", () => {
 	it("should create a new pub", async () => {
 		const id = crypto.randomUUID() as PubsId;
 		const pubOp = PubOp.upsert(id, {
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		});
 
@@ -102,8 +110,8 @@ describe("PubOp", () => {
 	it("should not fail when upserting existing pub", async () => {
 		const id = crypto.randomUUID() as PubsId;
 		const pubOp = PubOp.upsert(id, {
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		});
 
@@ -111,8 +119,8 @@ describe("PubOp", () => {
 		await expect(pub.id).toExist();
 
 		const pub2 = await PubOp.upsert(id, {
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		}).execute();
 
@@ -122,13 +130,13 @@ describe("PubOp", () => {
 	it("should create a new pub and set values", async () => {
 		const id = crypto.randomUUID() as PubsId;
 		const pubOp = PubOp.upsert(id, {
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Some title")
+			.set(seededCommunity.pubFields["Title"].slug, "Some title")
 			.set({
-				[pubFields["Description"].slug]: "Some description",
+				[seededCommunity.pubFields["Description"].slug]: "Some description",
 			});
 
 		const pub = await pubOp.execute();
@@ -136,11 +144,11 @@ describe("PubOp", () => {
 
 		expect(pub).toHaveValues([
 			{
-				fieldSlug: pubFields["Description"].slug,
+				fieldSlug: seededCommunity.pubFields["Description"].slug,
 				value: "Some description",
 			},
 			{
-				fieldSlug: pubFields["Title"].slug,
+				fieldSlug: seededCommunity.pubFields["Title"].slug,
 				value: "Some title",
 			},
 		]);
@@ -148,8 +156,8 @@ describe("PubOp", () => {
 
 	it("should be able to relate existing pubs", async () => {
 		const pubOp = PubOp.upsert(crypto.randomUUID() as PubsId, {
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		});
 
@@ -158,17 +166,21 @@ describe("PubOp", () => {
 		await expect(pub.id).toExist();
 
 		const pub2 = await PubOp.upsert(crypto.randomUUID() as PubsId, {
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.connect(pubFields["Some relation"].slug, pub.id, "test relations value")
+			.connect(
+				seededCommunity.pubFields["Some relation"].slug,
+				pub.id,
+				"test relations value"
+			)
 			.execute();
 
 		await expect(pub2.id).toExist();
 		expect(pub2).toHaveValues([
 			{
-				fieldSlug: pubFields["Some relation"].slug,
+				fieldSlug: seededCommunity.pubFields["Some relation"].slug,
 				value: "test relations value",
 				relatedPubId: pub.id,
 			},
@@ -177,41 +189,41 @@ describe("PubOp", () => {
 
 	it("should create multiple related pubs in a single operation", async () => {
 		const mainPub = PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Main Pub")
+			.set(seededCommunity.pubFields["Title"].slug, "Main Pub")
 			.connect(
-				pubFields["Some relation"].slug,
+				seededCommunity.pubFields["Some relation"].slug,
 				PubOp.create({
-					communityId: community.id,
-					pubTypeId: pubTypes["Basic Pub"].id,
+					communityId: seededCommunity.community.id,
+					pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 					lastModifiedBy: createLastModifiedBy("system"),
-				}).set(pubFields["Title"].slug, "Related Pub 1"),
+				}).set(seededCommunity.pubFields["Title"].slug, "Related Pub 1"),
 				"the first related pub"
 			)
 			.connect(
-				pubFields["Another relation"].slug,
+				seededCommunity.pubFields["Another relation"].slug,
 				PubOp.create({
-					communityId: community.id,
-					pubTypeId: pubTypes["Basic Pub"].id,
+					communityId: seededCommunity.community.id,
+					pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 					lastModifiedBy: createLastModifiedBy("system"),
-				}).set(pubFields["Title"].slug, "Related Pub 2"),
+				}).set(seededCommunity.pubFields["Title"].slug, "Related Pub 2"),
 				"the second related pub"
 			);
 
 		const result = await mainPub.execute();
 
 		expect(result).toHaveValues([
-			{ fieldSlug: pubFields["Title"].slug, value: "Main Pub" },
+			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Main Pub" },
 			{
-				fieldSlug: pubFields["Some relation"].slug,
+				fieldSlug: seededCommunity.pubFields["Some relation"].slug,
 				value: "the first related pub",
 				relatedPubId: expect.any(String),
 			},
 			{
-				fieldSlug: pubFields["Another relation"].slug,
+				fieldSlug: seededCommunity.pubFields["Another relation"].slug,
 				value: "the second related pub",
 				relatedPubId: expect.any(String),
 			},
@@ -220,45 +232,49 @@ describe("PubOp", () => {
 
 	it("should handle deeply nested relations", async () => {
 		const relatedPub = PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Level 1")
+			.set(seededCommunity.pubFields["Title"].slug, "Level 1")
 			.connect(
-				pubFields["Another relation"].slug,
+				seededCommunity.pubFields["Another relation"].slug,
 				PubOp.create({
-					communityId: community.id,
-					pubTypeId: pubTypes["Basic Pub"].id,
+					communityId: seededCommunity.community.id,
+					pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 					lastModifiedBy: createLastModifiedBy("system"),
-				}).set(pubFields["Title"].slug, "Level 2"),
+				}).set(seededCommunity.pubFields["Title"].slug, "Level 2"),
 				"the second related pub"
 			);
 
 		const mainPub = PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Root")
-			.connect(pubFields["Some relation"].slug, relatedPub, "the first related pub");
+			.set(seededCommunity.pubFields["Title"].slug, "Root")
+			.connect(
+				seededCommunity.pubFields["Some relation"].slug,
+				relatedPub,
+				"the first related pub"
+			);
 
 		const result = await mainPub.execute();
 
 		expect(result).toHaveValues([
-			{ fieldSlug: pubFields["Title"].slug, value: "Root" },
+			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Root" },
 			{
-				fieldSlug: pubFields["Some relation"].slug,
+				fieldSlug: seededCommunity.pubFields["Some relation"].slug,
 				value: "the first related pub",
 				relatedPubId: expect.any(String),
 				relatedPub: {
 					values: [
 						{
-							fieldSlug: pubFields["Title"].slug,
+							fieldSlug: seededCommunity.pubFields["Title"].slug,
 							value: "Level 1",
 						},
 						{
-							fieldSlug: pubFields["Another relation"].slug,
+							fieldSlug: seededCommunity.pubFields["Another relation"].slug,
 							value: "the second related pub",
 							relatedPubId: expect.any(String),
 						},
@@ -271,49 +287,63 @@ describe("PubOp", () => {
 	it("should handle mixing existing and new pubs in relations", async () => {
 		// First create a pub that we'll relate to
 		const existingPub = await PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Existing Pub")
+			.set(seededCommunity.pubFields["Title"].slug, "Existing Pub")
 			.execute();
 
 		const mainPub = PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Main Pub")
-			.connect(pubFields["Some relation"].slug, existingPub.id, "the first related pub")
+			.set(seededCommunity.pubFields["Title"].slug, "Main Pub")
 			.connect(
-				pubFields["Another relation"].slug,
+				seededCommunity.pubFields["Some relation"].slug,
+				existingPub.id,
+				"the first related pub"
+			)
+			.connect(
+				seededCommunity.pubFields["Another relation"].slug,
 				PubOp.create({
-					communityId: community.id,
-					pubTypeId: pubTypes["Basic Pub"].id,
+					communityId: seededCommunity.community.id,
+					pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 					lastModifiedBy: createLastModifiedBy("system"),
-				}).set(pubFields["Title"].slug, "New Related Pub"),
+				}).set(seededCommunity.pubFields["Title"].slug, "New Related Pub"),
 				"the second related pub"
 			);
 
 		const result = await mainPub.execute();
 
 		expect(result).toHaveValues([
-			{ fieldSlug: pubFields["Title"].slug, value: "Main Pub" },
+			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Main Pub" },
 			{
-				fieldSlug: pubFields["Some relation"].slug,
+				fieldSlug: seededCommunity.pubFields["Some relation"].slug,
 				value: "the first related pub",
 				relatedPubId: existingPub.id,
 				relatedPub: {
 					id: existingPub.id,
-					values: [{ fieldSlug: pubFields["Title"].slug, value: "Existing Pub" }],
+					values: [
+						{
+							fieldSlug: seededCommunity.pubFields["Title"].slug,
+							value: "Existing Pub",
+						},
+					],
 				},
 			},
 			{
-				fieldSlug: pubFields["Another relation"].slug,
+				fieldSlug: seededCommunity.pubFields["Another relation"].slug,
 				value: "the second related pub",
 				relatedPubId: expect.any(String),
 				relatedPub: {
-					values: [{ fieldSlug: pubFields["Title"].slug, value: "New Related Pub" }],
+					values: [
+						{
+							fieldSlug: seededCommunity.pubFields["Title"].slug,
+							value: "New Related Pub",
+						},
+					],
 				},
 			},
 		]);
@@ -321,34 +351,42 @@ describe("PubOp", () => {
 
 	it("should handle circular relations", async () => {
 		const pub1 = PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
-		}).set(pubFields["Title"].slug, "Pub 1");
+		}).set(seededCommunity.pubFields["Title"].slug, "Pub 1");
 
 		const pub2 = PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Pub 2")
-			.connect(pubFields["Some relation"].slug, pub1, "the first related pub");
+			.set(seededCommunity.pubFields["Title"].slug, "Pub 2")
+			.connect(
+				seededCommunity.pubFields["Some relation"].slug,
+				pub1,
+				"the first related pub"
+			);
 
-		pub1.connect(pubFields["Another relation"].slug, pub2, "the second related pub");
+		pub1.connect(
+			seededCommunity.pubFields["Another relation"].slug,
+			pub2,
+			"the second related pub"
+		);
 
 		const result = await pub1.execute();
 
 		expect(result).toHaveValues([
-			{ fieldSlug: pubFields["Title"].slug, value: "Pub 1" },
+			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Pub 1" },
 			{
-				fieldSlug: pubFields["Another relation"].slug,
+				fieldSlug: seededCommunity.pubFields["Another relation"].slug,
 				value: "the second related pub",
 				relatedPubId: expect.any(String),
 				relatedPub: {
 					values: [
-						{ fieldSlug: pubFields["Title"].slug, value: "Pub 2" },
+						{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Pub 2" },
 						{
-							fieldSlug: pubFields["Some relation"].slug,
+							fieldSlug: seededCommunity.pubFields["Some relation"].slug,
 							value: "the first related pub",
 							relatedPubId: result.id,
 						},
@@ -359,9 +397,9 @@ describe("PubOp", () => {
 	});
 
 	it("should fail if you try to createWithId a pub that already exists", async () => {
-		const pubOp = PubOp.createWithId(pubs[0].id, {
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+		const pubOp = PubOp.createWithId(seededCommunity.pubs[0].id, {
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		});
 
@@ -372,34 +410,34 @@ describe("PubOp", () => {
 
 	it("should update the value of a relationship", async () => {
 		const pub1 = await PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Pub 1")
+			.set(seededCommunity.pubFields["Title"].slug, "Pub 1")
 			.execute();
 
 		const pub2 = await PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Pub 2")
-			.connect(pubFields["Some relation"].slug, pub1.id, "initial value")
+			.set(seededCommunity.pubFields["Title"].slug, "Pub 2")
+			.connect(seededCommunity.pubFields["Some relation"].slug, pub1.id, "initial value")
 			.execute();
 
 		const updatedPub = await PubOp.upsert(pub2.id, {
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.connect(pubFields["Some relation"].slug, pub1.id, "updated value")
+			.connect(seededCommunity.pubFields["Some relation"].slug, pub1.id, "updated value")
 			.execute();
 
 		expect(updatedPub).toHaveValues([
-			{ fieldSlug: pubFields["Title"].slug, value: "Pub 2" },
+			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Pub 2" },
 			{
-				fieldSlug: pubFields["Some relation"].slug,
+				fieldSlug: seededCommunity.pubFields["Some relation"].slug,
 				value: "updated value",
 				relatedPubId: pub1.id,
 			},
@@ -411,61 +449,69 @@ describe("relation management", () => {
 	it("should disconnect a specific relation", async () => {
 		// Create two pubs to relate
 		const pub1 = await PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Pub 1")
+			.set(seededCommunity.pubFields["Title"].slug, "Pub 1")
 			.execute();
 
 		const pub2 = await PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Pub 2")
-			.connect(pubFields["Some relation"].slug, pub1.id, "initial value")
+			.set(seededCommunity.pubFields["Title"].slug, "Pub 2")
+			.connect(seededCommunity.pubFields["Some relation"].slug, pub1.id, "initial value")
 			.execute();
 
 		// Disconnect the relation
 		const updatedPub = await PubOp.update(pub2.id, {
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.disconnect(pubFields["Some relation"].slug, pub1.id)
+			.disconnect(seededCommunity.pubFields["Some relation"].slug, pub1.id)
 			.execute();
 
-		expect(updatedPub).toHaveValues([{ fieldSlug: pubFields["Title"].slug, value: "Pub 2" }]);
+		expect(updatedPub).toHaveValues([
+			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Pub 2" },
+		]);
 	});
 
 	it("should delete orphaned pubs when disconnecting relations", async () => {
 		// Create a pub that will become orphaned
 		const orphanedPub = await PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Soon to be orphaned")
+			.set(seededCommunity.pubFields["Title"].slug, "Soon to be orphaned")
 			.execute();
 
 		// Create a pub that relates to it
 		const mainPub = await PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Main pub")
-			.connect(pubFields["Some relation"].slug, orphanedPub.id, "only relation")
+			.set(seededCommunity.pubFields["Title"].slug, "Main pub")
+			.connect(
+				seededCommunity.pubFields["Some relation"].slug,
+				orphanedPub.id,
+				"only relation"
+			)
 			.execute();
 
 		// Disconnect with deleteOrphaned option
 		await PubOp.update(mainPub.id, {
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.disconnect(pubFields["Some relation"].slug, orphanedPub.id, { deleteOrphaned: true })
+			.disconnect(seededCommunity.pubFields["Some relation"].slug, orphanedPub.id, {
+				deleteOrphaned: true,
+			})
 			.execute();
 
 		await expect(orphanedPub.id).not.toExist();
@@ -474,65 +520,65 @@ describe("relation management", () => {
 	it("should clear all relations for a specific field", async () => {
 		// Create multiple related pubs
 		const related1 = PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
-		}).set(pubFields["Title"].slug, "Related 1");
+		}).set(seededCommunity.pubFields["Title"].slug, "Related 1");
 
 		const related2 = PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
-		}).set(pubFields["Title"].slug, "Related 2");
+		}).set(seededCommunity.pubFields["Title"].slug, "Related 2");
 
 		// Create main pub with multiple relations
 		const mainPub = await PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Main pub")
-			.connect(pubFields["Some relation"].slug, related1, "relation 1")
-			.connect(pubFields["Some relation"].slug, related2, "relation 2")
+			.set(seededCommunity.pubFields["Title"].slug, "Main pub")
+			.connect(seededCommunity.pubFields["Some relation"].slug, related1, "relation 1")
+			.connect(seededCommunity.pubFields["Some relation"].slug, related2, "relation 2")
 			.execute();
 
 		// Clear all relations for the field
 		const updatedPub = await PubOp.update(mainPub.id, {
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.clearRelationsForField(pubFields["Some relation"].slug)
+			.clearRelationsForField(seededCommunity.pubFields["Some relation"].slug)
 			.execute();
 
 		expect(updatedPub).toHaveValues([
-			{ fieldSlug: pubFields["Title"].slug, value: "Main pub" },
+			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Main pub" },
 		]);
 	});
 
 	it("should override existing relations when using override option", async () => {
 		// Create initial related pubs
 		const related1 = PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
-		}).set(pubFields["Title"].slug, "Related 1");
+		}).set(seededCommunity.pubFields["Title"].slug, "Related 1");
 
 		const related2 = PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
-		}).set(pubFields["Title"].slug, "Related 2");
+		}).set(seededCommunity.pubFields["Title"].slug, "Related 2");
 
 		// Create main pub with initial relations
 		const mainPub = await PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Main pub")
-			.connect(pubFields["Some relation"].slug, related1, "relation 1")
-			.connect(pubFields["Some relation"].slug, related2, "relation 2")
+			.set(seededCommunity.pubFields["Title"].slug, "Main pub")
+			.connect(seededCommunity.pubFields["Some relation"].slug, related1, "relation 1")
+			.connect(seededCommunity.pubFields["Some relation"].slug, related2, "relation 2")
 			.execute();
 
 		const relatedPub1 = mainPub.values.find((v) => v.value === "relation 1")?.relatedPubId;
@@ -543,28 +589,28 @@ describe("relation management", () => {
 		await expect(relatedPub2).toExist();
 
 		const related3 = await PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Related 3")
+			.set(seededCommunity.pubFields["Title"].slug, "Related 3")
 			.execute();
 
 		// Update with override - only related3 should remain
 		const updatedPub = await PubOp.upsert(mainPub.id, {
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.connect(pubFields["Some relation"].slug, related3.id, "new relation", {
+			.connect(seededCommunity.pubFields["Some relation"].slug, related3.id, "new relation", {
 				override: true,
 			})
 			.execute();
 
 		expect(updatedPub).toHaveValues([
-			{ fieldSlug: pubFields["Title"].slug, value: "Main pub" },
+			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Main pub" },
 			{
-				fieldSlug: pubFields["Some relation"].slug,
+				fieldSlug: seededCommunity.pubFields["Some relation"].slug,
 				value: "new relation",
 				relatedPubId: related3.id,
 			},
@@ -578,42 +624,46 @@ describe("relation management", () => {
 	it("should handle multiple override relations for the same field", async () => {
 		// Create related pubs
 		const related1 = await PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Related 1")
+			.set(seededCommunity.pubFields["Title"].slug, "Related 1")
 			.execute();
 
 		const related2 = await PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Related 2")
+			.set(seededCommunity.pubFields["Title"].slug, "Related 2")
 			.execute();
 
 		// Create main pub and set multiple relations with override
 		const mainPub = await PubOp.create({
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.set(pubFields["Title"].slug, "Main pub")
-			.connect(pubFields["Some relation"].slug, related1.id, "relation 1", { override: true })
+			.set(seededCommunity.pubFields["Title"].slug, "Main pub")
+			.connect(seededCommunity.pubFields["Some relation"].slug, related1.id, "relation 1", {
+				override: true,
+			})
 			.execute();
 
 		const updatedMainPub = await PubOp.update(mainPub.id, {
-			communityId: community.id,
-			pubTypeId: pubTypes["Basic Pub"].id,
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
-			.connect(pubFields["Some relation"].slug, related2.id, "relation 2", { override: true })
+			.connect(seededCommunity.pubFields["Some relation"].slug, related2.id, "relation 2", {
+				override: true,
+			})
 			.connect(
-				pubFields["Some relation"].slug,
+				seededCommunity.pubFields["Some relation"].slug,
 				PubOp.create({
-					communityId: community.id,
-					pubTypeId: pubTypes["Basic Pub"].id,
+					communityId: seededCommunity.community.id,
+					pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 					lastModifiedBy: createLastModifiedBy("system"),
 				}),
 				"relation 3",
@@ -623,17 +673,411 @@ describe("relation management", () => {
 
 		// Should have relation 2 and 3, but not 1
 		expect(updatedMainPub).toHaveValues([
-			{ fieldSlug: pubFields["Title"].slug, value: "Main pub" },
+			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Main pub" },
 			{
-				fieldSlug: pubFields["Some relation"].slug,
+				fieldSlug: seededCommunity.pubFields["Some relation"].slug,
 				value: "relation 2",
 				relatedPubId: related2.id,
 			},
 			{
-				fieldSlug: pubFields["Some relation"].slug,
+				fieldSlug: seededCommunity.pubFields["Some relation"].slug,
 				value: "relation 3",
 				relatedPubId: expect.any(String),
 			},
 		]);
+	});
+
+	it("should handle complex nested relation scenarios", async () => {
+		const trx = getTrx();
+		// manual rollback try/catch bc we are manually setting pubIds, so a failure in the middle of this will leave the db in a weird state
+		try {
+			// Create all pubs with meaningful IDs
+			const pubA = "aaaaaaaa-0000-0000-0000-000000000000" as PubsId;
+			const pubB = "bbbbbbbb-0000-0000-0000-000000000000" as PubsId;
+			const pubC = "cccccccc-0000-0000-0000-000000000000" as PubsId;
+			const pubD = "dddddddd-0000-0000-0000-000000000000" as PubsId;
+			const pubE = "eeeeeeee-0000-0000-0000-000000000000" as PubsId;
+			const pubF = "ffffffff-0000-0000-0000-000000000000" as PubsId;
+			const pubG = "11111111-0000-0000-0000-000000000000" as PubsId;
+			const pubH = "22222222-0000-0000-0000-000000000000" as PubsId;
+			const pubI = "33333333-0000-0000-0000-000000000000" as PubsId;
+			const pubJ = "44444444-0000-0000-0000-000000000000" as PubsId;
+			const pubK = "55555555-0000-0000-0000-000000000000" as PubsId;
+			const pubL = "66666666-0000-0000-0000-000000000000" as PubsId;
+
+			// Create the graph structure:
+			//          A          J
+			//       /     \       |
+			//     /        \      |
+			//   B           C --> I
+			//   |         /  \
+			//   G -->  E      D
+			//               /  \
+			//             F     H
+			//                 /  \
+			//                K --> L
+
+			// Create leaf nodes first
+			const pubL_op = PubOp.createWithId(pubL, {
+				communityId: seededCommunity.community.id,
+				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+				lastModifiedBy: createLastModifiedBy("system"),
+				trx,
+			}).set(seededCommunity.pubFields["Title"].slug, "L");
+
+			const pubK_op = PubOp.createWithId(pubK, {
+				communityId: seededCommunity.community.id,
+				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+				lastModifiedBy: createLastModifiedBy("system"),
+				trx,
+			})
+				.set(seededCommunity.pubFields["Title"].slug, "K")
+				.connect(seededCommunity.pubFields["Some relation"].slug, pubL_op, "to L");
+
+			const pubF_op = PubOp.createWithId(pubF, {
+				communityId: seededCommunity.community.id,
+				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+				lastModifiedBy: createLastModifiedBy("system"),
+				trx,
+			}).set(seededCommunity.pubFields["Title"].slug, "F");
+
+			const pubH_op = PubOp.createWithId(pubH, {
+				communityId: seededCommunity.community.id,
+				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+				lastModifiedBy: createLastModifiedBy("system"),
+				trx,
+			})
+				.set(seededCommunity.pubFields["Title"].slug, "H")
+				.connect(seededCommunity.pubFields["Some relation"].slug, pubK_op, "to K")
+				.connect(seededCommunity.pubFields["Some relation"].slug, pubL_op, "to L");
+
+			const pubE_op = PubOp.createWithId(pubE, {
+				communityId: seededCommunity.community.id,
+				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+				lastModifiedBy: createLastModifiedBy("system"),
+				trx,
+			})
+				.set(seededCommunity.pubFields["Title"].slug, "E")
+				.connect(seededCommunity.pubFields["Some relation"].slug, pubF_op, "to F");
+
+			const pubG_op = PubOp.createWithId(pubG, {
+				communityId: seededCommunity.community.id,
+				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+				lastModifiedBy: createLastModifiedBy("system"),
+				trx,
+			})
+				.set(seededCommunity.pubFields["Title"].slug, "G")
+				.connect(seededCommunity.pubFields["Some relation"].slug, pubE_op, "to E");
+
+			const pubD_op = PubOp.createWithId(pubD, {
+				communityId: seededCommunity.community.id,
+				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+				lastModifiedBy: createLastModifiedBy("system"),
+				trx,
+			})
+				.set(seededCommunity.pubFields["Title"].slug, "D")
+				.connect(seededCommunity.pubFields["Some relation"].slug, pubH_op, "to H");
+
+			const pubI_op = PubOp.createWithId(pubI, {
+				communityId: seededCommunity.community.id,
+				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+				lastModifiedBy: createLastModifiedBy("system"),
+				trx,
+			}).set(seededCommunity.pubFields["Title"].slug, "I");
+
+			// Create second layer
+			const pubB_op = PubOp.createWithId(pubB, {
+				communityId: seededCommunity.community.id,
+				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+				lastModifiedBy: createLastModifiedBy("system"),
+				trx,
+			})
+				.set(seededCommunity.pubFields["Title"].slug, "B")
+				.connect(seededCommunity.pubFields["Some relation"].slug, pubG_op, "to G");
+
+			const pubC_op = PubOp.createWithId(pubC, {
+				communityId: seededCommunity.community.id,
+				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+				lastModifiedBy: createLastModifiedBy("system"),
+				trx,
+			})
+				.set(seededCommunity.pubFields["Title"].slug, "C")
+				.connect(seededCommunity.pubFields["Some relation"].slug, pubI_op, "to I")
+				.connect(seededCommunity.pubFields["Some relation"].slug, pubD_op, "to D")
+				.connect(seededCommunity.pubFields["Some relation"].slug, pubE_op, "to E");
+
+			// Create root
+			const rootPub = await PubOp.createWithId(pubA, {
+				communityId: seededCommunity.community.id,
+				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+				lastModifiedBy: createLastModifiedBy("system"),
+				trx,
+			})
+				.set(seededCommunity.pubFields["Title"].slug, "A")
+				.connect(seededCommunity.pubFields["Some relation"].slug, pubB_op, "to B")
+				.connect(seededCommunity.pubFields["Some relation"].slug, pubC_op, "to C")
+				.execute();
+
+			const pubJ_op = await PubOp.createWithId(pubJ, {
+				communityId: seededCommunity.community.id,
+				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+				lastModifiedBy: createLastModifiedBy("system"),
+				trx,
+			})
+				.set(seededCommunity.pubFields["Title"].slug, "J")
+				.connect(seededCommunity.pubFields["Some relation"].slug, pubI, "to I")
+				.execute();
+
+			const { getPubsWithRelatedValuesAndChildren } = await import("~/lib/server/pub");
+
+			// verify the initial state
+			const initialState = await getPubsWithRelatedValuesAndChildren(
+				{
+					pubId: pubA,
+					communityId: seededCommunity.community.id,
+				},
+				{ trx, depth: 10 }
+			);
+
+			expect(initialState.values).toMatchObject([
+				{ value: "A" },
+				{
+					value: "to B",
+					relatedPubId: pubB,
+					relatedPub: {
+						values: [
+							{ value: "B" },
+							{
+								value: "to G",
+								relatedPubId: pubG,
+								relatedPub: {
+									values: [
+										{ value: "G" },
+										{
+											value: "to E",
+											relatedPubId: pubE,
+											relatedPub: {
+												values: [
+													{ value: "E" },
+													{
+														value: "to F",
+														relatedPubId: pubF,
+														relatedPub: { values: [{ value: "F" }] },
+													},
+												],
+											},
+										},
+									],
+								},
+							},
+						],
+					},
+				},
+				{
+					value: "to C",
+					relatedPubId: pubC,
+					relatedPub: {
+						values: [
+							{ value: "C" },
+							{
+								value: "to I",
+								relatedPubId: pubI,
+								relatedPub: {
+									values: [{ value: "I" }],
+								},
+							},
+							{
+								value: "to D",
+								relatedPubId: pubD,
+								relatedPub: {
+									values: [
+										{ value: "D" },
+										{
+											value: "to H",
+											relatedPubId: pubH,
+											relatedPub: {
+												values: [
+													{ value: "H" },
+													{
+														value: "to K",
+														relatedPubId: pubK,
+														relatedPub: {
+															values: [
+																{ value: "K" },
+																{
+																	value: "to L",
+																	relatedPubId: pubL,
+																	relatedPub: {
+																		values: [{ value: "L" }],
+																	},
+																},
+															],
+														},
+													},
+													{
+														value: "to L",
+													},
+												],
+											},
+										},
+									],
+								},
+							},
+							{
+								value: "to E",
+								relatedPubId: pubE,
+							},
+						],
+					},
+				},
+			]);
+
+			// Now disconnect C from A, which should
+			//  orphan everything from D down,
+			// but should not orphan I, bc J still points to it
+			// and should not orphan G, bc B still points to it
+			// it orphans L, even though K points to it, because K is itself an orphan
+			//        A             J
+			//      /              |
+			//    v        X       v
+			//   B           C --> I
+			//   |         /  \
+			//   v        v    v
+			//   G -->  E      D
+			//               /  \
+			//              v    v
+			//             F     H
+			//                 /  \
+			//                v    v
+			//                K --> L
+			await PubOp.update(pubA, {
+				communityId: seededCommunity.community.id,
+				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+				lastModifiedBy: createLastModifiedBy("system"),
+				trx,
+			})
+				.disconnect(seededCommunity.pubFields["Some relation"].slug, pubC, {
+					deleteOrphaned: true,
+				})
+				.execute();
+
+			// Verify deletions
+			await expect(pubA, "A should exist").toExist(trx);
+			await expect(pubB, "B should exist").toExist(trx);
+			await expect(pubC, "C should not exist").not.toExist(trx);
+			await expect(pubD, "D should not exist").not.toExist(trx);
+			await expect(pubE, "E should exist").toExist(trx); // Still connected through G
+			await expect(pubF, "F should exist").toExist(trx);
+			await expect(pubG, "G should exist").toExist(trx);
+			await expect(pubH, "H should not exist").not.toExist(trx);
+			await expect(pubI, "I should exist").toExist(trx); // Still connected through J
+			await expect(pubJ, "J should exist").toExist(trx);
+			await expect(pubK, "K should not exist").not.toExist(trx);
+			await expect(pubL, "L should not exist").not.toExist(trx);
+		} catch (e) {
+			rollback();
+			throw e;
+		}
+	});
+
+	it("should handle selective orphan deletion based on field", async () => {
+		// Create a pub with two relations
+		const related1 = await PubOp.create({
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+		})
+			.set(seededCommunity.pubFields["Title"].slug, "Related 1")
+			.execute();
+
+		const related2 = await PubOp.create({
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+		})
+			.set(seededCommunity.pubFields["Title"].slug, "Related 2")
+			.execute();
+
+		const mainPub = await PubOp.create({
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+		})
+			.set(seededCommunity.pubFields["Title"].slug, "Main")
+			.connect(seededCommunity.pubFields["Some relation"].slug, related1.id, "relation1")
+			.connect(seededCommunity.pubFields["Another relation"].slug, related2.id, "relation2")
+			.execute();
+
+		// Clear one field with deleteOrphaned and one without
+		await PubOp.update(mainPub.id, {
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+		})
+			.clearRelationsForField(seededCommunity.pubFields["Some relation"].slug, {
+				deleteOrphaned: true,
+			})
+			.clearRelationsForField(seededCommunity.pubFields["Another relation"].slug)
+			.execute();
+
+		// Related1 should be deleted (orphaned with deleteOrphaned: true)
+		await expect(related1.id).not.toExist();
+		// Related2 should still exist (orphaned but deleteOrphaned not set)
+		await expect(related2.id).toExist();
+	});
+
+	it("should handle override with mixed deleteOrphaned flags", async () => {
+		// Create initial relations
+		const toKeep = await PubOp.create({
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+		})
+			.set(seededCommunity.pubFields["Title"].slug, "Keep Me")
+			.execute();
+
+		const toDelete = await PubOp.create({
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+		})
+			.set(seededCommunity.pubFields["Title"].slug, "Delete Me")
+			.execute();
+
+		const mainPub = await PubOp.create({
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+		})
+			.set(seededCommunity.pubFields["Title"].slug, "Main")
+			.connect(seededCommunity.pubFields["Some relation"].slug, toKeep.id, "keep")
+			.connect(seededCommunity.pubFields["Another relation"].slug, toDelete.id, "delete")
+			.execute();
+
+		// Override relations with different deleteOrphaned flags
+		const newRelation = PubOp.create({
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+		}).set(seededCommunity.pubFields["Title"].slug, "New");
+
+		await PubOp.update(mainPub.id, {
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+		})
+			.connect(seededCommunity.pubFields["Some relation"].slug, newRelation, "new", {
+				override: true,
+			})
+			.connect(seededCommunity.pubFields["Another relation"].slug, newRelation, "also new", {
+				override: true,
+				deleteOrphaned: true,
+			})
+			.execute();
+
+		// toKeep should still exist (override without deleteOrphaned)
+		await expect(toKeep.id).toExist();
+		// toDelete should be deleted (override with deleteOrphaned)
+		await expect(toDelete.id).not.toExist();
 	});
 });

--- a/core/lib/server/pub-op.db.test.ts
+++ b/core/lib/server/pub-op.db.test.ts
@@ -1,11 +1,9 @@
-import { tr } from "date-fns/locale";
-import { beforeAll, beforeEach, describe, expect, expectTypeOf, it, vitest } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
-import type { PubsId, PubTypes, Stages } from "db/public";
+import type { PubsId } from "db/public";
 import { CoreSchemaType, MemberRole } from "db/public";
 
 import type { CommunitySeedOutput } from "~/prisma/seed/createSeed";
-import type { seedCommunity } from "~/prisma/seed/seedCommunity";
 import { mockServerCode } from "~/lib/__tests__/utils";
 import { createLastModifiedBy } from "../lastModifiedBy";
 import { PubOp } from "./pub-op";
@@ -1052,9 +1050,9 @@ describe("relation management", () => {
 			//   |         /  \
 			//   v        v    v
 			//   G -->  E      D
-			//               /  \
-			//              v    v
-			//             F     H
+			//          |      \
+			//          v       v
+			//          F       H
 			//                 /  \
 			//                v    v
 			//                K --> L

--- a/core/lib/server/pub-op.db.test.ts
+++ b/core/lib/server/pub-op.db.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, expectTypeOf, it, vitest } from "vitest";
+
+import type { PubsId, PubTypes, Stages } from "db/public";
+import { CoreSchemaType, MemberRole } from "db/public";
+
+import { mockServerCode } from "~/lib/__tests__/utils";
+import { createLastModifiedBy } from "../lastModifiedBy";
+import { PubOp } from "./pub-op";
+
+const { createSeed, seedCommunity } = await import("~/prisma/seed/seedCommunity");
+
+const { createForEachMockedTransaction } = await mockServerCode();
+
+const { getTrx } = createForEachMockedTransaction();
+
+const seed = createSeed({
+	community: {
+		name: "test",
+		slug: "test-server-pub",
+	},
+	users: {
+		admin: {
+			role: MemberRole.admin,
+		},
+		stageEditor: {
+			role: MemberRole.contributor,
+		},
+	},
+	pubFields: {
+		Title: { schemaName: CoreSchemaType.String },
+		Description: { schemaName: CoreSchemaType.String },
+		"Some relation": { schemaName: CoreSchemaType.String, relation: true },
+		"Another relation": { schemaName: CoreSchemaType.String, relation: true },
+	},
+	pubTypes: {
+		"Basic Pub": {
+			Title: { isTitle: true },
+			"Some relation": { isTitle: false },
+			"Another relation": { isTitle: false },
+		},
+		"Minimal Pub": {
+			Title: { isTitle: true },
+		},
+	},
+	stages: {
+		"Stage 1": {
+			members: {
+				stageEditor: MemberRole.editor,
+			},
+		},
+	},
+	pubs: [
+		{
+			pubType: "Basic Pub",
+			values: {
+				Title: "Some title",
+			},
+			stage: "Stage 1",
+		},
+		{
+			pubType: "Basic Pub",
+			values: {
+				Title: "Another title",
+			},
+			relatedPubs: {
+				"Some relation": [
+					{
+						value: "test relation value",
+						pub: {
+							pubType: "Basic Pub",
+							values: {
+								Title: "A pub related to another Pub",
+							},
+						},
+					},
+				],
+			},
+		},
+		{
+			stage: "Stage 1",
+			pubType: "Minimal Pub",
+			values: {
+				Title: "Minimal pub",
+			},
+		},
+	],
+});
+
+const { community, pubFields, pubTypes, stages, pubs, users } = await seedCommunity(seed);
+
+describe("PubOp", () => {
+	it("should create a new pub", async () => {
+		const trx = getTrx();
+		const id = crypto.randomUUID() as PubsId;
+		const pubOp = PubOp.upsert(id, {
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+			trx,
+		});
+
+		const pub = await pubOp.execute();
+		await expect(pub.id).toExist(trx);
+	});
+
+	it("should not fail when upserting existing pub", async () => {
+		const trx = getTrx();
+		const id = crypto.randomUUID() as PubsId;
+		const pubOp = PubOp.upsert(id, {
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+			trx,
+		});
+
+		const pub = await pubOp.execute();
+		await expect(pub.id).toExist(trx);
+
+		const pub2 = await PubOp.upsert(id, {
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+			trx,
+		}).execute();
+
+		await expect(pub2.id).toExist(trx);
+	});
+
+	it("should create a new pub and set values", async () => {
+		const id = crypto.randomUUID() as PubsId;
+		const pubOp = PubOp.upsert(id, {
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+		})
+			.set(pubFields["Title"].slug, "Some title")
+			.set({
+				[pubFields["Description"].slug]: "Some description",
+			});
+
+		const pub = await pubOp.execute();
+		await expect(pub.id).toExist();
+
+		expect(pub).toHaveValues([
+			{
+				fieldSlug: pubFields["Description"].slug,
+				value: "Some description",
+			},
+			{
+				fieldSlug: pubFields["Title"].slug,
+				value: "Some title",
+			},
+		]);
+	});
+
+	it("should be able to relate existing pubs", async () => {
+		const trx = getTrx();
+		const pubOp = PubOp.upsert(crypto.randomUUID() as PubsId, {
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+			trx,
+		});
+
+		const pub = await pubOp.execute();
+		await expect(pub.id).toExist(trx);
+
+		const pub2 = await PubOp.upsert(crypto.randomUUID() as PubsId, {
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+			trx,
+		})
+			.relate(pubFields["Some relation"].slug, "test relations value", pubOp)
+			.execute();
+
+		await expect(pub2.id).toExist(trx);
+		expect(pub2).toHaveValues([
+			{
+				fieldSlug: pubFields["Some relation"].slug,
+				value: "test relations value",
+				relatedPubId: pub.id,
+			},
+		]);
+	});
+
+	it("should create multiple related pubs in a single operation", async () => {
+		const trx = getTrx();
+		const mainPub = PubOp.create({
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+			trx,
+		})
+			.set(pubFields["Title"].slug, "Main Pub")
+			.relate(
+				pubFields["Some relation"].slug,
+				"the first related pub",
+				PubOp.create({
+					communityId: community.id,
+					pubTypeId: pubTypes["Basic Pub"].id,
+					lastModifiedBy: createLastModifiedBy("system"),
+					trx,
+				}).set(pubFields["Title"].slug, "Related Pub 1")
+			)
+			.relate(
+				pubFields["Another relation"].slug,
+				"the second related pub",
+				PubOp.create({
+					communityId: community.id,
+					pubTypeId: pubTypes["Basic Pub"].id,
+					lastModifiedBy: createLastModifiedBy("system"),
+					trx,
+				}).set(pubFields["Title"].slug, "Related Pub 2")
+			);
+
+		const result = await mainPub.execute();
+
+		expect(result).toHaveValues([
+			{ fieldSlug: pubFields["Title"].slug, value: "Main Pub" },
+			{
+				fieldSlug: pubFields["Some relation"].slug,
+				value: "the first related pub",
+				relatedPubId: expect.any(String),
+			},
+			{
+				fieldSlug: pubFields["Another relation"].slug,
+				value: "the second related pub",
+				relatedPubId: expect.any(String),
+			},
+		]);
+	});
+
+	it("should handle deeply nested relations", async () => {
+		const trx = getTrx();
+		const relatedPub = PubOp.create({
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+			trx,
+		})
+			.set(pubFields["Title"].slug, "Level 1")
+			.relate(
+				pubFields["Another relation"].slug,
+				"the second related pub",
+				PubOp.create({
+					communityId: community.id,
+					pubTypeId: pubTypes["Basic Pub"].id,
+					lastModifiedBy: createLastModifiedBy("system"),
+					trx,
+				}).set(pubFields["Title"].slug, "Level 2")
+			);
+
+		const mainPub = PubOp.create({
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+			trx,
+		})
+			.set(pubFields["Title"].slug, "Root")
+			.relate(pubFields["Some relation"].slug, "the first related pub", relatedPub);
+
+		const result = await mainPub.execute();
+
+		expect(result).toHaveValues([
+			{ fieldSlug: pubFields["Title"].slug, value: "Root" },
+			{
+				fieldSlug: pubFields["Some relation"].slug,
+				value: "the first related pub",
+				relatedPubId: expect.any(String),
+				relatedPub: {
+					values: [
+						{
+							fieldSlug: pubFields["Title"].slug,
+							value: "Level 1",
+						},
+						{
+							fieldSlug: pubFields["Another relation"].slug,
+							value: "the second related pub",
+							relatedPubId: expect.any(String),
+						},
+					],
+				},
+			},
+		]);
+	});
+
+	it("should handle mixing existing and new pubs in relations", async () => {
+		const trx = getTrx();
+
+		// First create a pub that we'll relate to
+		const existingPub = await PubOp.create({
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+			trx,
+		})
+			.set(pubFields["Title"].slug, "Existing Pub")
+			.execute();
+
+		const mainPub = PubOp.create({
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+			trx,
+		})
+			.set(pubFields["Title"].slug, "Main Pub")
+			.relate(pubFields["Some relation"].slug, "the first related pub", existingPub.id)
+			.relate(
+				pubFields["Another relation"].slug,
+				"the second related pub",
+				PubOp.create({
+					communityId: community.id,
+					pubTypeId: pubTypes["Basic Pub"].id,
+					lastModifiedBy: createLastModifiedBy("system"),
+					trx,
+				}).set(pubFields["Title"].slug, "New Related Pub")
+			);
+
+		const result = await mainPub.execute();
+
+		expect(result).toHaveValues([
+			{ fieldSlug: pubFields["Title"].slug, value: "Main Pub" },
+			{
+				fieldSlug: pubFields["Some relation"].slug,
+				value: "the first related pub",
+				relatedPubId: existingPub.id,
+				relatedPub: {
+					id: existingPub.id,
+					values: [{ fieldSlug: pubFields["Title"].slug, value: "Existing Pub" }],
+				},
+			},
+			{
+				fieldSlug: pubFields["Another relation"].slug,
+				value: "the second related pub",
+				relatedPubId: expect.any(String),
+				relatedPub: {
+					values: [{ fieldSlug: pubFields["Title"].slug, value: "New Related Pub" }],
+				},
+			},
+		]);
+	});
+
+	it("should handle circular relations", async () => {
+		const trx = getTrx();
+
+		const pub1 = PubOp.create({
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+			trx,
+		}).set(pubFields["Title"].slug, "Pub 1");
+
+		const pub2 = PubOp.create({
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+			trx,
+		})
+			.set(pubFields["Title"].slug, "Pub 2")
+			.relate(pubFields["Some relation"].slug, "the first related pub", pub1);
+
+		pub1.relate(pubFields["Another relation"].slug, "the second related pub", pub2);
+
+		const result = await pub1.execute();
+
+		expect(result).toHaveValues([
+			{ fieldSlug: pubFields["Title"].slug, value: "Pub 1" },
+			{
+				fieldSlug: pubFields["Another relation"].slug,
+				value: "the second related pub",
+				relatedPubId: expect.any(String),
+				relatedPub: {
+					values: [
+						{ fieldSlug: pubFields["Title"].slug, value: "Pub 2" },
+						{
+							fieldSlug: pubFields["Some relation"].slug,
+							value: "the first related pub",
+							relatedPubId: result.id,
+						},
+					],
+				},
+			},
+		]);
+	});
+
+	it("should fail if you try to createWithId a pub that already exists", async () => {
+		const trx = getTrx();
+		const pubOp = PubOp.createWithId(pubs[0].id, {
+			communityId: community.id,
+			pubTypeId: pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+			trx,
+		});
+
+		await expect(pubOp.execute()).rejects.toThrow(
+			/Cannot create a pub with an id that already exists/
+		);
+	});
+});

--- a/core/lib/server/pub-op.db.test.ts
+++ b/core/lib/server/pub-op.db.test.ts
@@ -873,7 +873,7 @@ describe("relation management", () => {
 				{ trx, depth: 10 }
 			);
 
-			expect(initialState.values).toMatchObject([
+			expect(initialState).toHaveValues([
 				{ value: "A" },
 				{
 					value: "to B",
@@ -916,13 +916,6 @@ describe("relation management", () => {
 						values: [
 							{ value: "C" },
 							{
-								value: "to I",
-								relatedPubId: pubI,
-								relatedPub: {
-									values: [{ value: "I" }],
-								},
-							},
-							{
 								value: "to D",
 								relatedPubId: pubD,
 								relatedPub: {
@@ -962,6 +955,13 @@ describe("relation management", () => {
 							{
 								value: "to E",
 								relatedPubId: pubE,
+							},
+							{
+								value: "to I",
+								relatedPubId: pubI,
+								relatedPub: {
+									values: [{ value: "I" }],
+								},
 							},
 						],
 					},

--- a/core/lib/server/pub-op.db.test.ts
+++ b/core/lib/server/pub-op.db.test.ts
@@ -640,7 +640,7 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.relate(seededCommunity.pubFields["Some relation"].slug, "new relation", related3.id, {
-				override: true,
+				replaceExisting: true,
 			})
 			.execute();
 
@@ -682,7 +682,7 @@ describe("relation management", () => {
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Main pub")
 			.relate(seededCommunity.pubFields["Some relation"].slug, "relation 1", related1.id, {
-				override: true,
+				replaceExisting: true,
 			})
 			.execute();
 
@@ -691,7 +691,7 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.relate(seededCommunity.pubFields["Some relation"].slug, "relation 2", related2.id, {
-				override: true,
+				replaceExisting: true,
 			})
 			.relate(
 				seededCommunity.pubFields["Some relation"].slug,
@@ -701,7 +701,7 @@ describe("relation management", () => {
 					pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 					lastModifiedBy: createLastModifiedBy("system"),
 				}),
-				{ override: true }
+				{ replaceExisting: true }
 			)
 			.execute();
 
@@ -1100,10 +1100,10 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.relate(seededCommunity.pubFields["Some relation"].slug, "new", newRelation, {
-				override: true,
+				replaceExisting: true,
 			})
 			.relate(seededCommunity.pubFields["Another relation"].slug, "also new", newRelation, {
-				override: true,
+				replaceExisting: true,
 				deleteOrphaned: true,
 			})
 			.execute();

--- a/core/lib/server/pub-op.db.test.ts
+++ b/core/lib/server/pub-op.db.test.ts
@@ -1145,6 +1145,52 @@ describe("relation management", () => {
 			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Test" },
 		]);
 	});
+
+	it("should be able to relate many pubs at once", async () => {
+		const pub = await PubOp.create({
+			communityId: seededCommunity.community.id,
+			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
+			lastModifiedBy: createLastModifiedBy("system"),
+		})
+			.relate(seededCommunity.pubFields["Some relation"].slug, [
+				{
+					target: (pubOp) =>
+						pubOp
+							.create({ pubTypeId: seededCommunity.pubTypes["Minimal Pub"].id })
+							.set(seededCommunity.pubFields["Title"].slug, "Relation 1"),
+					value: "relation1",
+				},
+				{
+					target: (pubOp) =>
+						pubOp
+							.create({ pubTypeId: seededCommunity.pubTypes["Minimal Pub"].id })
+							.set(seededCommunity.pubFields["Title"].slug, "Relation 2"),
+					value: "relation2",
+				},
+			])
+			.execute();
+
+		expect(pub).toHaveValues([
+			{
+				fieldSlug: seededCommunity.pubFields["Some relation"].slug,
+				value: "relation1",
+				relatedPub: {
+					values: [
+						{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Relation 1" },
+					],
+				},
+			},
+			{
+				fieldSlug: seededCommunity.pubFields["Some relation"].slug,
+				value: "relation2",
+				relatedPub: {
+					values: [
+						{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Relation 2" },
+					],
+				},
+			},
+		]);
+	});
 });
 
 describe("PubOp stage", () => {

--- a/core/lib/server/pub-op.ts
+++ b/core/lib/server/pub-op.ts
@@ -4,7 +4,14 @@ import { sql } from "kysely";
 
 import type { JsonValue, ProcessedPub } from "contracts";
 import type { Database } from "db/Database";
-import type { CommunitiesId, CoreSchemaType, PubFieldsId, PubsId, PubTypesId } from "db/public";
+import type {
+	CommunitiesId,
+	CoreSchemaType,
+	PubFieldsId,
+	PubsId,
+	PubTypesId,
+	PubValuesId,
+} from "db/public";
 import type { LastModifiedBy } from "db/types";
 import { assert, expect } from "utils";
 import { isUuid } from "utils/uuid";
@@ -12,6 +19,8 @@ import { isUuid } from "utils/uuid";
 import { db } from "~/kysely/database";
 import { autoRevalidate } from "./cache/autoRevalidate";
 import {
+	deletePub,
+	deletePubValuesByValueId,
 	getPubsWithRelatedValuesAndChildren,
 	maybeWithTrx,
 	upsertPubRelationValues,
@@ -20,30 +29,6 @@ import {
 } from "./pub";
 
 type PubValue = string | number | boolean | JsonValue;
-type SetCommand = { type: "set"; slug: string; value: PubValue };
-type RelateCommand = {
-	type: "relate";
-	slug: string;
-	value: PubValue;
-	target: PubOp | PubsId;
-	override?: boolean;
-	deleteOrphaned?: boolean;
-};
-
-type DisconnectCommand = {
-	type: "disconnect";
-	slug: string;
-	target: PubsId;
-	deleteOrphaned?: boolean;
-};
-
-type ClearRelationsCommand = {
-	type: "clearRelations";
-	slug?: string;
-	deleteOrphaned?: boolean;
-};
-
-type PubOpCommand = SetCommand | RelateCommand | DisconnectCommand | ClearRelationsCommand;
 
 type PubOpOptions = {
 	communityId: CommunitiesId;
@@ -52,89 +37,120 @@ type PubOpOptions = {
 	trx?: Transaction<Database>;
 };
 
-type OperationsMap = Map<
-	PubsId | symbol,
-	{
-		id?: PubsId;
-		mode: "create" | "upsert";
-		values: Omit<SetCommand, "type">[];
-		relationsToAdd: (Omit<RelateCommand, "type" | "target"> & { target: PubsId | symbol })[];
-		relationsToRemove: (Omit<DisconnectCommand, "type"> & { target: PubsId })[];
-		relationsToClear: (Omit<ClearRelationsCommand, "type"> & { slug: string })[];
-	}
->;
+type RelationOptions = {
+	override?: boolean;
+	deleteOrphaned?: boolean;
+};
+
+// Base commands that will be used internally
+type SetCommand = { type: "set"; slug: string; value: PubValue | undefined };
+type RelateCommand = {
+	type: "relate";
+	slug: string;
+	relations: Array<{ target: PubOp | PubsId; value: PubValue }>;
+	options: RelationOptions;
+};
+type DisconnectCommand = {
+	type: "disconnect";
+	slug: string;
+	target: PubsId;
+	deleteOrphaned?: boolean;
+};
+type ClearRelationsCommand = {
+	type: "clearRelations";
+	slug?: string;
+	deleteOrphaned?: boolean;
+};
+
+type UnsetCommand = {
+	type: "unset";
+	slug: string;
+};
+
+type PubOpCommand =
+	| SetCommand
+	| RelateCommand
+	| DisconnectCommand
+	| ClearRelationsCommand
+	| UnsetCommand;
+
+// Types for operation collection
+type OperationMode = "create" | "upsert" | "update";
+
+interface CollectedOperation {
+	id: PubsId | undefined;
+	mode: OperationMode;
+	values: Array<{ slug: string; value: PubValue }>;
+	relationsToAdd: Array<{
+		slug: string;
+		value: PubValue;
+		target: PubsId | symbol;
+		override?: boolean;
+		deleteOrphaned?: boolean;
+	}>;
+	relationsToRemove: Array<{
+		slug: string;
+		target: PubsId;
+		deleteOrphaned?: boolean;
+	}>;
+	relationsToClear: Array<{
+		slug: string | "*";
+		deleteOrphaned?: boolean;
+	}>;
+}
+
+type OperationsMap = Map<PubsId | symbol, CollectedOperation>;
+
+export type SingleRelationInput = {
+	target: PubOp | PubsId;
+	value: PubValue;
+	override?: boolean;
+	deleteOrphaned?: boolean;
+};
 
 function isPubId(val: string | PubsId): val is PubsId {
 	return isUuid(val);
 }
 
-export class PubOp {
-	readonly #options: PubOpOptions;
-	readonly #commands: PubOpCommand[] = [];
-	readonly #mode: "create" | "upsert" = "create";
-	readonly #initialId?: PubsId;
-	readonly #initialslug?: string;
-	readonly #initialValue?: PubValue;
-	readonly #thisSymbol: symbol;
-	static #symbolCounter = 0;
+type PubOpMode = "create" | "upsert" | "update";
 
-	private constructor(
-		options: PubOpOptions,
-		mode: "create" | "upsert",
-		initialId?: PubsId,
-		initialslug?: string,
-		initialValue?: PubValue,
-		commands: PubOpCommand[] = []
-	) {
-		this.#options = options;
-		this.#mode = mode;
-		this.#initialId = initialId;
-		this.#initialslug = initialslug;
-		this.#initialValue = initialValue;
-		this.#commands = commands;
-		this.#thisSymbol = Symbol(`pub-${PubOp.#symbolCounter++}`);
-	}
+type PubIdMap = Map<PubsId | symbol, PubsId>;
+type RelationModification = {
+	slug: string;
+	relatedPubId: PubsId | null;
+};
+type RelationModifications = {
+	overrides: Map<string, RelationModification[]>;
+	clears: Map<string, RelationModification[]>;
+	removes: Map<string, RelationModification[]>;
+};
 
-	static createWithId(id: PubsId, options: PubOpOptions): PubOp {
-		return new PubOp(options, "create", id);
-	}
+// Common operations available to all PubOp types
+abstract class BasePubOp {
+	protected readonly options: PubOpOptions;
+	protected readonly commands: PubOpCommand[] = [];
+	protected readonly thisSymbol: symbol;
+	protected static symbolCounter = 0;
 
-	static create(options: PubOpOptions): PubOp {
-		return new PubOp(options, "create");
-	}
-
-	static upsert(id: PubsId, options: PubOpOptions): PubOp;
-	static upsert(slug: string, value: PubValue, options: PubOpOptions): PubOp;
-	static upsert(
-		slugOrId: string | PubsId,
-		valueOrOptions: PubValue | PubOpOptions,
-		options?: PubOpOptions
-	): PubOp {
-		if (isPubId(slugOrId)) {
-			return new PubOp(valueOrOptions as PubOpOptions, "upsert", slugOrId);
-		}
-		return new PubOp(options!, "upsert", undefined, slugOrId, valueOrOptions as PubValue);
+	constructor(options: PubOpOptions) {
+		this.options = options;
+		this.thisSymbol = Symbol(`pub-${BasePubOp.symbolCounter++}`);
 	}
 
 	/**
-	 * Add a single value to this pub
-	 * The slug is the field slug of format `[communitySlug]:[fieldSlug]`
+	 * Set a single value or multiple values
 	 */
 	set(slug: string, value: PubValue): this;
-	/**
-	 * Add multiple values to this pub
-	 * The keys are the field slugs of format `[communitySlug]:[fieldSlug]`
-	 */
 	set(values: Record<string, PubValue>): this;
 	set(slugOrValues: string | Record<string, PubValue>, value?: PubValue): this {
 		if (typeof slugOrValues === "string") {
-			this.#commands.push({
+			this.commands.push({
 				type: "set",
 				slug: slugOrValues,
 				value: value!,
 			});
 		} else {
-			this.#commands.push(
+			this.commands.push(
 				...Object.entries(slugOrValues).map(([slug, value]) => ({
 					type: "set" as const,
 					slug,
@@ -146,95 +162,110 @@ export class PubOp {
 	}
 
 	/**
-	 * Relate this pub to another pub
-	 * @param slug The field slug
-	 * @param value The value for this relation
-	 * @param target The pub to relate to
-	 * @param options Additional options for this relation
+	 * Unset a value for a specific field
 	 */
-	relate(
+	unset(slug: string): this {
+		this.commands.push({
+			type: "set",
+			slug,
+			value: undefined,
+		});
+		return this;
+	}
+
+	/**
+	 * Connect to one or more pubs with the same value
+	 */
+	connect(slug: string, target: PubOp | PubsId, value: PubValue, options?: RelationOptions): this;
+	/**
+	 * Connect to one or more pubs with individual values
+	 */
+	connect(
 		slug: string,
-		value: PubValue,
-		target: PubOp | PubsId,
-		options?: {
-			override?: boolean;
-			deleteOrphaned?: boolean;
-		}
+		relations: Array<{ target: PubOp | PubsId; value: PubValue }>,
+		options?: RelationOptions
+	): this;
+	connect(
+		slug: string,
+		targetsOrRelations: PubOp | PubsId | Array<{ target: PubOp | PubsId; value: PubValue }>,
+		valueOrOptions?: PubValue | RelationOptions,
+		maybeOptions?: RelationOptions
 	): this {
-		this.#commands.push({
+		if (typeof targetsOrRelations === "string" && !isPubId(targetsOrRelations)) {
+			throw new Error(
+				`Invalid target: should either be an existing pub id or a PubOp instance, but got \`${targetsOrRelations}\``
+			);
+		}
+
+		const options =
+			(Array.isArray(targetsOrRelations)
+				? (valueOrOptions as RelationOptions)
+				: maybeOptions) ?? {};
+		const relations = Array.isArray(targetsOrRelations)
+			? targetsOrRelations
+			: [
+					{
+						target: targetsOrRelations,
+						value: valueOrOptions as PubValue,
+					},
+				];
+
+		this.commands.push({
 			type: "relate",
 			slug,
-			value,
-			target,
-			override: options?.override,
-			deleteOrphaned: options?.deleteOrphaned,
+			relations,
+			options,
 		});
 		return this;
 	}
 
 	/**
-	 * Remove a specific relation from this pub
+	 * Set relation values for existing relations
 	 */
-	disconnect(slug: string, target: PubsId, options?: { deleteOrphaned?: boolean }): this {
-		this.#commands.push({
-			type: "disconnect",
-			slug,
-			target,
-			deleteOrphaned: options?.deleteOrphaned,
-		});
-		return this;
+	setRelation(slug: string, target: PubsId, value: PubValue): this {
+		return this.connect(slug, [{ target, value }], { override: false });
 	}
-
 	/**
-	 * Clear all relations for specified field(s)
+	 * Set multiple relation values for existing relations
 	 */
-	clearRelations(options?: { slug?: string; deleteOrphaned?: boolean }): this {
-		this.#commands.push({
-			type: "clearRelations",
-			slug: options?.slug,
-			deleteOrphaned: options?.deleteOrphaned,
-		});
-		return this;
+	setRelations(slug: string, relations: Array<{ target: PubsId; value: PubValue }>): this {
+		return this.connect(slug, relations, { override: false });
 	}
 
-	private collectAllOperations(processed = new Set<symbol>()): OperationsMap {
+	async execute(): Promise<ProcessedPub> {
+		const { trx = db } = this.options;
+		const pubId = await maybeWithTrx(trx, (trx) => this.executeWithTrx(trx));
+		return getPubsWithRelatedValuesAndChildren(
+			{ pubId, communityId: this.options.communityId },
+			{ trx }
+		);
+	}
+
+	protected collectOperations(processed = new Set<symbol>()): OperationsMap {
 		// If we've already processed this PubOp, return empty map to avoid circular recursion
-		if (processed.has(this.#thisSymbol)) {
+		if (processed.has(this.thisSymbol)) {
 			return new Map();
 		}
 
 		const operations = new Map() as OperationsMap;
-		processed.add(this.#thisSymbol);
+		processed.add(this.thisSymbol);
 
-		operations.set(this.#initialId || this.#thisSymbol, {
-			id: this.#initialId,
-			mode: this.#mode,
-			values: [
-				// if we use a value rather than the id as the unique identifier
-				...(this.#initialslug
-					? [{ slug: this.#initialslug, value: this.#initialValue! }]
-					: []),
-				...this.#commands
-					.filter(
-						(cmd): cmd is Extract<PubOpCommand, { type: "set" }> => cmd.type === "set"
-					)
-					.map((cmd) => ({
-						slug: cmd.slug,
-						value: cmd.value,
-					})),
-			],
+		// Add this pub's operations
+		operations.set(this.getOperationKey(), {
+			id: this.getInitialId(),
+			mode: this.getMode(),
+			values: this.collectValues(),
 			relationsToAdd: [],
 			relationsToRemove: [],
 			relationsToClear: [],
 		});
 
-		for (const cmd of this.#commands) {
-			if (cmd.type === "set") {
-				continue;
-			}
-
-			const rootOp = operations.get(this.#initialId || this.#thisSymbol);
+		// Process commands
+		for (const cmd of this.commands) {
+			const rootOp = operations.get(this.getOperationKey());
 			assert(rootOp, "Root operation not found");
+
+			if (cmd.type === "set") continue; // Values already collected
 
 			if (cmd.type === "clearRelations") {
 				rootOp.relationsToClear.push({
@@ -247,57 +278,83 @@ export class PubOp {
 					target: cmd.target,
 					deleteOrphaned: cmd.deleteOrphaned,
 				});
-			} else if (!(cmd.target instanceof PubOp)) {
-				rootOp.relationsToAdd.push({
-					slug: cmd.slug,
-					value: cmd.value,
-					target: cmd.target,
-					override: cmd.override,
-					deleteOrphaned: cmd.deleteOrphaned,
-				});
-			} else {
-				rootOp.relationsToAdd.push({
-					slug: cmd.slug,
-					value: cmd.value,
-					target: cmd.target.#initialId || cmd.target.#thisSymbol,
-					override: cmd.override,
-					deleteOrphaned: cmd.deleteOrphaned,
-				});
+			} else if (cmd.type === "relate") {
+				// Process each relation in the command
+				cmd.relations.forEach((relation) => {
+					if (!(relation.target instanceof BasePubOp)) {
+						rootOp.relationsToAdd.push({
+							slug: cmd.slug,
+							value: relation.value,
+							target: relation.target as PubsId,
+							override: cmd.options.override,
+							deleteOrphaned: cmd.options.deleteOrphaned,
+						});
+					} else {
+						rootOp.relationsToAdd.push({
+							slug: cmd.slug,
+							value: relation.value,
+							target: relation.target.thisSymbol,
+							override: cmd.options.override,
+							deleteOrphaned: cmd.options.deleteOrphaned,
+						});
 
-				// Only collect target operations if we haven't processed it yet
-				// to prevent infinite loops
-				if (!processed.has(cmd.target.#thisSymbol)) {
-					const targetOps = cmd.target.collectAllOperations(processed);
-					for (const [key, value] of targetOps) {
-						operations.set(key, value);
+						// Collect nested PubOp operations
+						if (!processed.has(relation.target.thisSymbol)) {
+							const targetOps = relation.target.collectOperations(processed);
+							for (const [key, value] of targetOps) {
+								operations.set(key, value);
+							}
+						}
 					}
-				}
+				});
 			}
 		}
 
 		return operations;
 	}
 
-	private async executeWithTrx(trx: Transaction<Database>): Promise<PubsId> {
-		const operations = this.collectAllOperations();
+	// Helper methods for operation collection
+	protected abstract getMode(): OperationMode;
+	protected abstract getInitialId(): PubsId | undefined;
+	protected getOperationKey(): PubsId | symbol {
+		return this.getInitialId() || this.thisSymbol;
+	}
+
+	private collectValues(): Array<{ slug: string; value: PubValue }> {
+		return this.commands
+			.filter(
+				(cmd): cmd is Extract<PubOpCommand, { type: "set" }> =>
+					cmd.type === "set" && cmd.value !== undefined
+			)
+			.map((cmd) => ({
+				slug: cmd.slug,
+				value: cmd.value!,
+			}));
+	}
+
+	// Split executeWithTrx into smaller, focused methods
+	protected async executeWithTrx(trx: Transaction<Database>): Promise<PubsId> {
+		const operations = this.collectOperations();
+		const idMap = await this.createAllPubs(trx, operations);
+		await this.processRelations(trx, operations, idMap);
+		await this.processValues(trx, operations, idMap);
+
+		return this.resolvePubId(this.getOperationKey(), idMap);
+	}
+
+	private async createAllPubs(
+		trx: Transaction<Database>,
+		operations: OperationsMap
+	): Promise<PubIdMap> {
 		const idMap = new Map<PubsId | symbol, PubsId>();
+		const pubsToCreate = Array.from(operations.entries()).map(([key, _]) => ({
+			id: typeof key === "symbol" ? undefined : key,
+			communityId: this.options.communityId,
+			pubTypeId: this.options.pubTypeId,
+		}));
 
-		const pubsToCreate = [] as {
-			id: PubsId | undefined;
-			communityId: CommunitiesId;
-			pubTypeId: PubTypesId;
-		}[];
-
-		for (const [key, value] of operations) {
-			pubsToCreate.push({
-				id: typeof key === "symbol" ? undefined : key,
-				communityId: this.#options.communityId,
-				pubTypeId: this.#options.pubTypeId,
-			});
-		}
-
-		// we create the necessary pubs
-		const pubCreateResult = await autoRevalidate(
+		// Create pubs and handle conflicts
+		const createdPubs = await autoRevalidate(
 			trx
 				.insertInto("pubs")
 				.values(pubsToCreate)
@@ -305,301 +362,364 @@ export class PubOp {
 				.returningAll()
 		).execute();
 
-		let index = 0;
-		/**
-		 * this is somewhat convoluted, but basically:
-		 * - onConflict().doNothing() does not return anything if it's triggered
-		 * - therefore we need to fill in the "holes" in the pubCreateResult array
-		 * in order to effectively loop over it by comparing it with the operations
-		 */
-		const pubCreateResultWithHolesFilled = pubsToCreate.map((pubToCreate) => {
-			const correspondingPubCreateResult = pubCreateResult[index];
+		// Map IDs, handling both new and existing pubs
+		let createdIndex = 0;
+		let operationIndex = 0;
+		for (const [key, op] of operations) {
+			const createdPub = createdPubs[createdIndex];
+			const pubToCreate = pubsToCreate[operationIndex];
 
-			if (pubToCreate.id && pubToCreate.id !== correspondingPubCreateResult?.id) {
-				return null;
+			if (createdPub) {
+				idMap.set(key, createdPub.id);
+				createdIndex++;
+			} else if (pubToCreate.id) {
+				if (op.mode === "create") {
+					throw new Error(
+						`Cannot create a pub with an id that already exists: ${pubToCreate.id}`
+					);
+				}
+				idMap.set(key, pubToCreate.id);
+			} else if (typeof key === "symbol") {
+				throw new Error("Pub not created");
+			} else {
+				idMap.set(key, key);
+			}
+			operationIndex++;
+		}
+
+		return idMap;
+	}
+
+	private async processRelations(
+		trx: Transaction<Database>,
+		operations: OperationsMap,
+		idMap: PubIdMap
+	): Promise<void> {
+		for (const [key, op] of operations) {
+			const pubId = this.resolvePubId(key, idMap);
+
+			// Skip if no relation changes
+			const modifications = {
+				overrides: this.groupBySlug(op.relationsToAdd.filter((cmd) => cmd.override)),
+				clears: this.groupBySlug(op.relationsToClear),
+				removes: this.groupBySlug(op.relationsToRemove),
+			};
+
+			if (!this.hasModifications(modifications)) {
+				continue;
 			}
 
-			index++;
+			// Find and remove existing relations
+			const existingRelations = await trx
+				.selectFrom("pub_values")
+				.innerJoin("pub_fields", "pub_fields.id", "pub_values.fieldId")
+				.select(["pub_values.id", "relatedPubId", "pub_fields.slug"])
+				.where("pubId", "=", pubId)
+				.where("relatedPubId", "is not", null)
+				.where("slug", "in", [
+					...modifications.overrides.keys(),
+					...modifications.clears.keys(),
+					...modifications.removes.keys(),
+				])
+				.execute();
 
-			if (correspondingPubCreateResult) {
-				return correspondingPubCreateResult;
+			const relationsToRemove = existingRelations.filter(
+				(r) => !modifications.overrides.has(r.id)
+			);
+
+			if (relationsToRemove.length === 0) {
+				return;
 			}
+			await deletePubValuesByValueId({
+				pubId,
+				valueIds: relationsToRemove.map((r) => r.id),
+				lastModifiedBy: this.options.lastModifiedBy,
+				trx,
+			});
 
-			return null;
+			// Handle orphaned pubs if needed
+			await this.cleanupOrphanedPubs(trx, relationsToRemove, modifications);
+		}
+	}
+
+	private async processValues(
+		trx: Transaction<Database>,
+		operations: OperationsMap,
+		idMap: PubIdMap
+	): Promise<void> {
+		// Collect all values and relations to upsert
+		const toUpsert = Array.from(operations.entries()).flatMap(([key, op]) => {
+			const pubId = this.resolvePubId(key, idMap);
+			return [
+				// Regular values
+				...op.values.map((v) => ({
+					pubId,
+					slug: v.slug,
+					value: v.value,
+				})),
+				// Relations
+				...op.relationsToAdd.map((r) => ({
+					pubId,
+					slug: r.slug,
+					value: r.value,
+					relatedPubId: typeof r.target === "string" ? r.target : idMap.get(r.target)!,
+				})),
+			];
 		});
 
-		let idx = 0;
-		for (const [key, op] of operations) {
-			let result = pubCreateResultWithHolesFilled[idx];
-
-			if (result) {
-				idMap.set(key, result.id);
-				idx++;
-				continue;
-			}
-
-			// we are upserting a pub, OR we are creating a pub with a specific id that has failed
-			const possiblyExistingPubId = pubsToCreate[idx]?.id;
-
-			if (possiblyExistingPubId && op.mode === "create") {
-				throw new Error(
-					`Cannot create a pub with an id that already exists: ${possiblyExistingPubId}`
-				);
-			}
-
-			if (possiblyExistingPubId) {
-				idMap.set(key, possiblyExistingPubId);
-				idx++;
-				continue;
-			}
-
-			if (typeof key === "symbol") {
-				throw new Error("Pub not created");
-			}
-			idMap.set(key, key);
-
-			idx++;
+		if (toUpsert.length === 0) {
+			return;
 		}
 
-		const rootId = this.#initialId || idMap.get(this.#thisSymbol)!;
-		assert(rootId, "Root ID should exist");
-
-		// First handle relation clearing/disconnections
-		for (const [key, op] of operations) {
-			const pubId = typeof key === "symbol" ? idMap.get(key) : idMap.get(key);
-			assert(pubId, "Pub ID is required");
-
-			// Process relate commands with override
-			const overrideRelateCommands = op.relationsToAdd?.filter((cmd) => !!cmd.override) ?? [];
-
-			// Group by slug for override operations
-			const overridesBySlug = new Map<
-				string,
-				(Omit<RelateCommand, "type" | "target"> & { target: PubsId | symbol })[]
-			>();
-
-			for (const cmd of overrideRelateCommands) {
-				const cmds = overridesBySlug.get(cmd.slug) ?? [];
-				cmds.push(cmd);
-				overridesBySlug.set(cmd.slug, cmds);
-			}
-
-			// Handle all disconnections
-			if (
-				op.relationsToClear.length > 0 ||
-				op.relationsToRemove.length > 0 ||
-				overridesBySlug.size > 0
-			) {
-				// Build query to find relations to remove
-				const query = trx
-					.selectFrom("pub_values")
-					.innerJoin("pub_fields", "pub_fields.id", "pub_values.fieldId")
-					.select(["pub_values.id", "relatedPubId", "pub_fields.slug"])
-					.where("pubId", "=", pubId)
-					.where("relatedPubId", "is not", null);
-
-				// Add slug conditions
-				const slugConditions = [
-					...op.relationsToClear.map((cmd) => cmd.slug).filter(Boolean),
-					...op.relationsToRemove.map((cmd) => cmd.slug),
-					...overridesBySlug.keys(),
-				];
-
-				if (slugConditions.length > 0) {
-					query.where("slug", "in", slugConditions);
-				}
-
-				const existingRelations = await query.execute();
-
-				// Determine which relations to remove
-				const relationsToRemove = existingRelations.filter((rel) => {
-					// Remove if explicitly disconnected
-					if (
-						op.relationsToRemove.some(
-							(cmd) => cmd.slug === rel.slug && cmd.target === rel.relatedPubId
-						)
-					) {
-						return true;
-					}
-
-					// Remove if field is being cleared
-					if (op.relationsToClear.some((cmd) => !cmd.slug || cmd.slug === rel.slug)) {
-						return true;
-					}
-
-					// Remove if not in override set
-					const overrides = overridesBySlug.get(rel.slug);
-					if (
-						overrides &&
-						!overrides.some(
-							(cmd) =>
-								(typeof cmd.target === "string"
-									? cmd.target
-									: idMap.get(cmd.target)) === rel.relatedPubId
-						)
-					) {
-						return true;
-					}
-
-					return false;
-				});
-
-				// Remove the relations
-				if (relationsToRemove.length > 0) {
-					await trx
-						.deleteFrom("pub_values")
-						.where(
-							"pub_values.id",
-							"in",
-							relationsToRemove.map((r) => r.id)
-						)
-						.execute();
-
-					// Handle orphaned pubs if requested
-					const shouldCheckOrphaned = [
-						...op.relationsToClear,
-						...op.relationsToRemove,
-						...overrideRelateCommands,
-					].some((cmd) => cmd.deleteOrphaned);
-
-					if (shouldCheckOrphaned) {
-						const orphanedPubIds = relationsToRemove
-							.map((r) => r.relatedPubId!)
-							.filter(Boolean);
-
-						if (orphanedPubIds.length > 0) {
-							// Find and delete truly orphaned pubs
-							const orphanedPubs = await trx
-								.selectFrom("pubs as p")
-								.select("p.id")
-								.leftJoin("pub_values as pv", "pv.relatedPubId", "p.id")
-								.where("p.id", "in", orphanedPubIds)
-								.groupBy("p.id")
-								.having((eb) => eb.fn.count("pv.id"), "=", 0)
-								.execute();
-
-							if (orphanedPubs.length > 0) {
-								await trx
-									.deleteFrom("pubs")
-									.where(
-										"id",
-										"in",
-										orphanedPubs.map((p) => p.id)
-									)
-									.execute();
-							}
-						}
-					}
-				}
-			}
-		}
-
-		const valuesToUpsert = [] as {
-			pubId: PubsId;
-			slug: string;
-			value: PubValue;
-		}[];
-
-		const relationValuesToUpsert = [] as {
-			pubId: PubsId;
-			slug: string;
-			value: PubValue;
-			relatedPubId: PubsId;
-		}[];
-
-		for (const [key, op] of operations) {
-			const pubId = typeof key === "symbol" ? idMap.get(key) : idMap.get(key);
-
-			assert(pubId, "Pub ID is required");
-
-			if (op.values.length > 0) {
-				valuesToUpsert.push(
-					...op.values.map((v) => ({
-						pubId,
-						slug: v.slug,
-						value: v.value,
-					}))
-				);
-			}
-
-			if (op.relationsToAdd.length > 0) {
-				relationValuesToUpsert.push(
-					...op.relationsToAdd.map((r) => ({
-						pubId,
-						slug: r.slug,
-						value: r.value,
-						relatedPubId: expect(
-							typeof r.target === "string" ? r.target : idMap.get(r.target),
-							"Related pub ID should exist"
-						),
-					}))
-				);
-			}
-		}
-
-		if (valuesToUpsert.length === 0 && relationValuesToUpsert.length === 0) {
-			return rootId;
-		}
-
-		// kind of clunky, but why do it twice when we can do it once
-		const validatedPubAndRelationValues = await validatePubValues({
-			pubValues: [...valuesToUpsert, ...relationValuesToUpsert],
-			communityId: this.#options.communityId,
+		// Validate and upsert
+		const validated = await validatePubValues({
+			pubValues: toUpsert,
+			communityId: this.options.communityId,
 			continueOnValidationError: false,
 			trx,
 		});
 
-		const validatedPubValues = validatedPubAndRelationValues
-			.filter((v) => !("relatedPubId" in v) || !v.relatedPubId)
-			.map((v) => ({
-				pubId: v.pubId,
-				fieldId: v.fieldId,
-				value: v.value,
-				lastModifiedBy: this.#options.lastModifiedBy,
-			}));
-		const validatedRelationValues = validatedPubAndRelationValues
-			.filter(
-				(v): v is typeof v & { relatedPubId: PubsId } =>
-					"relatedPubId" in v && !!v.relatedPubId
-			)
-			.map((v) => ({
-				pubId: v.pubId,
-				fieldId: v.fieldId,
-				value: v.value,
-				relatedPubId: v.relatedPubId,
-				lastModifiedBy: this.#options.lastModifiedBy,
-			}));
+		const { values, relations } = this.partitionValidatedValues(validated);
 
+		// Perform upserts in parallel
 		await Promise.all([
-			upsertPubValues({
-				// this is a dummy pubId, we will use the ones on the validatedPubValues
-				pubId: "xxx" as PubsId,
-				pubValues: validatedPubValues,
-				lastModifiedBy: this.#options.lastModifiedBy,
-				trx,
-			}),
-			upsertPubRelationValues({
-				// this is a dummy pubId, we will use the ones on the validatedPubRelationValues
-				pubId: "xxx" as PubsId,
-				allRelationsToCreate: validatedRelationValues,
-				lastModifiedBy: this.#options.lastModifiedBy,
-				trx,
-			}),
+			values.length > 0 &&
+				upsertPubValues({
+					pubId: "xxx" as PubsId,
+					pubValues: values,
+					lastModifiedBy: this.options.lastModifiedBy,
+					trx,
+				}),
+			relations.length > 0 &&
+				upsertPubRelationValues({
+					pubId: "xxx" as PubsId,
+					allRelationsToCreate: relations,
+					lastModifiedBy: this.options.lastModifiedBy,
+					trx,
+				}),
 		]);
-
-		return rootId;
 	}
 
-	async execute(): Promise<ProcessedPub> {
-		const { trx = db } = this.#options;
+	// --- Helper methods ---
 
-		const pubId = await maybeWithTrx(trx, async (trx) => {
-			return await this.executeWithTrx(trx);
+	private hasModifications(mods: {
+		[K in "overrides" | "clears" | "removes"]: ReturnType<typeof this.groupBySlug>;
+	}): boolean {
+		return mods.overrides.size > 0 || mods.clears.size > 0 || mods.removes.size > 0;
+	}
+
+	private groupBySlug<T extends { slug: string }>(items: T[]): Map<string, T[]> {
+		return items.reduce((map, item) => {
+			const existing = map.get(item.slug) ?? [];
+			existing.push(item);
+			map.set(item.slug, existing);
+			return map;
+		}, new Map<string, T[]>());
+	}
+
+	private async cleanupOrphanedPubs(
+		trx: Transaction<Database>,
+		removedRelations: Array<{ relatedPubId: PubsId | null }>,
+		modifications: Record<string, Map<string, Array<{ deleteOrphaned?: boolean }>>>
+	): Promise<void> {
+		const shouldDelete = Object.values(modifications)
+			.flatMap((m) => Array.from(m.values()))
+			.flat()
+			.some((m) => m.deleteOrphaned);
+
+		if (!shouldDelete) return;
+
+		const orphanedIds = removedRelations
+			.map((r) => r.relatedPubId)
+			.filter((id): id is PubsId => id !== null);
+
+		if (orphanedIds.length === 0) return;
+
+		const trulyOrphaned = await trx
+			.selectFrom("pubs as p")
+			.select("p.id")
+			.leftJoin("pub_values as pv", "pv.relatedPubId", "p.id")
+			.where("p.id", "in", orphanedIds)
+			.groupBy("p.id")
+			.having((eb) => eb.fn.count("pv.id"), "=", 0)
+			.execute();
+
+		if (trulyOrphaned.length > 0) {
+			await deletePub({
+				pubId: trulyOrphaned.map((p) => p.id),
+				communityId: this.options.communityId,
+				lastModifiedBy: this.options.lastModifiedBy,
+				trx,
+			});
+		}
+	}
+
+	private partitionValidatedValues(validated: Array<any>) {
+		return {
+			values: validated
+				.filter((v) => !("relatedPubId" in v) || !v.relatedPubId)
+				.map((v) => ({
+					pubId: v.pubId,
+					fieldId: v.fieldId,
+					value: v.value,
+					lastModifiedBy: this.options.lastModifiedBy,
+				})),
+			relations: validated
+				.filter(
+					(v): v is typeof v & { relatedPubId: PubsId } =>
+						"relatedPubId" in v && !!v.relatedPubId
+				)
+				.map((v) => ({
+					pubId: v.pubId,
+					fieldId: v.fieldId,
+					value: v.value,
+					relatedPubId: v.relatedPubId,
+					lastModifiedBy: this.options.lastModifiedBy,
+				})),
+		};
+	}
+
+	private resolvePubId(key: PubsId | symbol, idMap: Map<PubsId | symbol, PubsId>): PubsId {
+		const pubId = typeof key === "symbol" ? idMap.get(key) : idMap.get(key);
+		assert(pubId, "Pub ID is required");
+		return pubId;
+	}
+}
+
+interface UpdateOnlyOps {
+	unset(slug: string): this;
+	disconnect(slug: string, target: PubsId, options?: { deleteOrphaned?: boolean }): this;
+	clearRelationsForField(slug: string, options?: { deleteOrphaned?: boolean }): this;
+	clearAllRelations(options?: { deleteOrphaned?: boolean }): this;
+}
+
+// Implementation classes - these are not exported
+class CreatePubOp extends BasePubOp {
+	private readonly initialId?: PubsId;
+
+	constructor(options: PubOpOptions, initialId?: PubsId) {
+		super(options);
+		this.initialId = initialId;
+	}
+
+	protected getMode(): OperationMode {
+		return "create";
+	}
+
+	protected getInitialId(): PubsId | undefined {
+		return this.initialId;
+	}
+}
+
+class UpsertPubOp extends BasePubOp {
+	private readonly initialId?: PubsId;
+	private readonly initialSlug?: string;
+	private readonly initialValue?: PubValue;
+
+	constructor(
+		options: PubOpOptions,
+		initialId?: PubsId,
+		initialSlug?: string,
+		initialValue?: PubValue
+	) {
+		super(options);
+		this.initialId = initialId;
+		this.initialSlug = initialSlug;
+		this.initialValue = initialValue;
+	}
+
+	protected getMode(): OperationMode {
+		return "upsert";
+	}
+
+	protected getInitialId(): PubsId | undefined {
+		return this.initialId;
+	}
+}
+
+class UpdatePubOp extends BasePubOp implements UpdateOnlyOps {
+	private readonly pubId: PubsId | undefined;
+	private readonly initialSlug?: string;
+	private readonly initialValue?: PubValue;
+
+	constructor(
+		id: PubsId | undefined,
+		options: PubOpOptions,
+		initialSlug?: string,
+		initialValue?: PubValue
+	) {
+		super(options);
+		this.pubId = id;
+		this.initialSlug = initialSlug;
+		this.initialValue = initialValue;
+	}
+
+	protected getMode(): OperationMode {
+		return "update";
+	}
+
+	unset(slug: string): this {
+		this.commands.push({
+			type: "unset",
+			slug,
 		});
+		return this;
+	}
 
-		return await getPubsWithRelatedValuesAndChildren(
-			{ pubId, communityId: this.#options.communityId },
-			{ trx }
-		);
+	disconnect(slug: string, target: PubsId, options?: { deleteOrphaned?: boolean }): this {
+		this.commands.push({
+			type: "disconnect",
+			slug,
+			target,
+			deleteOrphaned: options?.deleteOrphaned,
+		});
+		return this;
+	}
+
+	clearRelationsForField(slug: string, options?: { deleteOrphaned?: boolean }): this {
+		this.commands.push({
+			type: "clearRelations",
+			slug,
+			deleteOrphaned: options?.deleteOrphaned,
+		});
+		return this;
+	}
+
+	clearAllRelations(options?: { deleteOrphaned?: boolean }): this {
+		this.commands.push({
+			type: "clearRelations",
+			deleteOrphaned: options?.deleteOrphaned,
+		});
+		return this;
+	}
+	protected getInitialId(): PubsId | undefined {
+		return this.pubId;
+	}
+}
+
+// The factory class - this is the only exported class
+export class PubOp {
+	static create(options: PubOpOptions): CreatePubOp {
+		return new CreatePubOp(options);
+	}
+
+	static createWithId(id: PubsId, options: PubOpOptions): CreatePubOp {
+		return new CreatePubOp(options, id);
+	}
+
+	static update(id: PubsId, options: PubOpOptions): UpdatePubOp {
+		return new UpdatePubOp(id, options);
+	}
+
+	static updateByValue(slug: string, value: PubValue, options: PubOpOptions): UpdatePubOp {
+		return new UpdatePubOp(undefined, options, slug, value);
+	}
+
+	static upsert(id: PubsId, options: PubOpOptions): UpsertPubOp {
+		return new UpsertPubOp(options, id);
+	}
+
+	static upsertByValue(slug: string, value: PubValue, options: PubOpOptions): UpsertPubOp {
+		return new UpsertPubOp(options, undefined, slug, value);
 	}
 }

--- a/core/lib/server/pub-op.ts
+++ b/core/lib/server/pub-op.ts
@@ -844,20 +844,36 @@ class UpdatePubOp extends BasePubOp implements UpdateOnlyOps {
 	}
 }
 
-// The factory class - this is the only exported class
+/**
+ * A PubOp is a builder for a pub.
+ *
+ * It can be used to create, update or upsert a pub.
+ */
 export class PubOp {
+	/**
+	 * Create a new pub
+	 */
 	static create(options: PubOpOptions): CreatePubOp {
 		return new CreatePubOp(options);
 	}
 
+	/**
+	 * Create a new pub with a specific id
+	 */
 	static createWithId(id: PubsId, options: PubOpOptions): CreatePubOp {
 		return new CreatePubOp(options, id);
 	}
 
+	/**
+	 * Update an existing pub
+	 */
 	static update(id: PubsId, options: Omit<PubOpOptions, "pubTypeId">): UpdatePubOp {
 		return new UpdatePubOp(options, id);
 	}
 
+	/**
+	 * Update an existing pub by a specific value
+	 */
 	static updateByValue(
 		slug: string,
 		value: PubValue,
@@ -866,10 +882,23 @@ export class PubOp {
 		return new UpdatePubOp(options, undefined, slug, value);
 	}
 
+	/**
+	 * Upsert a pub
+	 *
+	 * Either create a new pub, or override an existing pub
+	 */
 	static upsert(id: PubsId, options: PubOpOptions): UpsertPubOp {
 		return new UpsertPubOp(options, id);
 	}
 
+	/**
+	 * Upsert a pub by a specific, presumed to be unique, value
+	 *
+	 * Eg you want to upsert a pub by a google drive id, you would do
+	 * ```ts
+	 * PubOp.upsertByValue("community-slug:googleDriveId", googleDriveId, options)
+	 * ```
+	 */
 	static upsertByValue(slug: string, value: PubValue, options: PubOpOptions): UpsertPubOp {
 		return new UpsertPubOp(options, undefined, slug, value);
 	}

--- a/core/lib/server/pub-op.ts
+++ b/core/lib/server/pub-op.ts
@@ -1,0 +1,398 @@
+import type { Transaction } from "kysely";
+
+import { sql } from "kysely";
+
+import type { JsonValue, ProcessedPub } from "contracts";
+import type { Database } from "db/Database";
+import type { CommunitiesId, CoreSchemaType, PubFieldsId, PubsId, PubTypesId } from "db/public";
+import type { LastModifiedBy } from "db/types";
+import { assert, expect } from "utils";
+import { isUuid } from "utils/uuid";
+
+import { db } from "~/kysely/database";
+import { autoRevalidate } from "./cache/autoRevalidate";
+import {
+	getPubsWithRelatedValuesAndChildren,
+	maybeWithTrx,
+	upsertPubRelationValues,
+	upsertPubValues,
+	validatePubValues,
+} from "./pub";
+
+type PubValue = string | number | boolean | JsonValue;
+type SetCommand = { type: "set"; slug: string; value: PubValue };
+type RelateCommand = { type: "relate"; slug: string; value: PubValue; target: PubOp | PubsId };
+
+type PubOpCommand = SetCommand | RelateCommand;
+
+type PubOpOptions = {
+	communityId: CommunitiesId;
+	pubTypeId: PubTypesId;
+	lastModifiedBy: LastModifiedBy;
+	trx?: Transaction<Database>;
+};
+
+type OperationsMap = Map<
+	PubsId | symbol,
+	{
+		id?: PubsId;
+		mode: "create" | "upsert";
+		values: Omit<SetCommand, "type">[];
+		relations: (Omit<RelateCommand, "type" | "target"> & { target: PubsId | symbol })[];
+	}
+>;
+
+function isPubId(val: string | PubsId): val is PubsId {
+	return isUuid(val);
+}
+
+export class PubOp {
+	readonly #options: PubOpOptions;
+	readonly #commands: PubOpCommand[] = [];
+	readonly #mode: "create" | "upsert" = "create";
+	readonly #initialId?: PubsId;
+	readonly #initialslug?: string;
+	readonly #initialValue?: PubValue;
+	readonly #thisSymbol: symbol;
+	static #symbolCounter = 0;
+
+	private constructor(
+		options: PubOpOptions,
+		mode: "create" | "upsert",
+		initialId?: PubsId,
+		initialslug?: string,
+		initialValue?: PubValue,
+		commands: PubOpCommand[] = []
+	) {
+		this.#options = options;
+		this.#mode = mode;
+		this.#initialId = initialId;
+		this.#initialslug = initialslug;
+		this.#initialValue = initialValue;
+		this.#commands = commands;
+		this.#thisSymbol = Symbol(`pub-${PubOp.#symbolCounter++}`);
+	}
+
+	static createWithId(id: PubsId, options: PubOpOptions): PubOp {
+		return new PubOp(options, "create", id);
+	}
+
+	static create(options: PubOpOptions): PubOp {
+		return new PubOp(options, "create");
+	}
+
+	static upsert(id: PubsId, options: PubOpOptions): PubOp;
+	static upsert(slug: string, value: PubValue, options: PubOpOptions): PubOp;
+	static upsert(
+		slugOrId: string | PubsId,
+		valueOrOptions: PubValue | PubOpOptions,
+		options?: PubOpOptions
+	): PubOp {
+		if (isPubId(slugOrId)) {
+			return new PubOp(valueOrOptions as PubOpOptions, "upsert", slugOrId);
+		}
+		return new PubOp(options!, "upsert", undefined, slugOrId, valueOrOptions as PubValue);
+	}
+
+	/**
+	 * Add a single value to this pub
+	 * The slug is the field slug of format `[communitySlug]:[fieldSlug]`
+	 */
+	set(slug: string, value: PubValue): this;
+	/**
+	 * Add multiple values to this pub
+	 * The keys are the field slugs of format `[communitySlug]:[fieldSlug]`
+	 */
+	set(values: Record<string, PubValue>): this;
+	set(slugOrValues: string | Record<string, PubValue>, value?: PubValue): this {
+		if (typeof slugOrValues === "string") {
+			this.#commands.push({
+				type: "set",
+				slug: slugOrValues,
+				value: value!,
+			});
+		} else {
+			this.#commands.push(
+				...Object.entries(slugOrValues).map(([slug, value]) => ({
+					type: "set" as const,
+					slug,
+					value,
+				}))
+			);
+		}
+		return this;
+	}
+
+	/**
+	 * Relate this pub to another pub which you'll create/upsert in the same operation
+	 */
+	relate(slug: string, value: PubValue, target: PubOp): this;
+	/**
+	 * Relate this pub to another pub with a known id
+	 */
+	relate(slug: string, value: PubValue, target: PubsId): this;
+	relate(slug: string, value: PubValue, target: PubOp | PubsId): this {
+		this.#commands.push({ type: "relate", slug, value, target });
+		return this;
+	}
+
+	private collectAllOperations(processed = new Set<symbol>()): OperationsMap {
+		// If we've already processed this PubOp, return empty map to avoid circular recursion
+		if (processed.has(this.#thisSymbol)) {
+			return new Map();
+		}
+
+		const operations = new Map() as OperationsMap;
+		processed.add(this.#thisSymbol);
+
+		operations.set(this.#initialId || this.#thisSymbol, {
+			id: this.#initialId,
+			mode: this.#mode,
+			values: [
+				// if we use a value rather than the id as the unique identifier
+				...(this.#initialslug
+					? [{ slug: this.#initialslug, value: this.#initialValue! }]
+					: []),
+				...this.#commands
+					.filter(
+						(cmd): cmd is Extract<PubOpCommand, { type: "set" }> => cmd.type === "set"
+					)
+					.map((cmd) => ({
+						slug: cmd.slug,
+						value: cmd.value,
+					})),
+			],
+			relations: [],
+		});
+
+		for (const cmd of this.#commands) {
+			if (cmd.type !== "relate") {
+				continue;
+			}
+
+			const rootOp = operations.get(this.#initialId || this.#thisSymbol);
+			assert(rootOp, "Root operation not found");
+
+			if (!(cmd.target instanceof PubOp)) {
+				rootOp.relations.push({
+					slug: cmd.slug,
+					value: cmd.value,
+					target: cmd.target,
+				});
+				continue;
+			}
+
+			rootOp.relations.push({
+				slug: cmd.slug,
+				value: cmd.value,
+				target: cmd.target.#initialId || cmd.target.#thisSymbol,
+			});
+
+			// Only collect target operations if we haven't processed it yet
+			// to prevent infinite loops
+			if (!processed.has(cmd.target.#thisSymbol)) {
+				const targetOps = cmd.target.collectAllOperations(processed);
+				for (const [key, value] of targetOps) {
+					operations.set(key, value);
+				}
+			}
+		}
+
+		return operations;
+	}
+
+	private async executeWithTrx(trx: Transaction<Database>): Promise<PubsId> {
+		const operations = this.collectAllOperations();
+		const idMap = new Map<PubsId | symbol, PubsId>();
+
+		const pubsToCreate = [] as {
+			id: PubsId | undefined;
+			communityId: CommunitiesId;
+			pubTypeId: PubTypesId;
+		}[];
+
+		for (const [key, value] of operations) {
+			pubsToCreate.push({
+				id: typeof key === "symbol" ? undefined : key,
+				communityId: this.#options.communityId,
+				pubTypeId: this.#options.pubTypeId,
+			});
+		}
+
+		// we create the necessary pubs
+		const pubCreateResult = await autoRevalidate(
+			trx
+				.insertInto("pubs")
+				.values(pubsToCreate)
+				.onConflict((oc) => oc.columns(["id"]).doNothing())
+				.returningAll()
+		).execute();
+
+		let index = 0;
+		/**
+		 * this is somewhat convoluted, but basically:
+		 * - onConflict().doNothing() does not return anything if it's triggered
+		 * - therefore we need to fill in the "holes" in the pubCreateResult array
+		 * in order to effectively loop over it by comparing it with the operations
+		 */
+		const pubCreateResultWithHolesFilled = pubsToCreate.map((pubToCreate) => {
+			const correspondingPubCreateResult = pubCreateResult[index];
+
+			if (pubToCreate.id && pubToCreate.id !== correspondingPubCreateResult?.id) {
+				return null;
+			}
+
+			index++;
+
+			if (correspondingPubCreateResult) {
+				return correspondingPubCreateResult;
+			}
+
+			return null;
+		});
+
+		let idx = 0;
+		for (const [key, op] of operations) {
+			let result = pubCreateResultWithHolesFilled[idx];
+
+			if (result) {
+				idMap.set(key, result.id);
+				idx++;
+				continue;
+			}
+
+			// we are upserting a pub, OR we are creating a pub with a specific id that has failed
+			const possiblyExistingPubId = pubsToCreate[idx]?.id;
+
+			if (possiblyExistingPubId && op.mode === "create") {
+				throw new Error(
+					`Cannot create a pub with an id that already exists: ${possiblyExistingPubId}`
+				);
+			}
+
+			if (possiblyExistingPubId) {
+				idMap.set(key, possiblyExistingPubId);
+				idx++;
+				continue;
+			}
+
+			if (typeof key === "symbol") {
+				throw new Error("Pub not created");
+			}
+			idMap.set(key, key);
+
+			idx++;
+		}
+
+		const rootId = this.#initialId || idMap.get(this.#thisSymbol)!;
+		assert(rootId, "Root ID should exist");
+
+		const valuesToUpsert = [] as {
+			pubId: PubsId;
+			slug: string;
+			value: PubValue;
+		}[];
+
+		const relationValuesToUpsert = [] as {
+			pubId: PubsId;
+			slug: string;
+			value: PubValue;
+			relatedPubId: PubsId;
+		}[];
+
+		for (const [key, op] of operations) {
+			const pubId = typeof key === "symbol" ? idMap.get(key) : idMap.get(key);
+
+			assert(pubId, "Pub ID is required");
+
+			if (op.values.length > 0) {
+				valuesToUpsert.push(
+					...op.values.map((v) => ({
+						pubId,
+						slug: v.slug,
+						value: v.value,
+					}))
+				);
+			}
+
+			if (op.relations.length > 0) {
+				relationValuesToUpsert.push(
+					...op.relations.map((r) => ({
+						pubId,
+						slug: r.slug,
+						value: r.value,
+						relatedPubId: expect(
+							typeof r.target === "string" ? r.target : idMap.get(r.target),
+							"Related pub ID should exist"
+						),
+					}))
+				);
+			}
+		}
+
+		if (valuesToUpsert.length === 0 && relationValuesToUpsert.length === 0) {
+			return rootId;
+		}
+
+		// kind of clunky, but why do it twice when we can do it once
+		const validatedPubAndRelationValues = await validatePubValues({
+			pubValues: [...valuesToUpsert, ...relationValuesToUpsert],
+			communityId: this.#options.communityId,
+			continueOnValidationError: false,
+			trx,
+		});
+
+		const validatedPubValues = validatedPubAndRelationValues
+			.filter((v) => !("relatedPubId" in v) || !v.relatedPubId)
+			.map((v) => ({
+				pubId: v.pubId,
+				fieldId: v.fieldId,
+				value: v.value,
+				lastModifiedBy: this.#options.lastModifiedBy,
+			}));
+		const validatedRelationValues = validatedPubAndRelationValues
+			.filter(
+				(v): v is typeof v & { relatedPubId: PubsId } =>
+					"relatedPubId" in v && !!v.relatedPubId
+			)
+			.map((v) => ({
+				pubId: v.pubId,
+				fieldId: v.fieldId,
+				value: v.value,
+				relatedPubId: v.relatedPubId,
+				lastModifiedBy: this.#options.lastModifiedBy,
+			}));
+
+		await Promise.all([
+			upsertPubValues({
+				// this is a dummy pubId, we will use the ones on the validatedPubValues
+				pubId: "xxx" as PubsId,
+				pubValues: validatedPubValues,
+				lastModifiedBy: this.#options.lastModifiedBy,
+				trx,
+			}),
+			upsertPubRelationValues({
+				// this is a dummy pubId, we will use the ones on the validatedPubRelationValues
+				pubId: "xxx" as PubsId,
+				allRelationsToCreate: validatedRelationValues,
+				lastModifiedBy: this.#options.lastModifiedBy,
+				trx,
+			}),
+		]);
+
+		return rootId;
+	}
+
+	async execute(): Promise<ProcessedPub> {
+		const { trx = db } = this.#options;
+
+		const pubId = await maybeWithTrx(trx, async (trx) => {
+			return await this.executeWithTrx(trx);
+		});
+
+		return await getPubsWithRelatedValuesAndChildren(
+			{ pubId, communityId: this.#options.communityId },
+			{ trx }
+		);
+	}
+}

--- a/core/lib/server/pub-op.ts
+++ b/core/lib/server/pub-op.ts
@@ -1,19 +1,10 @@
-import { randomUUID } from "crypto";
-
 import type { Transaction } from "kysely";
 
 import { sql } from "kysely";
 
 import type { JsonValue, ProcessedPub } from "contracts";
 import type { Database } from "db/Database";
-import type {
-	CommunitiesId,
-	PubFieldsId,
-	PubsId,
-	PubTypesId,
-	PubValuesId,
-	StagesId,
-} from "db/public";
+import type { CommunitiesId, PubFieldsId, PubsId, PubTypesId, StagesId } from "db/public";
 import type { LastModifiedBy } from "db/types";
 import { assert, expect } from "utils";
 import { isUuid } from "utils/uuid";

--- a/core/lib/server/pub-op.ts
+++ b/core/lib/server/pub-op.ts
@@ -53,14 +53,14 @@ type RelationOptions =
 			/**
 			 * If true, existing relations on the same field will be removed
 			 */
-			override?: false;
+			replaceExisting?: false;
 			deleteOrphaned?: never;
 	  }
 	| {
 			/**
 			 * If true, existing relations on the same field will be removed
 			 */
-			override: true;
+			replaceExisting: true;
 			/**
 			 * If true, pubs that have been disconnected,
 			 * either manually or because they were orphaned because of `override: true`,
@@ -435,7 +435,7 @@ abstract class BasePubOp {
 							slug: cmd.slug,
 							value: relation.value,
 							target: relation.target as PubsId,
-							override: cmd.options.override,
+							override: cmd.options.replaceExisting,
 							deleteOrphaned: cmd.options.deleteOrphaned,
 						});
 
@@ -446,7 +446,7 @@ abstract class BasePubOp {
 						slug: cmd.slug,
 						value: relation.value,
 						target: relation.target.id,
-						override: cmd.options.override,
+						override: cmd.options.replaceExisting,
 						deleteOrphaned: cmd.options.deleteOrphaned,
 					});
 

--- a/core/lib/server/pub-trigger.db.test.ts
+++ b/core/lib/server/pub-trigger.db.test.ts
@@ -22,7 +22,7 @@ const { testDb, createForEachMockedTransaction, createSingleMockedTransaction } 
 	await mockServerCode();
 const { getTrx, rollback, commit } = createForEachMockedTransaction(testDb);
 
-const { createSeed } = await import("~/prisma/seed/seedCommunity");
+const { createSeed } = await import("~/prisma/seed/createSeed");
 
 const pubTriggerTestSeed = createSeed({
 	community: {

--- a/core/lib/server/pub.db.test.ts
+++ b/core/lib/server/pub.db.test.ts
@@ -646,45 +646,44 @@ describe("getPubsWithRelatedValuesAndChildren", () => {
 		pubWithRelatedValuesAndChildren.children[0].values.sort((a, b) =>
 			a.fieldSlug.localeCompare(b.fieldSlug)
 		);
-		expect(pubWithRelatedValuesAndChildren).toMatchObject({
-			values: [
-				{
-					value: "test relation value",
-					relatedPub: {
-						values: [{ value: "Nested Related Pub" }],
-						children: [{ values: [{ value: "Nested Child of Nested Related Pub" }] }],
-					},
+		expect(pubWithRelatedValuesAndChildren).toHaveValues([
+			{ value: "Some title" },
+			{
+				value: "test relation value",
+				relatedPub: {
+					values: [{ value: "Nested Related Pub" }],
+					children: [{ values: [{ value: "Nested Child of Nested Related Pub" }] }],
 				},
-				{ value: "Some title" },
-			],
-			children: [
-				{
+			},
+		]);
+
+		expect(pubWithRelatedValuesAndChildren.children).toHaveLength(1);
+		expect(pubWithRelatedValuesAndChildren.children[0]).toHaveValues([
+			{ value: "Child of Root Pub" },
+			{
+				value: "Nested Relation",
+				relatedPub: {
 					values: [
 						{
-							value: "Nested Relation 2",
-						},
-						{
-							value: "Nested Relation",
+							value: "Double nested relation",
 							relatedPub: {
-								values: [
-									{
-										value: "Nested Related Pub of Child of Root Pub",
-									},
-									{
-										value: "Double nested relation",
-										relatedPub: {
-											values: [{ value: "Double nested relation title" }],
-										},
-									},
-								],
+								values: [{ value: "Double nested relation title" }],
 							},
 						},
-						{ value: "Child of Root Pub" },
+						{
+							value: "Nested Related Pub of Child of Root Pub",
+						},
 					],
-					children: [{ values: [{ value: "Grandchild of Root Pub" }] }],
 				},
-			],
-		});
+			},
+			{
+				value: "Nested Relation 2",
+			},
+		]);
+		expect(pubWithRelatedValuesAndChildren.children[0].children).toHaveLength(1);
+		expect(pubWithRelatedValuesAndChildren.children[0].children[0]).toHaveValues([
+			{ value: "Grandchild of Root Pub" },
+		]);
 	});
 
 	it("should be able to filter by pubtype or stage and pubtype and stage", async () => {
@@ -903,21 +902,19 @@ describe("getPubsWithRelatedValuesAndChildren", () => {
 			{ depth: 10, fieldSlugs: [pubFields.Title.slug, pubFields["Some relation"].slug] }
 		)) as unknown as UnprocessedPub[];
 
-		expect(pubWithRelatedValuesAndChildren).toMatchObject({
-			values: [
-				{ value: "test title" },
-				{
-					value: "test relation value",
-					relatedPub: {
-						values: [
-							{
-								value: "test relation title",
-							},
-						],
-					},
+		expect(pubWithRelatedValuesAndChildren).toHaveValues([
+			{
+				value: "test relation value",
+				relatedPub: {
+					values: [
+						{
+							value: "test relation title",
+						},
+					],
 				},
-			],
-		});
+			},
+			{ value: "test title" },
+		]);
 	});
 
 	it("is able to exclude children and related pubs from being fetched", async () => {
@@ -964,14 +961,12 @@ describe("getPubsWithRelatedValuesAndChildren", () => {
 		expectTypeOf(pubWithRelatedValuesAndChildren.children).toEqualTypeOf<undefined>();
 
 		expect(pubWithRelatedValuesAndChildren.children).toEqual(undefined);
-		expect(pubWithRelatedValuesAndChildren).toMatchObject({
-			values: [
-				{ value: "test title" },
-				{
-					value: "test relation value",
-				},
-			],
-		});
+		expect(pubWithRelatedValuesAndChildren).toHaveValues([
+			{
+				value: "test relation value",
+			},
+			{ value: "test title" },
+		]);
 
 		expect(pubWithRelatedValuesAndChildren.values[1].relatedPub).toBeUndefined();
 		// check that the relatedPub is `undefined` in type as well as value due to `{withRelatedPubs: false}`
@@ -1031,6 +1026,7 @@ describe("getPubsWithRelatedValuesAndChildren", () => {
 			{ withMembers: true }
 		);
 
+		pub.members.sort((a, b) => a.slug.localeCompare(b.slug));
 		expect(pub).toMatchObject({
 			members: newUsers.map((u) => ({ ...u, role: MemberRole.admin })),
 		});

--- a/core/lib/server/pub.db.test.ts
+++ b/core/lib/server/pub.db.test.ts
@@ -6,9 +6,8 @@ import { CoreSchemaType, MemberRole } from "db/public";
 
 import type { UnprocessedPub } from "./pub";
 import { mockServerCode } from "~/lib/__tests__/utils";
+import { createSeed } from "~/prisma/seed/createSeed";
 import { createLastModifiedBy } from "../lastModifiedBy";
-
-const { createSeed } = await import("~/prisma/seed/seedCommunity");
 
 const { createForEachMockedTransaction } = await mockServerCode();
 

--- a/core/lib/server/pub.fts.db.test.ts
+++ b/core/lib/server/pub.fts.db.test.ts
@@ -2,14 +2,15 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 
 import { CoreSchemaType, MemberRole } from "db/public";
 
-import type { Seed } from "~/prisma/seed/seedCommunity";
+import type { Seed } from "~/prisma/seed/createSeed";
 import { mockServerCode } from "~/lib/__tests__/utils";
+import { createSeed } from "~/prisma/seed/createSeed";
 
 const { createForEachMockedTransaction, testDb } = await mockServerCode();
 
 const { getTrx } = createForEachMockedTransaction();
 
-const communitySeed = {
+const communitySeed = createSeed({
 	community: {
 		name: "test",
 		slug: "test-server-pub",
@@ -74,11 +75,15 @@ const communitySeed = {
 			},
 		},
 	],
-} as Seed;
+});
 
-const seed = async (trx = testDb, seed?: Seed) => {
+const seed = async <T extends Seed | undefined>(trx = testDb, seed?: T) => {
 	const { seedCommunity } = await import("~/prisma/seed/seedCommunity");
-	const seeded = await seedCommunity(seed ?? { ...communitySeed }, undefined, trx);
+	if (!seed) {
+		return seedCommunity(communitySeed, undefined, trx);
+	}
+
+	const seeded = await seedCommunity(seed, undefined, trx);
 
 	return seeded;
 };

--- a/core/lib/server/pub.sort.db.test.ts
+++ b/core/lib/server/pub.sort.db.test.ts
@@ -6,9 +6,8 @@ import type { PubsId } from "db/public";
 import { CoreSchemaType } from "db/public";
 
 import { mockServerCode } from "~/lib/__tests__/utils";
+import { createSeed } from "~/prisma/seed/createSeed";
 import { createLastModifiedBy } from "../lastModifiedBy";
-
-const { createSeed } = await import("~/prisma/seed/seedCommunity");
 
 const { testDb } = await mockServerCode();
 

--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -663,6 +663,10 @@ export const deletePubValuesByValueId = async ({
 	lastModifiedBy: LastModifiedBy;
 	trx?: typeof db;
 }) => {
+	if (valueIds.length === 0) {
+		return;
+	}
+
 	const result = await maybeWithTrx(trx, async (trx) => {
 		const deletedPubValues = await autoRevalidate(
 			trx

--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -999,6 +999,10 @@ export const removeAllPubRelationsBySlugs = async ({
 	lastModifiedBy: LastModifiedBy;
 	trx?: typeof db;
 }) => {
+	if (slugs.length === 0) {
+		return [];
+	}
+
 	const fields = await getFieldInfoForSlugs({
 		slugs: slugs,
 		communityId,

--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -421,7 +421,7 @@ export const doesPubExist = async (
 /**
  * For recursive transactions
  */
-const maybeWithTrx = async <T>(
+export const maybeWithTrx = async <T>(
 	trx: Transaction<Database> | Kysely<Database>,
 	fn: (trx: Transaction<Database>) => Promise<T>
 ): Promise<T> => {
@@ -698,10 +698,12 @@ const getFieldInfoForSlugs = async ({
 	slugs,
 	communityId,
 	includeRelations = true,
+	trx = db,
 }: {
 	slugs: string[];
 	communityId: CommunitiesId;
 	includeRelations?: boolean;
+	trx?: typeof db;
 }) => {
 	const toBeUpdatedPubFieldSlugs = Array.from(new Set(slugs));
 
@@ -713,6 +715,7 @@ const getFieldInfoForSlugs = async ({
 		communityId,
 		slugs: toBeUpdatedPubFieldSlugs,
 		includeRelations,
+		trx,
 	}).executeTakeFirstOrThrow();
 
 	const pubFields = Object.values(fields);
@@ -746,21 +749,24 @@ const getFieldInfoForSlugs = async ({
 	}));
 };
 
-const validatePubValues = async <T extends { slug: string; value: unknown }>({
+export const validatePubValues = async <T extends { slug: string; value: unknown }>({
 	pubValues,
 	communityId,
 	continueOnValidationError = false,
 	includeRelations = true,
+	trx = db,
 }: {
 	pubValues: T[];
 	communityId: CommunitiesId;
 	continueOnValidationError?: boolean;
 	includeRelations?: boolean;
+	trx?: typeof db;
 }) => {
 	const relevantPubFields = await getFieldInfoForSlugs({
 		slugs: pubValues.map(({ slug }) => slug),
 		communityId,
 		includeRelations,
+		trx,
 	});
 
 	const mergedPubFields = mergeSlugsWithFields(pubValues, relevantPubFields);

--- a/core/lib/server/pubFields.ts
+++ b/core/lib/server/pubFields.ts
@@ -14,6 +14,7 @@ type GetPubFieldsInput =
 			communityId: CommunitiesId;
 			includeRelations?: boolean;
 			slugs?: string[];
+			trx?: typeof db;
 	  }
 	| {
 			pubId: PubsId;
@@ -21,6 +22,7 @@ type GetPubFieldsInput =
 			communityId: CommunitiesId;
 			includeRelations?: boolean;
 			slugs?: string[];
+			trx?: typeof db;
 	  }
 	| {
 			pubId?: never;
@@ -28,6 +30,7 @@ type GetPubFieldsInput =
 			communityId: CommunitiesId;
 			includeRelations?: boolean;
 			slugs?: string[];
+			trx?: typeof db;
 	  };
 
 /**
@@ -42,7 +45,7 @@ type GetPubFieldsInput =
 export const getPubFields = (props: GetPubFieldsInput) => autoCache(_getPubFields(props));
 
 export const _getPubFields = (props: GetPubFieldsInput) =>
-	db
+	(props.trx ?? db)
 		.with("ids", (eb) =>
 			eb
 				.selectFrom("pub_fields")

--- a/core/lib/server/vitest.d.ts
+++ b/core/lib/server/vitest.d.ts
@@ -1,0 +1,14 @@
+import "vitest";
+
+import type { ProcessedPub } from "./pub";
+import type { db } from "~/kysely/database";
+
+interface CustomMatchers<R = unknown> {
+	toHaveValues(expected: Partial<ProcessedPub["values"][number]>[]): R;
+	toExist(expected?: typeof db): Promise<R>;
+}
+
+declare module "vitest" {
+	interface Assertion<T = any> extends CustomMatchers<T> {}
+	interface AsymmetricMatchersContaining extends CustomMatchers {}
+}

--- a/core/prisma/seed/createSeed.ts
+++ b/core/prisma/seed/createSeed.ts
@@ -1,0 +1,55 @@
+import type { CommunitiesId } from "db/public";
+
+import type {
+	FormInitializer,
+	PubFieldsInitializer,
+	PubInitializer,
+	PubTypeInitializer,
+	seedCommunity,
+	StageConnectionsInitializer,
+	StagesInitializer,
+	UsersInitializer,
+} from "./seedCommunity";
+
+/**
+ * Convenience method in case you want to define the input of `seedCommunity` before actually calling it
+ */
+export const createSeed = <
+	const PF extends PubFieldsInitializer,
+	const PT extends PubTypeInitializer<PF>,
+	const U extends UsersInitializer,
+	const S extends StagesInitializer<U>,
+	const SC extends StageConnectionsInitializer<S>,
+	const PI extends PubInitializer<PF, PT, U, S>[],
+	const F extends FormInitializer<PF, PT, U, S>,
+>(props: {
+	community: {
+		id?: CommunitiesId;
+		name: string;
+		slug: string;
+		avatar?: string;
+	};
+	pubFields?: PF;
+	pubTypes?: PT;
+	users?: U;
+	stages?: S;
+	stageConnections?: SC;
+	pubs?: PI;
+	forms?: F;
+}) => props;
+
+export type Seed = Parameters<typeof createSeed>[0];
+
+export type CommunitySeedOutput<S extends Record<string, any>> = Awaited<
+	ReturnType<
+		typeof seedCommunity<
+			NonNullable<S["pubFields"]>,
+			NonNullable<S["pubTypes"]>,
+			NonNullable<S["users"]>,
+			NonNullable<S["stages"]>,
+			NonNullable<S["stageConnections"]>,
+			NonNullable<S["pubs"]>,
+			NonNullable<S["forms"]>
+		>
+	>
+>;

--- a/core/prisma/seed/seedCommunity.ts
+++ b/core/prisma/seed/seedCommunity.ts
@@ -55,7 +55,7 @@ export type PubFieldsInitializer = Record<
 	}
 >;
 
-type PubTypeInitializer<PF extends PubFieldsInitializer> = Record<
+export type PubTypeInitializer<PF extends PubFieldsInitializer> = Record<
 	string,
 	Partial<Record<keyof PF, { isTitle: boolean }>>
 >;
@@ -65,7 +65,7 @@ type PubTypeInitializer<PF extends PubFieldsInitializer> = Record<
  * except the `role`, which will be set to `MemberRole.editor` by default.
  * Set to `null` if you don't want to add the user as a member
  */
-type UsersInitializer = Record<
+export type UsersInitializer = Record<
 	string,
 	{
 		/**
@@ -82,7 +82,7 @@ type UsersInitializer = Record<
 	}
 >;
 
-type ActionInstanceInitializer = {
+export type ActionInstanceInitializer = {
 	[K in ActionName]: {
 		/**
 		 * @default randomUUID
@@ -97,7 +97,7 @@ type ActionInstanceInitializer = {
 /**
  * Map of stagename to list of permissions
  */
-type StagesInitializer<U extends UsersInitializer> = Record<
+export type StagesInitializer<U extends UsersInitializer> = Record<
 	string,
 	{
 		id?: StagesId;
@@ -108,7 +108,7 @@ type StagesInitializer<U extends UsersInitializer> = Record<
 	}
 >;
 
-type StageConnectionsInitializer<S extends StagesInitializer<any>> = Partial<
+export type StageConnectionsInitializer<S extends StagesInitializer<any>> = Partial<
 	Record<
 		keyof S,
 		{
@@ -118,7 +118,7 @@ type StageConnectionsInitializer<S extends StagesInitializer<any>> = Partial<
 	>
 >;
 
-type PubInitializer<
+export type PubInitializer<
 	PF extends PubFieldsInitializer,
 	PT extends PubTypeInitializer<PF>,
 	U extends UsersInitializer,
@@ -229,7 +229,7 @@ type PubInitializer<
 	};
 }[keyof PT & string];
 
-type FormElementInitializer<
+export type FormElementInitializer<
 	PF extends PubFieldsInitializer,
 	PT extends PubTypeInitializer<PF>,
 	PubType extends keyof PT,
@@ -251,7 +251,7 @@ type FormElementInitializer<
 		}[keyof PubFieldsForPubType]
 	: never;
 
-type FormInitializer<
+export type FormInitializer<
 	PF extends PubFieldsInitializer,
 	PT extends PubTypeInitializer<PF>,
 	U extends UsersInitializer,
@@ -1169,32 +1169,3 @@ export async function seedCommunity<
 				: undefined,
 	};
 }
-
-/**
- * Convenience method in case you want to define the input of `seedCommunity` before actually calling it
- */
-export const createSeed = <
-	const PF extends PubFieldsInitializer,
-	const PT extends PubTypeInitializer<PF>,
-	const U extends UsersInitializer,
-	const S extends StagesInitializer<U>,
-	const SC extends StageConnectionsInitializer<S>,
-	const PI extends PubInitializer<PF, PT, U, S>[],
-	const F extends FormInitializer<PF, PT, U, S>,
->(props: {
-	community: {
-		id?: CommunitiesId;
-		name: string;
-		slug: string;
-		avatar?: string;
-	};
-	pubFields?: PF;
-	pubTypes?: PT;
-	users?: U;
-	stages?: S;
-	stageConnections?: SC;
-	pubs?: PI;
-	forms?: F;
-}) => props;
-
-export type Seed = Parameters<typeof createSeed>[0];

--- a/core/vitest.config.mts
+++ b/core/vitest.config.mts
@@ -5,7 +5,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	plugins: [react(), tsconfigPaths()],
 	test: {
-		globalSetup: ["./globalSetup.ts"],
+		globalSetup: ["./lib/__tests__/globalSetup.ts"],
+		setupFiles: ["./lib/__tests__/matchers.ts"],
 		environment: "jsdom",
 		environmentMatchGlobs: [
 			["**/(!db).test.ts", "jsdom"],

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -6,6 +6,7 @@
 	"module": "dist/schemas.esm.js",
 	"exports": {
 		".": "./dist/schemas.js",
+		"./formats": "./dist/schemas-formats.js",
 		"./schemas": "./dist/schemas-schemas.js",
 		"./package.json": "./package.json"
 	},
@@ -31,7 +32,8 @@
 	"preconstruct": {
 		"entrypoints": [
 			"index.ts",
-			"schemas.ts"
+			"schemas.ts",
+			"formats.ts"
 		],
 		"exports": true,
 		"___experimentalFlags_WILL_CHANGE_IN_PATCH": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,13 @@
 	"main": "dist/utils.cjs.js",
 	"module": "dist/utils.esm.js",
 	"exports": {
+		"./doi": "./dist/utils-doi.js",
+		"./url": "./dist/utils-url.js",
+		"./uuid": "./dist/utils-uuid.js",
 		".": "./dist/utils.js",
+		"./sleep": "./dist/utils-sleep.js",
+		"./assert": "./dist/utils-assert.js",
+		"./classnames": "./dist/utils-classnames.js",
 		"./package.json": "./package.json"
 	},
 	"scripts": {
@@ -24,6 +30,15 @@
 	},
 	"prettier": "@pubpub/prettier-config",
 	"preconstruct": {
+		"entrypoints": [
+			"index.ts",
+			"assert.ts",
+			"classnames.ts",
+			"url.ts",
+			"doi.ts",
+			"sleep.ts",
+			"uuid.ts"
+		],
 		"exports": true,
 		"___experimentalFlags_WILL_CHANGE_IN_PATCH": {
 			"typeModule": true,

--- a/packages/utils/src/uuid.ts
+++ b/packages/utils/src/uuid.ts
@@ -1,0 +1,5 @@
+export const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+export const isUuid = (value: string) => {
+	return uuidRegex.test(value);
+};


### PR DESCRIPTION
## Issue(s) Resolved

Adds a new PubOp system for creating, updating and managing relationships between Pubs using a fluent-like API/


## High-level Explanation of PR

> [!NOTE]
> This PR is an RFC! Meaning I'm totally happy not merging it!
> I'm more interested in your general thoughts on this approach, please nitpick it to hell!

This PR introduces a new `PubOp` system that provides a fluent, builder-style API for managing Pub operations. The system handles complex scenarios like creating multiple related pubs, managing nested relationships, and handling pub value updates in a single transaction.

### API

The API follows a builder pattern, allowing for chaining operations:

```ts
const pub = await PubOp.create({
  communityId: community.id,
  pubTypeId: pubType.id,
  lastModifiedBy: createLastModifiedBy({ userId: user.id }),
})
  .set('title', 'My Pub')
  .relate('someRelation', 'relation value', relatedPubId)
  .execute();
```

#### All builders

Currently there's 3 kinds of operations you can do:

- `create`
- `update`
- `upsert`

For `create`, there's also an explicit `createWithId`.
For both `update` and `upsert`, there's an `updateByValue` and an `upsertByValue`. These allow you to, instead of selecting a pub by id, select a pub by a specific value, eg a google drive id.

#### Basic capabilities

Currently, the `PubOp` allows you to do a bunch of things, here's a small table that shows what you can do with each of the operations:

| Capability                      | Create | Update | Upsert |
| ------------------------------- | ------ | ------ | ------ |
| Set values                      | ✓      | ✓      | ✓      |
| Connect/create related pubs     | ✓      | ✓      | ✓      |
| Set stage/move pub              | ✓      | ✓      | ✓      |
| Explicitly disconnect relations | -      | ✓      | -      |
| Explicitly disconnect values    | -      | ✓      | -      |
| Override existing values        | -      | ✓      | ✓      |
| Replace existing relations      | -      | ✓      | ✓      |

##### Set values

```ts
const pub = await PubOp.createWithId(pubId, {
  /*...*/
})
  .set('community-slug:title', 'My Pub')
  .execute();
```

##### Set many values in one go

```ts
const pub = await PubOp.upsert(pubId, {
  /*...*/
})
  .set({
    'community-slug:title': 'My Pub',
    'community-slug:description': 'My Pub description',
  })
  .execute();
```

##### Relate pubs

```ts
const pub = await PubOp.create({
  /*...*/
})
  .relate('community-slug:someRelation', 'relation value 1', relatedPubId1)
  .relate('community-slug:someRelation', 'relation value 2', relatedPubId2)
  .execute();
```

##### Relate multiple pubs in one go

```ts
const pub = await PubOp.create({
  /*...*/
})
  .relate('community-slug:someRelation', [
    {
      value: 'relation value 1',
      target: relatedPubId1,
    },
    {
      value: 'relation value 2',
      target: relatedPubId2,
    },
  ])
  .execute();
```

##### Nested relate

You can nest pub operations, allowing you to create, relate, and/or update multiple pubs in a single operation:

```ts
const pub = await PubOp.upsert(pubId, {
  /*...*/
})
  .relate(
    'someRelation',
    'value',
    PubOp.upsert(relatedPubId, {
      /*...*/
    })
      .set('title', 'Related Pub')
      .relate(
        'anotherRelation',
        'value2',
        PubOp.upsert(relatedPubId2, {
          /*...*/
        }).set('title', 'Related Pub 2')
      )
  )
  .execute();
```

If you don't want to keep repeating `{ communityId: ..., lastModifiedBy: ... }`, you also define a function instead
This just returns a new `PubOp` with `communityId` etc already set.

You'll still need to provide the `pubTypeId` for `upsert` and `create` operations.

```ts
const pub = await PubOp.create({
  communityId,
  pubTypeId,
  lastModifiedBy: createLastModifiedBy({ userId }),
})
  .set('community-slug:title', 'Community Title')
  .relate('community-slug:someRelation', 'relation value', (pubOp) =>
    pubOp
      .create({
        pubTypeId,
      })
      .set('pub-type-slug:title', 'Nested Pub')
  )
  .execute();
```


<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan

1. Look at the tests in
https://github.com/pubpub/platform/blob/64ebece2eab27b80e4c1b7d8c3c6a988d863f193/core/lib/server/pub-op.db.test.ts#L1-L1329

2. Write one extra test to get a feel for it (don't need to push it, but would be appreciated!)

## Screenshots (if applicable)

## Notes

> [!NOTE]
> This new API isn't used anywhere yet, that comes later!
