### PR TITLE
Allow adding elements to an empty form

### DIFF
--- a/core/app/components/FormBuilder/ElementPanel/SelectElement.tsx
+++ b/core/app/components/FormBuilder/ElementPanel/SelectElement.tsx
@@ -49,7 +49,7 @@ export const SelectElement = ({ panelState }: { panelState: PanelState }) => {
 						fieldId: field.id,
 						required: true,
 						type: ElementType.pubfield,
-						rank: mudder.base62.mudder(elements[elementsCount - 1].rank, "", 1)[0],
+						rank: mudder.base62.mudder(elements[elementsCount - 1]?.rank, "", 1)[0],
 						configured: false,
 						config: field.isRelation
 							? {
@@ -138,7 +138,7 @@ export const SelectElement = ({ panelState }: { panelState: PanelState }) => {
 										element: elementType,
 										type: ElementType.structural,
 										rank: mudder.base62.mudder(
-											elements[elementsCount - 1].rank,
+											elements[elementsCount - 1]?.rank,
 											"",
 											1
 										)[0],


### PR DESCRIPTION
## Issue(s) Resolved
If you deleted all the elements from a form, it was impossible to add new elements to the form. The bug was easy to miss/rarely happens because we always create forms with some default fields.
https://kfg.sentry.io/issues/6368052103/?referrer=github-pr-bot

## Test Plan
- Open (or create) a form in the preview app 
- Delete every element
- Save the form
- Add a new element back to the form (it shouldn't crash)