### PR TITLE
Related pubs bug but in the external form

### DIFF
--- a/core/app/c/[communitySlug]/pubs/[pubId]/edit/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/edit/page.tsx
@@ -130,7 +130,7 @@ export default async function Page(props: {
 			}
 		>
 			<div className="flex justify-center py-10">
-				<div className="prose max-w-prose flex-1">
+				<div className="max-w-prose flex-1">
 					<PubEditor
 						searchParams={searchParams}
 						pubId={pub.id}

--- a/core/app/c/[communitySlug]/pubs/create/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/create/page.tsx
@@ -70,7 +70,7 @@ export default async function Page(props: {
 			right={<div />}
 		>
 			<div className="flex justify-center py-10">
-				<div className="prose max-w-prose flex-1">
+				<div className="max-w-prose flex-1">
 					<PubEditor
 						searchParams={searchParams}
 						communityId={community.id}

--- a/core/app/components/pubs/PubEditor/PubEditor.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditor.tsx
@@ -1,7 +1,8 @@
 import { randomUUID } from "crypto";
 
 import type { ProcessedPub } from "contracts";
-import type { CommunitiesId, PubFieldsId, PubsId, PubTypesId, StagesId } from "db/public";
+import type { CommunitiesId, PubsId, PubTypesId, StagesId } from "db/public";
+import { CoreSchemaType } from "db/public";
 import { expect } from "utils";
 
 import type { FormElements, PubFieldElement } from "../../forms/types";
@@ -44,8 +45,10 @@ const RelatedPubValueElement = ({
 				<p className="text-sm">
 					You are creating a Pub related to{" "}
 					<span className="font-semibold">{getPubTitle(relatedPub)}</span> through the{" "}
-					<span className="font-semibold">{fieldName}</span> pub field. Please enter a
-					value for this relationship.
+					<span className="font-semibold">{fieldName}</span> pub field.
+					{element.schemaName !== CoreSchemaType.Null && (
+						<span>Please enter a value for this relationship.</span>
+					)}
 				</p>
 				<PubFieldFormElement
 					label={label}
@@ -269,12 +272,17 @@ export async function PubEditor(props: PubEditorProps) {
 	const currentStageId = pub?.stage?.id ?? ("stageId" in props ? props.stageId : undefined);
 	const pubForForm = pub ?? { id: pubId, values: [], pubTypeId: form.pubTypeId };
 
+	// For the Context, we want both the pubs from the initial pub query (which is limited)
+	// as well as the pubs related to this pub
+	const relatedPubs = pub ? pub.values.flatMap((v) => (v.relatedPub ? [v.relatedPub] : [])) : [];
+	const pubsForContext = [...pubs, ...relatedPubs];
+
 	return (
 		<FormElementToggleProvider fieldSlugs={allSlugs}>
 			<ContextEditorContextProvider
 				pubId={pubId}
 				pubTypeId={pubType.id}
-				pubs={pubs}
+				pubs={pubsForContext}
 				pubTypes={pubTypes}
 			>
 				<PubEditorWrapper


### PR DESCRIPTION
## Issue(s) Resolved
Follow up to https://github.com/pubpub/platform/pull/1017, I realized I made a bad assumption there, and forgot that external forms can also edit existing pubs. So the external form fill page needs pretty much the same code there.

## High-level Explanation of PR

Same solution as https://github.com/pubpub/platform/pull/1017

## Test Plan

There's a built in test case for this one!

1. In the arcadia seed, get the Author James McJimothy's pubid (should be the first pub that shows up in http://localhost:3000/c/arcadia-research/pubs)
2. Select the form "Issue Editor" http://localhost:3000/c/arcadia-research/public/forms/issue-default-editor/fill
3. Add James McJimothy's pubId to the end of this url `?pubId={pubId}`
4. The app will error on main, but be ok on this branch

## Screenshots (if applicable)

## Notes
