### PR TITLE
fix: pub create/edit form grow to container

### DIFF
--- a/core/app/c/[communitySlug]/pubs/[pubId]/edit/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/edit/page.tsx
@@ -130,7 +130,7 @@ export default async function Page(props: {
 			}
 		>
 			<div className="flex justify-center py-10">
-				<div className="prose flex-1">
+				<div className="prose max-w-prose flex-1">
 					<PubEditor
 						searchParams={searchParams}
 						pubId={pub.id}

--- a/core/app/c/[communitySlug]/pubs/[pubId]/edit/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/edit/page.tsx
@@ -130,7 +130,7 @@ export default async function Page(props: {
 			}
 		>
 			<div className="flex justify-center py-10">
-				<div className="max-w-prose">
+				<div className="prose flex-1">
 					<PubEditor
 						searchParams={searchParams}
 						pubId={pub.id}

--- a/core/app/c/[communitySlug]/pubs/create/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/create/page.tsx
@@ -79,7 +79,7 @@ export default async function Page(props: {
 			right={<div />}
 		>
 			<div className="flex justify-center py-10">
-				<div className="prose flex-1">
+				<div className="prose max-w-prose flex-1">
 					<PubEditor
 						searchParams={searchParams}
 						communityId={community.id}

--- a/core/app/c/[communitySlug]/pubs/create/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/create/page.tsx
@@ -79,7 +79,7 @@ export default async function Page(props: {
 			right={<div />}
 		>
 			<div className="flex justify-center py-10">
-				<div className="max-w-prose">
+				<div className="prose flex-1">
 					<PubEditor
 						searchParams={searchParams}
 						communityId={community.id}

--- a/core/playwright/pub.spec.ts
+++ b/core/playwright/pub.spec.ts
@@ -207,7 +207,12 @@ test.describe("Creating a pub", () => {
 		// Now update
 		await page.getByTestId("pub-dropdown-button").first().click();
 		await page.getByRole("link", { name: "Update Pub" }).click();
-		await page.locator(".ProseMirror").click();
+		await page.locator(".ProseMirror").click({
+			position: {
+				x: 0,
+				y: 0,
+			},
+		});
 		await page.keyboard.type("prefix ");
 
 		await page.getByRole("button", { name: "Save" }).click();


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #962 

## High-level Explanation of PR

Quick fix to make the pub create/edit forms a bit wider.

<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan

1. Open the pub create and edit forms and observe that they are now wider!

## Screenshots (if applicable)

<img width="728" alt="Screenshot 2025-02-18 at 12 36 27 PM" src="https://github.com/user-attachments/assets/2e2c09d5-fbf1-4d9a-980c-01c1cb42a11b" />



## Notes
