### PR TITLE
dev: add dependabot to maintain deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
+# Dependabot configuration file
+# See documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+    # package.json + pnpm catalog updates
+    - package-ecosystem: "npm"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+          day: "monday"
+      open-pull-requests-limit: 10
+      labels:
+          - "dependencies"
+          - "npm"
+      commit-message:
+          prefix: "npm"
+          include: "scope"
+      # group all minor and patch updates together
+      groups:
+          minor-patch-dependencies:
+              patterns:
+                  - "*"
+              update-types:
+                  - "minor"
+                  - "patch"
+
+    # GitHub Actions updates
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+          day: "monday"
+      open-pull-requests-limit: 5
+      labels:
+          - "dependencies"
+          - "github-actions"
+      commit-message:
+          prefix: "github-actions"
+          include: "scope"
+
+    # docker updates
+    - package-ecosystem: "docker"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+          day: "monday"
+      open-pull-requests-limit: 5
+      labels:
+          - "dependencies"
+          - "docker"
+      commit-message:
+          prefix: "docker"
+          include: "scope"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,8 @@
 		"ms-playwright.playwright",
 		"YoavBls.pretty-ts-errors",
 		"esbenp.prettier-vscode",
-		"dbaeumer.vscode-eslint"
+		"dbaeumer.vscode-eslint",
+		// for yaml autocompletion using the # yaml-language-server: $schema=... directive
+		"redhat.vscode-yaml"
 	]
 }


### PR DESCRIPTION
- **dev: add dependabot**
- **dev: add yaml extension suggestion**

## Issue(s) Resolved
Dependencies going out of date and being annoying to update.

## High-level Explanation of PR

Adds a `dependabot.yml` with some relatively arbitrary settings.

`dependabot` recently [added support for `pnpm` workspace catalogs](https://github.blog/changelog/2025-02-04-dependabot-now-supports-pnpm-workspace-catalogs-ga/) which we we recently introduced. This means we can use it now, as our most important dependncies are managed in `workspaces.yml`.

In case you are unaware of what `dependabot` is: basically a bot that puts up PRs updating dependencies that have gone out of date. 

### How to handle dependabot pull requests.

Given that we now have a reasonably robust test-suite, i feel relatively comfortable merging in patch/minor version updates if they pass our tests. For major versions we should still do some sleuthing I think.

I have set it up st it will put up PRs on monday. Given i'm usually the first person online, I'm happy to go through the PRs and handle them.

### Proposal

- minor/patchs updates: 
  - if `dependabot`s minor/patch PR(s) pass our tests, we just merge them in.
- major updates:
  - if the PR passes tests
        - run it locally once going through some things.
        - merge if it feels right
  - if the PR does not pass tests
    - try to make it pass tests
        -  do some local testing, then request review
    - if unable to make it pass tests easily
        - make proposal on whether to merge it in or not
  - for core dependencies (next, react, kysely, those in the catalogs)
        - unlikely that they pass tests anywan
        - first discuss with team whether major version update is desired


## Test Plan

## Screenshots (if applicable)

## Notes
