### PR TITLE
Simplify gaction processing

### DIFF
--- a/core/actions/googleDriveImport/formatDriveData.ts
+++ b/core/actions/googleDriveImport/formatDriveData.ts
@@ -13,31 +13,34 @@ import type { DriveData } from "./getGDriveFiles";
 import { uploadFileToS3 } from "~/lib/server";
 import schema from "./discussionSchema";
 import {
-	appendFigureAttributes,
-	cleanUnusedSpans,
-	formatFigureReferences,
-	formatLists,
+	// appendFigureAttributes,
+	// cleanUnusedSpans,
+	findAnchor,
+	// formatFigureReferences,
+	// formatLists,
 	getDescription,
-	processLocalLinks,
-	removeDescription,
-	removeEmptyFigCaption,
+	getTextContent,
+	// processLocalLinks,
+	// removeDescription,
+	// removeEmptyFigCaption,
 	removeGoogleLinkForwards,
-	removeVerboseFormatting,
-	structureAnchors,
-	structureAudio,
-	structureBlockMath,
-	structureBlockquote,
-	structureCodeBlock,
-	structureFiles,
-	structureFootnotes,
-	structureFormatting,
-	structureIframes,
-	structureImages,
-	structureInlineCode,
-	structureInlineMath,
-	structureReferences,
-	structureTables,
-	structureVideos,
+	// removeVerboseFormatting,
+	// structureAnchors,
+	// structureAudio,
+	// structureBlockMath,
+	// structureBlockquote,
+	// structureCodeBlock,
+	// structureFiles,
+	// structureFootnotes,
+	// structureFormatting,
+	// structureIframes,
+	// structureImages,
+	// structureInlineCode,
+	// structureInlineMath,
+	// structureReferences,
+	// structureTables,
+	// structureVideos,
+	tableToObjectArray,
 } from "./gdocPlugins";
 import { getAssetFile } from "./getGDriveFiles";
 
@@ -51,34 +54,56 @@ export type FormattedDriveData = {
 	}[];
 	discussions: { id: PubsId; values: {} }[];
 };
-const processAssets = async (html: string, pubId: string): Promise<string> => {
+const processAssetsNative = async (html: string, pubId: string): Promise<string> => {
 	const result = await rehype()
+		.use(removeGoogleLinkForwards)
 		.use(() => async (tree: Root) => {
 			const assetUrls: { [key: string]: string } = {};
+			const typesToProcess: Record<string, string[]> = {
+				image: ["source"],
+				video: ["source", "staticimage"],
+				audio: ["source"],
+				file: ["source"],
+				iframe: ["source", "staticimage"],
+			};
 			visit(tree, "element", (node: any) => {
-				const hasSrc = ["img", "video", "audio", "source", "iframe"].includes(node.tagName);
-				const isDownload =
-					node.tagName === "a" && node.properties.className === "file-button";
-				if (hasSrc || isDownload) {
-					const propertyKey = hasSrc ? "src" : "href";
-					const originalAssetUrl = node.properties[propertyKey];
-
-					if (originalAssetUrl) {
-						try {
-							const urlObject = new URL(originalAssetUrl);
-							const isIframe = node.tagName === "iframe";
-							if (!isIframe && !urlObject.hostname.endsWith(".pubpub.org")) {
-								assetUrls[originalAssetUrl] = "";
-							}
-							if (isIframe && urlObject.hostname.endsWith("drive.google.com")) {
-								assetUrls[originalAssetUrl] = "";
-							}
-						} catch (err) {
-							logger.error(err);
-						}
+				if (node.tagName === "table") {
+					const tableData: any = tableToObjectArray(node);
+					const tableType = tableData[0].type;
+					if (typesToProcess[tableType]) {
+						logger.warn(`Got a table to process, ${tableType}`);
+						tableData.forEach((dataRow: any) => {
+							typesToProcess[tableType].forEach((field) => {
+								const originalAssetUrl = dataRow[field];
+								logger.warn(
+									`field, ${field}. OriginalAssetUrl, ${originalAssetUrl}`
+								);
+								if (originalAssetUrl) {
+									try {
+										const urlObject = new URL(originalAssetUrl);
+										const isIframe = tableType === "iframe";
+										if (
+											!isIframe &&
+											!urlObject.hostname.endsWith(".pubpub.org")
+										) {
+											assetUrls[originalAssetUrl] = "";
+										}
+										if (
+											isIframe &&
+											urlObject.hostname.endsWith("drive.google.com")
+										) {
+											assetUrls[originalAssetUrl] = "";
+										}
+									} catch (err) {
+										logger.error(err);
+									}
+								}
+							});
+						});
 					}
 				}
 			});
+
 			await Promise.all(
 				Object.keys(assetUrls).map(async (originalAssetUrl) => {
 					try {
@@ -107,16 +132,39 @@ const processAssets = async (html: string, pubId: string): Promise<string> => {
 					}
 				})
 			);
-
 			visit(tree, "element", (node: any) => {
-				const hasSrc = ["img", "video", "audio", "source", "iframe"].includes(node.tagName);
-				const isDownload =
-					node.tagName === "a" && node.properties.className === "file-button";
-				if (hasSrc || isDownload) {
-					const propertyKey = hasSrc ? "src" : "href";
-					const originalAssetUrl = node.properties[propertyKey];
-					if (assetUrls[originalAssetUrl]) {
-						node.properties[propertyKey] = assetUrls[originalAssetUrl];
+				if (node.tagName === "table") {
+					const tableData: any = tableToObjectArray(node);
+					const tableType = tableData[0].type;
+					if (typesToProcess[tableType]) {
+						tableData.forEach((dataRow: any) => {
+							typesToProcess[tableType].forEach((field) => {
+								const originalAssetUrl = dataRow[field];
+								if (assetUrls[originalAssetUrl]) {
+									visit(node, "element", (child: any) => {
+										if (child.tagName === "td") {
+											const cellContent = getTextContent(child).trim();
+											if (cellContent === originalAssetUrl) {
+												child.children = [
+													{
+														type: "text",
+														value: assetUrls[originalAssetUrl],
+													},
+												];
+											}
+											const anchor = findAnchor(child);
+											if (
+												anchor &&
+												anchor.properties.href === originalAssetUrl
+											) {
+												anchor.properties.href =
+													assetUrls[originalAssetUrl];
+											}
+										}
+									});
+								}
+							});
+						});
 					}
 				}
 			});
@@ -124,36 +172,109 @@ const processAssets = async (html: string, pubId: string): Promise<string> => {
 		.process(html);
 	return String(result);
 };
+// const processAssets = async (html: string, pubId: string): Promise<string> => {
+// 	const result = await rehype()
+// 		.use(() => async (tree: Root) => {
+// 			const assetUrls: { [key: string]: string } = {};
+// 			visit(tree, "element", (node: any) => {
+// 				const hasSrc = ["img", "video", "audio", "source", "iframe"].includes(node.tagName);
+// 				const isDownload =
+// 					node.tagName === "a" && node.properties.className === "file-button";
+// 				if (hasSrc || isDownload) {
+// 					const propertyKey = hasSrc ? "src" : "href";
+// 					const originalAssetUrl = node.properties[propertyKey];
 
-const processHtml = async (html: string): Promise<string> => {
-	const result = await rehype()
-		.use(structureFormatting)
-		.use(formatLists)
-		.use(removeVerboseFormatting)
-		.use(removeGoogleLinkForwards)
-		.use(processLocalLinks)
-		.use(formatFigureReferences) /* Assumes figures are still tables */
-		.use(structureImages)
-		.use(structureVideos)
-		.use(structureAudio)
-		.use(structureFiles)
-		.use(structureIframes)
-		.use(structureBlockMath)
-		.use(structureInlineMath)
-		.use(structureBlockquote)
-		.use(structureCodeBlock)
-		.use(structureInlineCode)
-		.use(structureAnchors)
-		.use(structureTables)
-		.use(cleanUnusedSpans)
-		.use(structureReferences)
-		.use(structureFootnotes)
-		.use(appendFigureAttributes) /* Assumes figures are <figure> elements */
-		.use(removeEmptyFigCaption)
-		.use(removeDescription)
-		.process(html);
-	return String(result);
-};
+// 					if (originalAssetUrl) {
+// 						try {
+// 							const urlObject = new URL(originalAssetUrl);
+// 							const isIframe = node.tagName === "iframe";
+// 							if (!isIframe && !urlObject.hostname.endsWith(".pubpub.org")) {
+// 								assetUrls[originalAssetUrl] = "";
+// 							}
+// 							if (isIframe && urlObject.hostname.endsWith("drive.google.com")) {
+// 								assetUrls[originalAssetUrl] = "";
+// 							}
+// 						} catch (err) {
+// 							logger.error(err);
+// 						}
+// 					}
+// 				}
+// 			});
+// 			await Promise.all(
+// 				Object.keys(assetUrls).map(async (originalAssetUrl) => {
+// 					try {
+// 						const assetData = await getAssetFile(originalAssetUrl);
+// 						if (assetData) {
+// 							const uploadedUrl = await uploadFileToS3(
+// 								pubId,
+// 								assetData.filename,
+// 								assetData.buffer,
+// 								{ contentType: assetData.mimetype }
+// 							);
+// 							assetUrls[originalAssetUrl] = uploadedUrl
+// 								.replace(
+// 									"assets.app.pubpub.org.s3.us-east-1.amazonaws.com",
+// 									"assets.app.pubpub.org"
+// 								)
+// 								.replace(
+// 									"s3.us-east-1.amazonaws.com/assets.app.pubpub.org",
+// 									"assets.app.pubpub.org"
+// 								);
+// 						} else {
+// 							assetUrls[originalAssetUrl] = originalAssetUrl;
+// 						}
+// 					} catch (err) {
+// 						assetUrls[originalAssetUrl] = originalAssetUrl;
+// 					}
+// 				})
+// 			);
+
+// 			visit(tree, "element", (node: any) => {
+// 				const hasSrc = ["img", "video", "audio", "source", "iframe"].includes(node.tagName);
+// 				const isDownload =
+// 					node.tagName === "a" && node.properties.className === "file-button";
+// 				if (hasSrc || isDownload) {
+// 					const propertyKey = hasSrc ? "src" : "href";
+// 					const originalAssetUrl = node.properties[propertyKey];
+// 					if (assetUrls[originalAssetUrl]) {
+// 						node.properties[propertyKey] = assetUrls[originalAssetUrl];
+// 					}
+// 				}
+// 			});
+// 		})
+// 		.process(html);
+// 	return String(result);
+// };
+
+// const processHtml = async (html: string): Promise<string> => {
+// 	const result = await rehype()
+// 		.use(structureFormatting)
+// 		.use(formatLists)
+// 		.use(removeVerboseFormatting)
+// 		.use(removeGoogleLinkForwards)
+// 		.use(processLocalLinks)
+// 		.use(formatFigureReferences) /* Assumes figures are still tables */
+// 		.use(structureImages)
+// 		.use(structureVideos)
+// 		.use(structureAudio)
+// 		.use(structureFiles)
+// 		.use(structureIframes)
+// 		.use(structureBlockMath)
+// 		.use(structureInlineMath)
+// 		.use(structureBlockquote)
+// 		.use(structureCodeBlock)
+// 		.use(structureInlineCode)
+// 		.use(structureAnchors)
+// 		.use(structureTables)
+// 		.use(cleanUnusedSpans)
+// 		.use(structureReferences)
+// 		.use(structureFootnotes)
+// 		.use(appendFigureAttributes) /* Assumes figures are <figure> elements */
+// 		.use(removeEmptyFigCaption)
+// 		.use(removeDescription)
+// 		.process(html);
+// 	return String(result);
+// };
 
 export const formatDriveData = async (
 	dataFromDrive: DriveData,
@@ -161,8 +282,8 @@ export const formatDriveData = async (
 	pubId: string,
 	createVersions: boolean
 ): Promise<FormattedDriveData> => {
-	const formattedPubHtml = await processHtml(dataFromDrive.pubHtml);
-	const formattedPubHtmlWithAssets = await processAssets(formattedPubHtml, pubId);
+	// const formattedPubHtml = await processHtml(dataFromDrive.pubHtml);
+	const formattedPubHtmlWithAssets = await processAssetsNative(dataFromDrive.pubHtml, pubId);
 	if (!createVersions) {
 		return {
 			pubHtml: String(formattedPubHtmlWithAssets),
@@ -192,8 +313,9 @@ export const formatDriveData = async (
 	};
 
 	for (const version of dataFromDrive.versions) {
-		const processedHtml = await processHtml(version.html);
-		version.html = String(processedHtml);
+		// const processedHtml = await processHtml(version.html);
+		// version.html = String(processedHtml);
+		version.html = String(version.html);
 	}
 	const versions = dataFromDrive.versions.map((version) => {
 		const { timestamp, html } = version;

--- a/core/actions/googleDriveImport/gdocPlugins.ts
+++ b/core/actions/googleDriveImport/gdocPlugins.ts
@@ -123,7 +123,8 @@ export const tableToObjectArray = (node: any) => {
 		}
 
 		const isAssetSource =
-			["image", "video", "audio", "file", "iframe"].includes(tableType) && headerVal === "source";
+			["image", "video", "audio", "file", "iframe"].includes(tableType) &&
+			headerVal === "source";
 		const isStaticSource = headerVal === "staticimage";
 		if (isAssetSource || isStaticSource) {
 			const anchor = findAnchor(cell);

--- a/core/actions/googleDriveImport/gdocPlugins.ts
+++ b/core/actions/googleDriveImport/gdocPlugins.ts
@@ -54,6 +54,22 @@ export const getTextContent = (node: any): string => {
 	}
 	return "";
 };
+
+export const findAnchor = (node: any): any => {
+	if (node.tagName === "a") {
+		return node;
+	}
+	if (node.children) {
+		for (const child of node.children) {
+			const found = findAnchor(child);
+			if (found) {
+				return found;
+			}
+		}
+	}
+	return null;
+};
+
 export const tableToObjectArray = (node: any) => {
 	if (!node) return [{ type: "empty" }];
 
@@ -107,24 +123,9 @@ export const tableToObjectArray = (node: any) => {
 		}
 
 		const isAssetSource =
-			["image", "video", "audio", "file"].includes(tableType) && headerVal === "source";
+			["image", "video", "audio", "file", "iframe"].includes(tableType) && headerVal === "source";
 		const isStaticSource = headerVal === "staticimage";
 		if (isAssetSource || isStaticSource) {
-			const findAnchor = (node: any): any => {
-				if (node.tagName === "a") {
-					return node;
-				}
-				if (node.children) {
-					for (const child of node.children) {
-						const found = findAnchor(child);
-						if (found) {
-							return found;
-						}
-					}
-				}
-				return null;
-			};
-
 			const anchor = findAnchor(cell);
 			if (anchor && anchor.properties.href) {
 				return anchor.properties.href;


### PR DESCRIPTION
This PR sets the stage for removing the majority of google doc processing (it will now instead be done as part of the frontend build process). The major change is updating the way we process/re-upload assets, since we're dealing with raw google doc tables now, instead of formatted HTML figure elements.

I'm pushing this up to main so I can do my test to compare that frontend HTML is identical after this refactor. If all works, there will be another commit and PR that removes the unnecessary code after it's been migrating to the frontend.