### PR TITLE
chore: PR preview fixes

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -36,7 +36,11 @@ jobs:
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
     deploy-preview:
-        permissions: write-all
+        permissions:
+            contents: read
+            deployments: write
+            pull-requests: write
+            statuses: write
         runs-on: ubuntu-latest
         timeout-minutes: 30
         needs:
@@ -71,13 +75,13 @@ jobs:
               with:
                   label: preview
                   admins: 3mcd
-                  cidrs: "0.0.0.0/0"
                   compose_files: ./self-host/docker-compose.yml,docker-compose.preview.yml
                   default_port: 443
                   instance_type: small
-                  ports: 443,9001
+                  ports: 80,443,9001
                   registries: docker://AWS:${{steps.ecrtoken.outputs.value}}@246372085946.dkr.ecr.us-east-1.amazonaws.com
               env:
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   AWS_REGION: ${{ env.AWS_REGION }}
+                  PULLPREVIEW_LOGGER_LEVEL: DEBUG

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -11,6 +11,7 @@ services:
             ASSETS_UPLOAD_SECRET_KEY: preview-different123
             ASSETS_STORAGE_ENDPOINT: https://${PULLPREVIEW_PUBLIC_DNS}/assets
     minio-init:
+        restart: on-failure
         environment:
             MINIO_ROOT_USER: preview
             MINIO_ROOT_PASSWORD: preview123

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -12,7 +12,6 @@ services:
             ASSETS_STORAGE_ENDPOINT: https://${PULLPREVIEW_PUBLIC_DNS}/assets
     minio-init:
         restart: on-failure
-        attach: false
         environment:
             MINIO_ROOT_USER: preview
             MINIO_ROOT_PASSWORD: preview123

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -12,6 +12,7 @@ services:
             ASSETS_STORAGE_ENDPOINT: https://${PULLPREVIEW_PUBLIC_DNS}/assets
     minio-init:
         restart: on-failure
+        attach: false
         environment:
             MINIO_ROOT_USER: preview
             MINIO_ROOT_PASSWORD: preview123

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -10,13 +10,13 @@ services:
             ASSETS_UPLOAD_KEY: preview-different
             ASSETS_UPLOAD_SECRET_KEY: preview-different123
             ASSETS_STORAGE_ENDPOINT: https://${PULLPREVIEW_PUBLIC_DNS}/assets
-    minio-init:
-        restart: on-failure
-        environment:
-            MINIO_ROOT_USER: preview
-            MINIO_ROOT_PASSWORD: preview123
-            ASSETS_UPLOAD_KEY: preview-different
-            ASSETS_UPLOAD_SECRET_KEY: preview-different123
+    # minio-init:
+    #     restart: on-failure
+    #     environment:
+    #         MINIO_ROOT_USER: preview
+    #         MINIO_ROOT_PASSWORD: preview123
+    #         ASSETS_UPLOAD_KEY: preview-different
+    #         ASSETS_UPLOAD_SECRET_KEY: preview-different123
     minio:
         environment:
             MINIO_ROOT_USER: preview

--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -93,12 +93,12 @@ services:
     minio:
         image: minio/minio:latest
         env_file: .env
-        healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/ready"]
-            interval: 1m30s
-            timeout: 30s
-            retries: 5
-            start_period: 30s
+        # healthcheck:
+        #     test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/ready"]
+        #     interval: 1m30s
+        #     timeout: 30s
+        #     retries: 5
+        #     start_period: 30s
         restart: unless-stopped
         command: server --console-address ":9001" /data
         ports:

--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -110,23 +110,23 @@ services:
             - app-network
 
     # initialize minio
-    minio-init:
-        depends_on:
-            minio:
-                condition: service_healthy
-        image: minio/mc:latest
-        env_file: .env
-        entrypoint: >
-            /bin/sh -c '
-            /usr/bin/mc config host add myminio http://minio:9000 "$${MINIO_ROOT_USER}" "$${MINIO_ROOT_PASSWORD}";
-            /usr/bin/mc mb --ignore-existing myminio/"$${ASSETS_BUCKET_NAME}";
-            /usr/bin/mc anonymous set download myminio/"$${ASSETS_BUCKET_NAME}";
-            /usr/bin/mc admin user add myminio "$${ASSETS_UPLOAD_KEY}" "$${ASSETS_UPLOAD_SECRET_KEY}";
-            /usr/bin/mc admin policy attach myminio readwrite --user "$${ASSETS_UPLOAD_KEY}";
-            exit 0;
-            '
-        networks:
-            - app-network
+    # minio-init:
+    #     depends_on:
+    #         minio:
+    #             condition: service_healthy
+    #     image: minio/mc:latest
+    #     env_file: .env
+    #     entrypoint: >
+    #         /bin/sh -c '
+    #         /usr/bin/mc config host add myminio http://minio:9000 "$${MINIO_ROOT_USER}" "$${MINIO_ROOT_PASSWORD}";
+    #         /usr/bin/mc mb --ignore-existing myminio/"$${ASSETS_BUCKET_NAME}";
+    #         /usr/bin/mc anonymous set download myminio/"$${ASSETS_BUCKET_NAME}";
+    #         /usr/bin/mc admin user add myminio "$${ASSETS_UPLOAD_KEY}" "$${ASSETS_UPLOAD_SECRET_KEY}";
+    #         /usr/bin/mc admin policy attach myminio readwrite --user "$${ASSETS_UPLOAD_KEY}";
+    #         exit 0;
+    #         '
+    #     networks:
+    #         - app-network
 
 volumes:
     caddy-data:

--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -93,12 +93,12 @@ services:
     minio:
         image: minio/minio:latest
         env_file: .env
-        # healthcheck:
-        #     test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/ready"]
-        #     interval: 1m30s
-        #     timeout: 30s
-        #     retries: 5
-        #     start_period: 30s
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/ready"]
+            interval: 1m30s
+            timeout: 30s
+            retries: 5
+            start_period: 30s
         restart: unless-stopped
         command: server --console-address ":9001" /data
         ports:


### PR DESCRIPTION
This PR temporarily disables the minio-init service, which variably returns status code 0 or 1. I'm not sure what the cause is yet, but since file uploads are not working, I'm going to go ahead and merge this to get the preview workflow to report successes.