### PR TITLE
dev: set some next settings to improve build times

### DIFF
--- a/core/next.config.mjs
+++ b/core/next.config.mjs
@@ -52,6 +52,8 @@ const nextConfig = {
 	],
 	experimental: {
 		optimizePackageImports: ["@icons-pack/react-simple-icons", "lucide-react"],
+		webpackBuildWorker: true,
+		parallelServerBuildTraces: true,
 	},
 	// open telemetry cries a lot during build, don't think it's serious
 	// https://github.com/open-telemetry/opentelemetry-js/issues/4173

--- a/core/next.config.mjs
+++ b/core/next.config.mjs
@@ -52,17 +52,20 @@ const nextConfig = {
 	],
 	experimental: {
 		optimizePackageImports: ["@icons-pack/react-simple-icons", "lucide-react"],
-		webpackBuildWorker: true,
-		parallelServerBuildTraces: true,
 	},
 	// open telemetry cries a lot during build, don't think it's serious
 	// https://github.com/open-telemetry/opentelemetry-js/issues/4173
-	// webpack: (config, { buildId, dev, isServer, defaultLoaders, nextRuntime, webpack }) => {
-	// 	if (isServer) {
-	// 		config.ignoreWarnings = [{ module: /opentelemetry/ }];
-	// 	}
-	// 	return config;
-	// },
+	webpack: (config, { buildId, dev, isServer, defaultLoaders, nextRuntime, webpack }) => {
+		if (config.cache && !dev) {
+			config.cache = Object.freeze({
+				type: "memory",
+			});
+		}
+		if (isServer) {
+			config.ignoreWarnings = [{ module: /opentelemetry/ }];
+		}
+		return config;
+	},
 };
 
 const modifiedConfig = withPreconstruct(


### PR DESCRIPTION
## Issue(s) Resolved

Next builds are long.

## High-level Explanation of PR

TLDR: total CI time decrease for building core is 1m30s!! very nice

Enables `experimental.parallelServerBulldTraces` in `next.config.mjs`. This makes the tracing of server routes take place in a separate worker, which slightly decreases build times (ideally).

As you can see below, this results in ~50s or roughly 19% faster `next build`s! Seems great for doing literally nothing.  

Additionally, I disable webpack caching in line with [this next recommendation](https://nextjs.org/docs/app/building-your-application/optimizing/memory-usage#disable-webpack-cache). Currently serializing and writing the webpack cache takes a long time, we even get this warning often
```
<w> [webpack.cache.PackFileCacheStrategy] Serializing big strings (243kiB) impacts deserialization performance (consider using Buffer instead and decode when needed)
```

Disabling this cache writing results in an additional 40s saved.

In total, this results in a **33% decrease** in `next build` times!!

This is imo still crazy slow, but at least it's slightly less so.


> [!NOTE]
> The webpack cache is very useful, in theory. If we could effectively cache it, subsequent builds would be substantially faster.
> I've not been able to figure out how to do this in docker yet though (caching docker layers is prohibitively slow, we should not do it).
> We could only disable the webpack cache on CI, but i'm personally very rarely doing repeated builds myself without doing a `next dev` in between, so i'd rather have a faster initial build locally than faster rebuilds.



### In CI
Time is last step of `#24` the step `Build, Tag, and Push to ECR`

**Main**

https://github.com/pubpub/platform/actions/runs/13527437906/job/37801720865
```
#24 DONE 275.4s
```

https://github.com/pubpub/platform/actions/runs/13541214032/job/37842525354?pr=998
**+ `webpackBuildWorker` + `parallelServerBuildTraces`**  
```
#24 DONE 223.2s
```

https://github.com/pubpub/platform/actions/runs/13542305151/job/37845940104?pr=998

**+ `webpackBuildWorker` + `parallelServerBuildTraces` + cache freeze**
```
#24 DONE 183.5s
```

Improvement of 50ish seconds, not bad!

### On my machine

result of running 
```sh
rm -rf .next && time pnpm --filter core build
```

**Main**
```
      127.14 real       210.20 user        32.80 sys       
```

**+ `webpackBuildWorker`**
```
      102.50 real       183.38 user        31.65 sys
```

**+ `webpackBuildWorker` + `parallelServerBuildTraces`**  
```    
      93.87 real       157.80 user        28.09 sys
```
So a 30ish to 60ish second decrease, pretty nice!


**+ `webpackBuildWorker` + `parallelServerBuildTraces` + cache freeze**
```
       75.88 real       107.77 user        16.19 sys
```
An additional 50sec decrease! very nice

<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan

Run build locally, hopefully do not get OOM errors.

Check that Sentry sourcemaps are still being uploaded correctly (should not be influenced i think)

## Screenshots (if applicable)

## Notes
