### PR TITLE
feat: render submit buttons on edit page

### DIFF
--- a/core/app/components/forms/types.ts
+++ b/core/app/components/forms/types.ts
@@ -9,6 +9,7 @@ import type {
 	PubFieldsId,
 	PubsId,
 	PubValuesId,
+	StagesId,
 	StructuralFormElement,
 } from "db/public";
 
@@ -62,7 +63,7 @@ export type ButtonElement = {
 	element: null;
 	content: null;
 	required: null;
-	stageId: null;
+	stageId: StagesId | null;
 	config: null;
 	component: null;
 	schemaName: null;

--- a/core/app/components/pubs/PubEditor/PubEditor.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditor.tsx
@@ -2,7 +2,7 @@ import { randomUUID } from "crypto";
 
 import type { ProcessedPub } from "contracts";
 import type { CommunitiesId, PubsId, PubTypesId, StagesId } from "db/public";
-import { CoreSchemaType } from "db/public";
+import { Capabilities, CoreSchemaType, MembershipType } from "db/public";
 import { expect } from "utils";
 
 import type { FormElements, PubFieldElement } from "../../forms/types";
@@ -10,6 +10,7 @@ import type { RenderWithPubContext } from "~/lib/server/render/pub/renderWithPub
 import type { AutoReturnType, PubField } from "~/lib/types";
 import { db } from "~/kysely/database";
 import { getLoginData } from "~/lib/authentication/loginData";
+import { userCan } from "~/lib/authorization/capabilities";
 import { getPubTitle } from "~/lib/pubs";
 import { getForm } from "~/lib/server/form";
 import { getPubsWithRelatedValues } from "~/lib/server/pub";
@@ -250,6 +251,12 @@ export async function PubEditor(props: PubEditorProps) {
 		},
 	};
 
+	const renderFormButtons = await userCan(
+		Capabilities.editPubWithForm,
+		{ type: MembershipType.pub, pubId },
+		user!.id
+	);
+
 	const renderWithPubContext = {
 		communityId: community.id,
 		recipient: memberWithUser as RenderWithPubContext["recipient"],
@@ -288,7 +295,7 @@ export async function PubEditor(props: PubEditorProps) {
 					formSlug={form.slug}
 					isUpdating={isUpdating}
 					withAutoSave={false}
-					withButtonElements={false}
+					withButtonElements={renderFormButtons}
 					htmlFormId={props.formId}
 					stageId={currentStageId}
 					relatedPub={

--- a/core/app/components/pubs/PubEditor/PubEditor.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditor.tsx
@@ -251,8 +251,8 @@ export async function PubEditor(props: PubEditorProps) {
 		},
 	};
 
-	const renderFormButtons = await userCan(
-		Capabilities.editPubWithForm,
+	const renderStageSelect = await userCan(
+		Capabilities.movePub,
 		{ type: MembershipType.pub, pubId },
 		user!.id
 	);
@@ -295,7 +295,7 @@ export async function PubEditor(props: PubEditorProps) {
 					formSlug={form.slug}
 					isUpdating={isUpdating}
 					withAutoSave={false}
-					withButtonElements={renderFormButtons}
+					withButtonElements
 					htmlFormId={props.formId}
 					stageId={currentStageId}
 					relatedPub={
@@ -315,11 +315,13 @@ export async function PubEditor(props: PubEditorProps) {
 								fieldName={relatedPubData.relatedPubField.name}
 							/>
 						) : null}
-						<StageSelectClient
-							fieldLabel="Stage"
-							fieldName="stageId"
-							stages={community.stages}
-						/>
+						{renderStageSelect && (
+							<StageSelectClient
+								fieldLabel="Stage"
+								fieldName="stageId"
+								stages={community.stages}
+							/>
+						)}
 						{formElements}
 						{pubOnlyElementDefinitions.map((formElementDef) => (
 							<FormElement

--- a/core/app/components/pubs/PubEditor/PubEditor.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditor.tsx
@@ -251,11 +251,9 @@ export async function PubEditor(props: PubEditorProps) {
 		},
 	};
 
-	const renderStageSelect = await userCan(
-		Capabilities.movePub,
-		{ type: MembershipType.pub, pubId },
-		user!.id
-	);
+	const renderStageSelect =
+		pub === undefined ||
+		(await userCan(Capabilities.movePub, { type: MembershipType.pub, pubId }, user!.id));
 
 	const renderWithPubContext = {
 		communityId: community.id,

--- a/core/app/components/pubs/PubEditor/PubEditorClient.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditorClient.tsx
@@ -327,14 +327,19 @@ export const PubEditorClient = ({
 				buttonElements,
 			});
 
-			const newStageId = stageIdFromForm ?? stageIdFromButtonConfig;
-			const stageIdChanged = newStageId !== stageId;
+			const newStageId =
+				stageIdFromForm !== stageId
+					? stageIdFromForm
+					: stageIdFromButtonConfig !== stageId
+						? stageIdFromButtonConfig
+						: undefined;
+
 			let result;
 			if (isUpdating) {
 				result = await runUpdatePub({
 					pubId: pubId,
 					pubValues,
-					stageId: stageIdChanged ? newStageId : undefined,
+					stageId: newStageId,
 					formSlug,
 					continueOnValidationError: autoSave,
 					deleted,
@@ -367,12 +372,10 @@ export const PubEditorClient = ({
 				// Reset dirty state to prevent the unsaved changes warning from
 				// blocking navigation.
 				// See https://stackoverflow.com/questions/63953501/react-hook-form-resetting-isdirty-without-clearing-form
-				formInstance.reset(
-					{},
-					{
-						keepValues: true,
-					}
-				);
+				formInstance.reset({
+					...formValues,
+					stageId: newStageId ?? stageId,
+				});
 
 				onSuccess({ isAutoSave: autoSave, submitButtonId, values: pubValues });
 			}

--- a/core/app/components/pubs/PubEditor/PubEditorClient.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditorClient.tsx
@@ -328,9 +328,9 @@ export const PubEditorClient = ({
 			});
 
 			const newStageId =
-				(stageIdFromForm !== stageId
+				(stageIdFromForm !== null && stageIdFromForm !== stageId
 					? stageIdFromForm
-					: stageIdFromButtonConfig !== stageId
+					: stageIdFromButtonConfig !== null && stageIdFromButtonConfig !== stageId
 						? stageIdFromButtonConfig
 						: undefined) ?? undefined;
 

--- a/core/app/components/pubs/PubEditor/PubEditorClient.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditorClient.tsx
@@ -328,11 +328,11 @@ export const PubEditorClient = ({
 			});
 
 			const newStageId =
-				stageIdFromForm !== stageId
+				(stageIdFromForm !== stageId
 					? stageIdFromForm
 					: stageIdFromButtonConfig !== stageId
 						? stageIdFromButtonConfig
-						: undefined;
+						: undefined) ?? undefined;
 
 			let result;
 			if (isUpdating) {

--- a/core/app/components/pubs/PubEditor/PubEditorClient.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditorClient.tsx
@@ -327,20 +327,15 @@ export const PubEditorClient = ({
 				buttonElements,
 			});
 
-			let newStageId: StagesId | undefined = undefined;
-
-			if (stageIdFromForm && stageIdFromForm !== stageId) {
-				newStageId = stageIdFromForm;
-			} else if (stageIdFromButtonConfig && stageIdFromButtonConfig !== stageId) {
-				newStageId = stageIdFromButtonConfig;
-			}
+			const newStageId = stageIdFromButtonConfig ?? stageIdFromForm ?? undefined;
+			const stageIdChanged = newStageId !== stageId;
 
 			let result;
 			if (isUpdating) {
 				result = await runUpdatePub({
 					pubId: pubId,
 					pubValues,
-					stageId: newStageId,
+					stageId: stageIdChanged ? newStageId : undefined,
 					formSlug,
 					continueOnValidationError: autoSave,
 					deleted,

--- a/core/app/components/pubs/PubEditor/PubEditorClient.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditorClient.tsx
@@ -327,12 +327,13 @@ export const PubEditorClient = ({
 				buttonElements,
 			});
 
-			const newStageId =
-				(stageIdFromForm !== null && stageIdFromForm !== stageId
-					? stageIdFromForm
-					: stageIdFromButtonConfig !== null && stageIdFromButtonConfig !== stageId
-						? stageIdFromButtonConfig
-						: undefined) ?? undefined;
+			let newStageId: StagesId | undefined = undefined;
+
+			if (stageIdFromForm && stageIdFromForm !== stageId) {
+				newStageId = stageIdFromForm;
+			} else if (stageIdFromButtonConfig && stageIdFromButtonConfig !== stageId) {
+				newStageId = stageIdFromButtonConfig;
+			}
 
 			let result;
 			if (isUpdating) {


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #1041

## High-level Explanation of PR

This PR renders a form's submit buttons on the pub update/edit page when the logged in user is a pub contributor.

In addition the PR hides the stage select dropdown on the pub update/edit page when the logged-in user does not have `movePub` capability.

<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan

1. Add a submit button to the default form of an existing pub type in any community. Configure the submit button with a stage to move into when clicked.
2. Create a pub of this pub type using the create pub button on either the pub/workflows pages or the stage editor panel.
3. Submit the form using the normal Save button. You should see the pub has no stage (or the stage you selected in the form).
4. Submit the form using the new submit button you added to the default form in step 1. You should see the pub now has the stage you specified in step 1.
