### PR TITLE
feat: add remove button to pub page

### DIFF
--- a/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
@@ -169,7 +169,7 @@ export default async function Page(props: {
 							<span>Update</span>
 						</Link>
 					</Button>
-					<RemovePubButton pubId={pub.id} />
+					<RemovePubButton pubId={pub.id} redirectTo={`/c/${communitySlug}/pubs`} />
 				</div>
 			</div>
 

--- a/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
@@ -15,6 +15,7 @@ import { MembersList } from "~/app/components//Memberships/MembersList";
 import { PubsRunActionDropDownMenu } from "~/app/components/ActionUI/PubsRunActionDropDownMenu";
 import { AddMemberDialog } from "~/app/components/Memberships/AddMemberDialog";
 import { CreatePubButton } from "~/app/components/pubs/CreatePubButton";
+import { RemovePubButton } from "~/app/components/pubs/RemovePubButton";
 import SkeletonTable from "~/app/components/skeletons/SkeletonTable";
 import { db } from "~/kysely/database";
 import { getPageLoginData } from "~/lib/authentication/loginData";
@@ -156,12 +157,20 @@ export default async function Page(props: {
 					</div>
 					<h1 className="mb-2 text-xl font-bold">{getPubTitle(pub)} </h1>
 				</div>
-				<Button variant="outline" asChild className="flex items-center gap-1">
-					<Link href={`/c/${communitySlug}/pubs/${pub.id}/edit`}>
-						<Pencil size="14" />
-						Update
-					</Link>
-				</Button>
+				<div className="flex items-center gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						asChild
+						className="flex items-center gap-x-2 py-4"
+					>
+						<Link href={`/c/${communitySlug}/pubs/${pub.id}/edit`}>
+							<Pencil size="12" />
+							<span>Update</span>
+						</Link>
+					</Button>
+					<RemovePubButton pubId={pub.id} />
+				</div>
 			</div>
 
 			<div className="flex flex-wrap space-x-4">

--- a/core/app/components/pubs/RemovePubButton.tsx
+++ b/core/app/components/pubs/RemovePubButton.tsx
@@ -1,7 +1,7 @@
 import type { ButtonProps } from "ui/button";
 import { Trash } from "ui/icon";
 
-import type { PubRemoveProps } from "./RemovePubForm";
+import type { PubRemoveProps } from "./RemovePubFormClient";
 import { PathAwareDialog } from "../PathAwareDialog";
 import { PubRemove } from "./RemovePubForm";
 

--- a/core/app/components/pubs/RemovePubForm.tsx
+++ b/core/app/components/pubs/RemovePubForm.tsx
@@ -1,13 +1,8 @@
 import { Suspense } from "react";
 import dynamic from "next/dynamic";
 
-import type { PubsId } from "db/public";
-
+import type { PubRemoveProps } from "./RemovePubFormClient";
 import { SkeletonCard } from "../skeletons/SkeletonCard";
-
-export type PubRemoveProps = {
-	pubId: PubsId;
-};
 
 const PubRemoveForm = dynamic(
 	async () => {
@@ -18,10 +13,10 @@ const PubRemoveForm = dynamic(
 	{ loading: () => <SkeletonCard /> }
 );
 
-export async function PubRemove({ pubId }: PubRemoveProps) {
+export async function PubRemove({ pubId, redirectTo }: PubRemoveProps) {
 	return (
 		<Suspense fallback={<div>Loading...</div>}>
-			<PubRemoveForm pubId={pubId} />
+			<PubRemoveForm pubId={pubId} redirectTo={redirectTo} />
 		</Suspense>
 	);
 }

--- a/core/app/components/pubs/RemovePubFormClient.tsx
+++ b/core/app/components/pubs/RemovePubFormClient.tsx
@@ -13,7 +13,12 @@ import { toast } from "ui/use-toast";
 import { useServerAction } from "~/lib/serverActions";
 import * as actions from "./PubEditor/actions";
 
-export const PubRemoveForm = ({ pubId }: { pubId: PubsId }) => {
+export type PubRemoveProps = {
+	pubId: PubsId;
+	redirectTo?: string;
+};
+
+export const PubRemoveForm = ({ pubId, redirectTo }: PubRemoveProps) => {
 	const form = useForm({
 		mode: "onChange",
 		reValidateMode: "onChange",
@@ -32,8 +37,12 @@ export const PubRemoveForm = ({ pubId }: { pubId: PubsId }) => {
 	}, [path, searchParams]);
 
 	const closeForm = useCallback(() => {
-		router.replace(pathWithoutFormParam);
-	}, [pathWithoutFormParam]);
+		if (redirectTo) {
+			router.push(redirectTo);
+		} else {
+			router.replace(pathWithoutFormParam);
+		}
+	}, [pathWithoutFormParam, redirectTo, router]);
 
 	const onSubmit = async () => {
 		const result = await runRemovePub({

--- a/core/playwright/pub.spec.ts
+++ b/core/playwright/pub.spec.ts
@@ -62,7 +62,7 @@ test.describe("Moving a pub", () => {
 		await pubDetailsPage.goTo();
 		await expect(page.getByTestId("current-stage")).toHaveText("Submitted");
 		// For this initial stage, there are only destinations ,no sources
-		await page.getByRole("button", { name: "Move" }).click();
+		await page.getByRole("button", { name: "Move", exact: true }).click();
 		const sources = page.getByTestId("sources");
 		const destinations = page.getByTestId("destinations");
 		await expect(sources).toHaveCount(0);
@@ -70,7 +70,7 @@ test.describe("Moving a pub", () => {
 		await expect(page.getByTestId("current-stage")).toHaveText("Ask Author for Consent");
 
 		// Open the move modal again and expect to be able to move to sources and destinations
-		await page.getByRole("button", { name: "Move" }).click();
+		await page.getByRole("button", { name: "Move", exact: true }).click();
 		await expect(sources.getByRole("button", { name: "Submitted" })).toHaveCount(1);
 		await expect(destinations.getByRole("button", { name: "To Evaluate" })).toHaveCount(1);
 	});
@@ -91,7 +91,7 @@ test.describe("Moving a pub", () => {
 		const pubDetailsPage = new PubDetailsPage(page, COMMUNITY_SLUG, pubId);
 		await pubDetailsPage.goTo();
 		await expect(page.getByTestId("current-stage")).toHaveText("Shelved");
-		await expect(page.getByRole("button", { name: "Move" })).toHaveCount(0);
+		await expect(page.getByRole("button", { name: "Move", exact: true })).toHaveCount(0);
 	});
 });
 


### PR DESCRIPTION
## Issue(s) Resolved

Can't remove pub from pub page, only from Pub list or stages page.

## High-level Explanation of PR

Just add the `PubRemoveButton` to `/c/[communitySlug]/pubs/[pubId]`

## Test Plan

1. Create new Pub
2. Go to Pub page
3. Press remove button

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/f292ea24-e156-478e-b6de-c4a944fd8681)


## Notes
