### PR TITLE
Remove leftover children heading on pub details page

### DIFF
--- a/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/[pubId]/page.tsx
@@ -239,9 +239,6 @@ export default async function Page(props: {
 					</div>
 				</div>
 			</div>
-			<div>
-				<h2 className="text-xl font-bold">Pub Contents</h2>
-			</div>
 			{(pubTypeHasRelatedPubs || pubHasRelatedPubs) && (
 				<div className="flex flex-col gap-2" data-testid="related-pubs">
 					<h2 className="mb-2 text-xl font-bold">Related Pubs</h2>


### PR DESCRIPTION

## Issue(s) Resolved
Removes the "Pub Contents" header from pub pages

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/da4f1d7a-ed1e-4e4d-9e00-173364fd0acb" />