### PR TITLE
refactor: move db creation to factory fn for env-independent instances

### DIFF
--- a/core/kysely/database-init.ts
+++ b/core/kysely/database-init.ts
@@ -68,7 +68,7 @@ export const createDatabase = (options: DatabaseOptions) => {
 	 * For debugging and testing of latency
 	 */
 	const artificialLatencyPlugin =
-		options.latency && options.env !== "production"
+		options.latency && options.nodeEnv !== "production"
 			? new ArtificialLatencyPlugin(options.latency)
 			: null;
 

--- a/core/kysely/database-init.ts
+++ b/core/kysely/database-init.ts
@@ -15,7 +15,7 @@ type DatabaseOptions = {
 	debug?: boolean;
 	logLevel?: string;
 	latency?: number;
-	env?: string;
+	nodeEnv?: string;
 };
 
 const int8TypeId = 20;

--- a/core/kysely/database-init.ts
+++ b/core/kysely/database-init.ts
@@ -1,0 +1,86 @@
+import type { LogEvent } from "kysely";
+
+import { Kysely, PostgresDialect } from "kysely";
+import pg from "pg";
+
+import type { Database } from "db/Database";
+import { databaseTables } from "db/table-names";
+import { logger } from "logger";
+
+import { ArtificialLatencyPlugin } from "./artificial-latency-plugin";
+import { UpdatedAtPlugin } from "./updated-at-plugin";
+
+type DatabaseOptions = {
+	url: string;
+	debug?: boolean;
+	logLevel?: string;
+	latency?: number;
+	env?: string;
+};
+
+const int8TypeId = 20;
+// Map int8 to number.
+// this is likely fine
+pg.types.setTypeParser(int8TypeId, (val: any) => {
+	return parseInt(val, 10);
+});
+
+const tablesWithUpdateAt = databaseTables
+	.filter((table) => table.columns.find((column) => column.name === "updatedAt"))
+	.map((table) => table.name);
+
+export const createDatabase = (options: DatabaseOptions) => {
+	const dialect = new PostgresDialect({
+		pool: new pg.Pool({
+			connectionString: options.url,
+		}),
+	});
+
+	const kyselyLogger =
+		options.logLevel === "debug" && options.debug
+			? ({ query: { sql, parameters }, ...event }: LogEvent) => {
+					const params = parameters.map((p) => {
+						if (p === null) {
+							return "null";
+						}
+						if (p instanceof Date) {
+							return `'${p.toISOString()}'`;
+						}
+						if (typeof p === "object") {
+							const stringified = `'${JSON.stringify(p)}'`;
+							if (Array.isArray(p)) {
+								return "ARRAY " + stringified;
+							}
+							return stringified;
+						}
+						return `'${p}'`;
+					});
+					logger.debug(
+						{ event },
+						"Kysely query:\n%s",
+						sql.replaceAll(/\$[0-9]+/g, () => params.shift()!)
+					);
+				}
+			: undefined;
+
+	const updatedAtPlugin = new UpdatedAtPlugin(tablesWithUpdateAt);
+	/**
+	 * For debugging and testing of latency
+	 */
+	const artificialLatencyPlugin =
+		options.latency && options.env !== "production"
+			? new ArtificialLatencyPlugin(options.latency)
+			: null;
+
+	const plugins = [updatedAtPlugin, artificialLatencyPlugin].filter((plugin) => plugin !== null);
+
+	// Database interface is passed to Kysely's constructor, and from now on, Kysely
+	// knows your database structure.
+	// Dialect is passed to Kysely's constructor, and from now on, Kysely knows how
+	// to communicate with your database.
+	return new Kysely<Database>({
+		dialect,
+		log: kyselyLogger,
+		plugins,
+	});
+};

--- a/core/kysely/database.ts
+++ b/core/kysely/database.ts
@@ -5,6 +5,6 @@ export const db = createDatabase({
 	url: env.DATABASE_URL,
 	logLevel: env.LOG_LEVEL,
 	debug: env.KYSELY_DEBUG === "true",
-	env: env.NODE_ENV,
+	nodeEnv: env.NODE_ENV,
 	latency: env.KYSELY_ARTIFICIAL_LATENCY,
 });

--- a/core/kysely/database.ts
+++ b/core/kysely/database.ts
@@ -1,77 +1,10 @@
-import type { LogEvent } from "kysely";
-
-import { Kysely, PostgresDialect } from "kysely";
-import pg from "pg";
-
-import type { Database } from "db/Database";
-import { databaseTables } from "db/table-names";
-import { logger } from "logger";
-
 import { env } from "~/lib/env/env.mjs";
-import { ArtificialLatencyPlugin } from "./artificial-latency-plugin";
-import { UpdatedAtPlugin } from "./updated-at-plugin";
+import { createDatabase } from "./database-init";
 
-const int8TypeId = 20;
-// Map int8 to number.
-// this is likely fine
-pg.types.setTypeParser(int8TypeId, (val: any) => {
-	return parseInt(val, 10);
-});
-
-const dialect = new PostgresDialect({
-	pool: new pg.Pool({
-		connectionString: env.DATABASE_URL,
-	}),
-});
-
-const kyselyLogger =
-	env.LOG_LEVEL === "debug" && env.KYSELY_DEBUG === "true"
-		? ({ query: { sql, parameters }, ...event }: LogEvent) => {
-				const params = parameters.map((p) => {
-					if (p === null) {
-						return "null";
-					}
-					if (p instanceof Date) {
-						return `'${p.toISOString()}'`;
-					}
-					if (typeof p === "object") {
-						const stringified = `'${JSON.stringify(p)}'`;
-						if (Array.isArray(p)) {
-							return "ARRAY " + stringified;
-						}
-						return stringified;
-					}
-					return `'${p}'`;
-				});
-				logger.debug(
-					{ event },
-					"Kysely query:\n%s",
-					sql.replaceAll(/\$[0-9]+/g, () => params.shift()!)
-				);
-			}
-		: undefined;
-
-const tablesWithUpdateAt = databaseTables
-	.filter((table) => table.columns.find((column) => column.name === "updatedAt"))
-	.map((table) => table.name);
-
-const updatedAtPlugin = new UpdatedAtPlugin(tablesWithUpdateAt);
-/**
- * For debugging and testing of latency
- */
-const artificialLatencyPlugin =
-	env.KYSELY_ARTIFICIAL_LATENCY && env.NODE_ENV !== "production"
-		? new ArtificialLatencyPlugin(env.KYSELY_ARTIFICIAL_LATENCY)
-		: null;
-
-const plugins = [updatedAtPlugin, artificialLatencyPlugin].filter((plugin) => plugin !== null);
-
-// Database interface is passed to Kysely's constructor, and from now on, Kysely
-// knows your database structure.
-// Dialect is passed to Kysely's constructor, and from now on, Kysely knows how
-// to communicate with your database.
-export const db = new Kysely<Database>({
-	dialect,
-	log: kyselyLogger,
-	plugins,
+export const db = createDatabase({
+	url: env.DATABASE_URL,
+	logLevel: env.LOG_LEVEL,
+	debug: env.KYSELY_DEBUG === "true",
+	env: env.NODE_ENV,
+	latency: env.KYSELY_ARTIFICIAL_LATENCY,
 });

--- a/core/kysely/scripts/migrate-hierarchy.ts
+++ b/core/kysely/scripts/migrate-hierarchy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, no-restricted-properties */
 
 import pluralize from "pluralize";
 

--- a/core/kysely/scripts/migrate-hierarchy.ts
+++ b/core/kysely/scripts/migrate-hierarchy.ts
@@ -11,7 +11,7 @@ import { slugifyString } from "~/lib/string";
 import { createDatabase } from "../database-init";
 
 const db = createDatabase({
-	url: `DATABASE_URL=postgresql://${process.env.PGUSER}:${process.env.PGPASSWORD}@${process.env.PGHOST}:${process.env.PGPORT}/${process.env.PGDATABASE}`,
+	url: `postgresql://${process.env.PGUSER}:${process.env.PGPASSWORD}@${process.env.PGHOST}:${process.env.PGPORT}/${process.env.PGDATABASE}`,
 	logLevel: "debug",
 	debug: true,
 });

--- a/core/kysely/scripts/migrate-hierarchy.ts
+++ b/core/kysely/scripts/migrate-hierarchy.ts
@@ -8,7 +8,14 @@ import { expect } from "utils";
 
 import { createLastModifiedBy } from "~/lib/lastModifiedBy";
 import { slugifyString } from "~/lib/string";
-import { db } from "../database";
+import { createDatabase } from "../database-init";
+
+const db = createDatabase({
+	url: `DATABASE_URL=postgresql://${process.env.PGUSER}:${process.env.PGPASSWORD}@${process.env.PGHOST}:${process.env.PGPORT}/${process.env.PGDATABASE}`,
+	logLevel: "debug",
+	debug: true,
+	env: "production",
+});
 
 type Relation = {
 	parentPubId: PubsId;

--- a/core/kysely/scripts/migrate-hierarchy.ts
+++ b/core/kysely/scripts/migrate-hierarchy.ts
@@ -14,7 +14,6 @@ const db = createDatabase({
 	url: `DATABASE_URL=postgresql://${process.env.PGUSER}:${process.env.PGPASSWORD}@${process.env.PGHOST}:${process.env.PGPORT}/${process.env.PGDATABASE}`,
 	logLevel: "debug",
 	debug: true,
-	env: "production",
 });
 
 type Relation = {


### PR DESCRIPTION
## Issue(s) Resolved

Partial #952 

## High-level Explanation of PR

This PR just moves the instantiation of our Kysely instance into a factory function so we can create instances of Kysely in an env-independent way.

<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan

Quick smoke test should do the trick!
