### PR TITLE
Global feature flags via environment variables

### DIFF
--- a/core/.env.test
+++ b/core/.env.test
@@ -19,4 +19,3 @@ HONEYCOMB_API_KEY="xxx"
 # KYSELY_DEBUG="true"
 
 GCLOUD_KEY_FILE='xxx'
-

--- a/core/actions/_lib/runActionInstance.ts
+++ b/core/actions/_lib/runActionInstance.ts
@@ -237,7 +237,7 @@ export async function runActionInstance(args: RunActionInstanceArgs, trx = db) {
 		};
 	}
 
-	if (env.DISABLED_ACTIONS?.includes(actionInstance.action)) {
+	if (env.FLAGS.get("disabled-actions").includes(actionInstance.action)) {
 		return {
 			error: "Action is disabled",
 			stack: args.stack,

--- a/core/actions/_lib/runActionInstance.ts
+++ b/core/actions/_lib/runActionInstance.ts
@@ -16,7 +16,7 @@ import { logger } from "logger";
 import type { ActionSuccess } from "../types";
 import type { ClientException, ClientExceptionOptions } from "~/lib/serverActions";
 import { db } from "~/kysely/database";
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 import { hydratePubValues } from "~/lib/fields/utils";
 import { createLastModifiedBy } from "~/lib/lastModifiedBy";
 import { getPubsWithRelatedValues } from "~/lib/server";

--- a/core/actions/_lib/runActionInstance.ts
+++ b/core/actions/_lib/runActionInstance.ts
@@ -16,7 +16,7 @@ import { logger } from "logger";
 import type { ActionSuccess } from "../types";
 import type { ClientException, ClientExceptionOptions } from "~/lib/serverActions";
 import { db } from "~/kysely/database";
-import { env } from "~/lib/env/env";
+import { flags } from "~/lib/env/env";
 import { hydratePubValues } from "~/lib/fields/utils";
 import { createLastModifiedBy } from "~/lib/lastModifiedBy";
 import { getPubsWithRelatedValues } from "~/lib/server";
@@ -237,7 +237,7 @@ export async function runActionInstance(args: RunActionInstanceArgs, trx = db) {
 		};
 	}
 
-	if (env.FLAGS.get("disabled-actions").includes(actionInstance.action)) {
+	if (flags.get("disabled-actions").includes(actionInstance.action)) {
 		return {
 			error: "Action is disabled",
 			stack: args.stack,

--- a/core/actions/datacite/run.ts
+++ b/core/actions/datacite/run.ts
@@ -9,7 +9,7 @@ import { assert, AssertionError, expect } from "utils";
 import type { ActionPub } from "../types";
 import type { action } from "./action";
 import type { components } from "./types";
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 import { getPubsWithRelatedValues, updatePub } from "~/lib/server";
 import { isClientExceptionOptions } from "~/lib/serverActions";
 import { defineRun } from "../types";

--- a/core/actions/googleDriveImport/getGDriveFiles.ts
+++ b/core/actions/googleDriveImport/getGDriveFiles.ts
@@ -7,7 +7,7 @@ import { JWT } from "google-auth-library";
 
 import { logger } from "logger";
 
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 
 // Load the service account key JSON file
 // const keyFilePath = path.join(process.cwd(), 'src/utils/google/keyFile.json');

--- a/core/app/(user)/magic-link/route.ts
+++ b/core/app/(user)/magic-link/route.ts
@@ -7,7 +7,7 @@ import type { AuthTokenType } from "db/public";
 import { logger } from "logger";
 
 import { lucia } from "~/lib/authentication/lucia";
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 import { InvalidTokenError, TokenFailureReason, validateToken } from "~/lib/server/token";
 
 const redirectToURL = (

--- a/core/app/api/v0/c/[communitySlug]/internal/[...ts-rest]/route.ts
+++ b/core/app/api/v0/c/[communitySlug]/internal/[...ts-rest]/route.ts
@@ -8,7 +8,7 @@ import { runInstancesForEvent } from "~/actions/_lib/runActionInstance";
 import { scheduleActionInstances } from "~/actions/_lib/scheduleActionInstance";
 import { runActionInstance } from "~/actions/api/server";
 import { compareAPIKeys, getBearerToken } from "~/lib/authentication/api";
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 import { NotFoundError, tsRestHandleErrors } from "~/lib/server";
 import { findCommunityBySlug } from "~/lib/server/community";
 
@@ -97,4 +97,4 @@ const handler = createNextHandler(
 	}
 );
 
-export { handler as GET, handler as POST, handler as PUT, handler as PATCH, handler as DELETE };
+export { handler as DELETE, handler as GET, handler as PATCH, handler as POST, handler as PUT };

--- a/core/app/c/[communitySlug]/developers/docs/page.tsx
+++ b/core/app/c/[communitySlug]/developers/docs/page.tsx
@@ -8,7 +8,7 @@ import { redirect } from "next/navigation";
 
 import { getPageLoginData } from "~/lib/authentication/loginData";
 import { isCommunityAdmin } from "~/lib/authentication/roles";
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 
 export const dynamic = "force-dynamic";
 

--- a/core/app/c/[communitySlug]/pubs/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import type { CommunitiesId } from "db/public";
 
 import { getPageLoginData } from "~/lib/authentication/loginData";
+import { env } from "~/lib/env/env";
 import { findCommunityBySlug } from "~/lib/server/community";
 import PubHeader from "./PubHeader";
 import { PaginatedPubList } from "./PubList";

--- a/core/instrumentation.edge.mts
+++ b/core/instrumentation.edge.mts
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/nextjs";
 
 import { logger } from "logger";
 
-import { env } from "./lib/env/env.mjs";
+import { env } from "./lib/env/env";
 
 logger.info("Running instrumentation hook for edge...");
 

--- a/core/instrumentation.node.mts
+++ b/core/instrumentation.node.mts
@@ -4,7 +4,7 @@ import * as Sentry from "@sentry/nextjs";
 
 import { logger } from "logger";
 
-import { env } from "./lib/env/env.mjs";
+import { env } from "./lib/env/env";
 
 // function hook() {
 logger.info("Running instrumentation hook for nodejs...");

--- a/core/kysely/database.ts
+++ b/core/kysely/database.ts
@@ -1,4 +1,4 @@
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 import { createDatabase } from "./database-init";
 
 export const db = createDatabase({

--- a/core/lib/__tests__/db.ts
+++ b/core/lib/__tests__/db.ts
@@ -8,7 +8,7 @@ import { databaseTables } from "db/table-names";
 import { logger } from "logger";
 
 import { UpdatedAtPlugin } from "~/kysely/updated-at-plugin";
-import { env } from "../env/env.mjs";
+import { env } from "../env/env";
 
 const int8TypeId = 20;
 

--- a/core/lib/api.ts
+++ b/core/lib/api.ts
@@ -2,7 +2,7 @@ import { initTsrReactQuery } from "@ts-rest/react-query/v5";
 
 import { siteApi } from "contracts";
 
-import { env } from "./env/env.mjs";
+import { env } from "./env/env";
 
 export const client = initTsrReactQuery(siteApi, {
 	baseUrl: typeof window === "undefined" ? env.PUBPUB_URL : window.location.origin,

--- a/core/lib/authentication/createMagicLink.ts
+++ b/core/lib/authentication/createMagicLink.ts
@@ -1,7 +1,7 @@
 import type { AuthTokenType, UsersId } from "db/public";
 
 import { db } from "~/kysely/database";
-import { env } from "../env/env.mjs";
+import { env } from "../env/env";
 import { createToken } from "../server/token";
 
 type NativeMagicLinkOptions = {

--- a/core/lib/authentication/lucia.ts
+++ b/core/lib/authentication/lucia.ts
@@ -17,7 +17,7 @@ import { AuthTokenType } from "db/public";
 import { logger } from "logger";
 
 import { db } from "~/kysely/database";
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 
 type UserWithMembersShips = Omit<Users, "passwordHash"> & {
 	memberships: (CommunityMemberships & {

--- a/core/lib/env/env.ts
+++ b/core/lib/env/env.ts
@@ -1,18 +1,64 @@
 // @ts-check
+import type { ZodTypeAny } from "zod";
 
 import { createEnv } from "@t3-oss/env-nextjs";
-import { z } from "zod";
+import { z, ZodError } from "zod";
 
-/**
- * Parameters which are optional if the app is self-hosted
- * but we do want checked for our AWS deploys
- *
- * @template {import("zod").ZodTypeAny} Z
- * @param {Z} schema
- */
-const selfHostedOptional = (schema) => {
+import { actionSchema } from "db/public";
+
+const selfHostedOptional = (schema: ZodTypeAny) => {
 	return process.env.SELF_HOSTED ? schema.optional() : schema;
 };
+
+const flagStateToBoolean = (flagState: string, ctx: z.RefinementCtx) => {
+	switch (flagState) {
+		case "on":
+		case "true":
+			return true;
+		case "off":
+		case "false":
+			return false;
+	}
+	ctx.addIssue({
+		code: z.ZodIssueCode.custom,
+		message: "Invalid flag state",
+		fatal: true,
+	});
+	return z.NEVER;
+};
+
+const flagSchema = z.union([
+	z.tuple([
+		z.literal("disabled-actions"),
+		z
+			.string()
+			.transform((s) => s.split("+"))
+			.pipe(actionSchema.array()),
+	]),
+	z.tuple([
+		z.literal("invites"),
+		z.string().transform(flagStateToBoolean).optional().default("on"),
+	]),
+	z.tuple([
+		z.literal("uploads"),
+		z.string().transform(flagStateToBoolean).optional().default("on"),
+	]),
+]);
+
+type FlagSchema = z.infer<typeof flagSchema>;
+type FlagName = FlagSchema[0];
+type FlagArgs<F extends FlagName> = Extract<FlagSchema, [F, unknown]>[1];
+
+class Flags {
+	#flags;
+	constructor(flags: z.infer<typeof flagSchema>[]) {
+		this.#flags = new Map(flags as [string, unknown][]);
+	}
+	get<F extends FlagName>(flagName: F): FlagArgs<F> {
+		return (this.#flags.get(flagName) ??
+			flagSchema.parse([flagName, undefined])) as FlagArgs<F>;
+	}
+}
 
 export const env = createEnv({
 	shared: {
@@ -52,25 +98,26 @@ export const env = createEnv({
 		DATACITE_REPOSITORY_ID: z.string().optional(),
 		DATACITE_PASSWORD: z.string().optional(),
 		SENTRY_AUTH_TOKEN: z.string().optional(),
-		DISABLED_ACTIONS: z
+		FLAGS: z
 			.string()
 			.transform((value) => value.split(","))
-			.pipe(
-				z
-					// TODO: Figure out how to get `import {actionSchema} from "db/public"` working
-					.enum([
-						"log",
-						"pdf",
-						"email",
-						"pushToV6",
-						"http",
-						"move",
-						"googleDriveImport",
-						"datacite",
-					])
-					.array()
-			)
-			.optional(),
+			.transform((flagStrings, ctx) => {
+				const parsedFlags: z.infer<typeof flagSchema>[] = [];
+				for (const flagString of flagStrings) {
+					try {
+						const [flagName, flagArgs] = flagString.split(":");
+						const parsedFlag = flagSchema.parse([flagName, flagArgs]);
+						parsedFlags.push(parsedFlag);
+					} catch (error) {
+						if (error instanceof ZodError) {
+							error.issues.forEach(ctx.addIssue);
+						}
+					}
+				}
+				return new Flags(parsedFlags);
+			})
+			.optional()
+			.default(""),
 	},
 	client: {},
 	experimental__runtimeEnv: {

--- a/core/lib/env/env.ts
+++ b/core/lib/env/env.ts
@@ -32,8 +32,10 @@ const flagSchema = z.union([
 		z.literal("disabled-actions"),
 		z
 			.string()
-			.transform((s) => s.split("+"))
-			.pipe(actionSchema.array()),
+			.transform((s) => (s.length === 0 ? [] : s.split("+").map((a) => a.trim())))
+			.pipe(actionSchema.array())
+			.optional()
+			.default(""),
 	]),
 	z.tuple([
 		z.literal("invites"),
@@ -104,6 +106,9 @@ export const env = createEnv({
 			.transform((flagStrings, ctx) => {
 				const parsedFlags: z.infer<typeof flagSchema>[] = [];
 				for (const flagString of flagStrings) {
+					if (flagString === "") {
+						continue;
+					}
 					try {
 						const [flagName, flagArgs] = flagString.split(":");
 						const parsedFlag = flagSchema.parse([flagName, flagArgs]);

--- a/core/lib/env/flags.ts
+++ b/core/lib/env/flags.ts
@@ -1,0 +1,79 @@
+import { z, ZodError } from "zod";
+
+import { actionSchema } from "db/public";
+
+const flagStateToBoolean = (flagState: string, ctx: z.RefinementCtx) => {
+	switch (flagState) {
+		case "on":
+		case "true":
+			return true;
+		case "off":
+		case "false":
+			return false;
+	}
+	ctx.addIssue({
+		code: z.ZodIssueCode.custom,
+		message: "Invalid flag state",
+		fatal: true,
+	});
+	return z.NEVER;
+};
+
+const flagSchema = z.union([
+	z.tuple([
+		z.literal("disabled-actions"),
+		z
+			.string()
+			.optional()
+			.transform((s) => (s ? s.split("+").map((a) => a.trim()) : []))
+			.pipe(actionSchema.array()),
+	]),
+	z.tuple([
+		z.literal("invites"),
+		z.string().transform(flagStateToBoolean).optional().default("on"),
+	]),
+	z.tuple([
+		z.literal("uploads"),
+		z.string().transform(flagStateToBoolean).optional().default("on"),
+	]),
+]);
+
+export const flagsSchema = z
+	.string()
+	.optional()
+	.transform((s) => (s ? s.split(",") : []))
+	.transform((flagStrings, ctx) => {
+		const parsedFlags: FlagSchema[] = [];
+		for (const flagString of flagStrings) {
+			if (flagString === "") {
+				continue;
+			}
+			try {
+				const [flagName, flagArgs] = flagString.split(":");
+				const parsedFlag = flagSchema.parse([flagName, flagArgs]);
+				parsedFlags.push(parsedFlag);
+			} catch (error) {
+				if (error instanceof ZodError) {
+					error.issues.forEach(ctx.addIssue);
+				}
+			}
+		}
+		return parsedFlags;
+	});
+
+type FlagSchema = z.infer<typeof flagSchema>;
+type FlagName = FlagSchema[0];
+type FlagArgs<F extends FlagName> = Extract<FlagSchema, [F, unknown]>[1];
+
+class Flags {
+	#flags;
+	constructor(flags: FlagSchema[]) {
+		this.#flags = new Map(flags as [string, unknown][]);
+	}
+	get<F extends FlagName>(flagName: F): FlagArgs<F> {
+		return (this.#flags.get(flagName) ??
+			flagSchema.parse([flagName, undefined])[1]) as FlagArgs<F>;
+	}
+}
+
+export const createFlags = (flags: FlagSchema[]) => new Flags(flags);

--- a/core/lib/server/assets.db.test.ts
+++ b/core/lib/server/assets.db.test.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { mockServerCode } from "~/lib/__tests__/utils";
-import { env } from "../env/env.mjs";
+import { env } from "../env/env";
 
 const { createForEachMockedTransaction } = await mockServerCode();
 

--- a/core/lib/server/assets.ts
+++ b/core/lib/server/assets.ts
@@ -5,7 +5,7 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import type { PubsId } from "db/public";
 import { logger } from "logger";
 
-import { env } from "../env/env.mjs";
+import { env } from "../env/env";
 
 let s3Client: S3Client;
 

--- a/core/lib/server/cache/autoRevalidate.ts
+++ b/core/lib/server/cache/autoRevalidate.ts
@@ -4,7 +4,7 @@ import { logger } from "logger";
 
 import type { autoCache } from "./autoCache";
 import type { AutoRevalidateOptions, DirectAutoOutput, ExecuteFn, QB } from "./types";
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 import { getCommunitySlug } from "./getCommunitySlug";
 import { revalidateTagsForCommunity } from "./revalidate";
 import { cachedFindTables, directAutoOutput } from "./sharedAuto";

--- a/core/lib/server/cache/memoize.ts
+++ b/core/lib/server/cache/memoize.ts
@@ -6,7 +6,7 @@ import { unstable_cache } from "next/cache";
 import { logger } from "logger";
 
 import type { CacheTag } from "./cacheTags";
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 import { ONE_YEAR } from "./constants";
 
 type Callback<Parameters extends unknown[], ReturnType> = (

--- a/core/lib/server/cache/revalidate.ts
+++ b/core/lib/server/cache/revalidate.ts
@@ -3,7 +3,7 @@ import { revalidateTag } from "next/cache";
 import { logger } from "logger";
 
 import type { CacheScope } from "./cacheTags";
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 import { createCommunityCacheTags } from "./cacheTags";
 import { getCommunitySlug } from "./getCommunitySlug";
 

--- a/core/lib/server/email.tsx
+++ b/core/lib/server/email.tsx
@@ -11,7 +11,7 @@ import type { XOR } from "../types";
 import type { FormInviteLinkProps } from "./form";
 import { db } from "~/kysely/database";
 import { createMagicLink } from "~/lib/authentication/createMagicLink";
-import { env } from "../env/env.mjs";
+import { env } from "../env/env";
 import { createFormInviteLink } from "./form";
 import { getSmtpClient } from "./mailgun";
 

--- a/core/lib/server/jobs.ts
+++ b/core/lib/server/jobs.ts
@@ -5,7 +5,7 @@ import { makeWorkerUtils } from "graphile-worker";
 import { logger } from "logger";
 
 import type { ClientException, ClientExceptionOptions } from "../serverActions";
-import { env } from "../env/env.mjs";
+import { env } from "../env/env";
 
 import "date-fns";
 

--- a/core/lib/server/mailgun.ts
+++ b/core/lib/server/mailgun.ts
@@ -2,7 +2,7 @@ import type SMTPPool from "nodemailer/lib/smtp-pool";
 
 import nodemailer from "nodemailer";
 
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 
 let smtpclient: nodemailer.Transporter;
 

--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -37,14 +37,7 @@ import type {
 	UsersId,
 } from "db/public";
 import type { LastModifiedBy, StageConstraint } from "db/types";
-import {
-	Capabilities,
-	CoreSchemaType,
-	MemberRole,
-	MembershipType,
-	OperationType,
-	pubTypesIdSchema,
-} from "db/public";
+import { Capabilities, CoreSchemaType, MemberRole, MembershipType, OperationType } from "db/public";
 import { NO_STAGE_OPTION } from "db/types";
 import { logger } from "logger";
 import { assert, expect } from "utils";
@@ -53,7 +46,7 @@ import type { DefinitelyHas, MaybeHas, XOR } from "../types";
 import type { SafeUser } from "./user";
 import { db } from "~/kysely/database";
 import { isUniqueConstraintError } from "~/kysely/errors";
-import { env } from "../env/env.mjs";
+import { env } from "../env/env";
 import { parseRichTextForPubFieldsAndRelatedPubs } from "../fields/richText";
 import { hydratePubValues, mergeSlugsWithFields } from "../fields/utils";
 import { parseLastModifiedBy } from "../lastModifiedBy";

--- a/core/lib/server/render/pub/renderWithPubUtils.ts
+++ b/core/lib/server/render/pub/renderWithPubUtils.ts
@@ -3,7 +3,7 @@ import { CoreSchemaType } from "db/public";
 import { expect } from "utils";
 
 import { db } from "~/kysely/database";
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 import { autoCache } from "~/lib/server/cache/autoCache";
 import { addMemberToForm, createFormInviteLink } from "../../form";
 

--- a/core/next.config.ts
+++ b/core/next.config.ts
@@ -1,17 +1,16 @@
 // @ts-check
 
+import type { NextConfig, normalizeConfig } from "next/dist/server/config";
+
 import { PHASE_PRODUCTION_BUILD } from "next/dist/shared/lib/constants.js";
 import withPreconstruct from "@preconstruct/next";
 import { withSentryConfig } from "@sentry/nextjs";
 
-import { env } from "./lib/env/env.mjs";
+import { env } from "./lib/env/env";
 
 // import { PHASE_DEVELOPMENT_SERVER } from "next/constants";
 
-/**
- * @type {import("next").NextConfig}
- */
-const nextConfig = {
+const nextConfig: NextConfig = {
 	output: "standalone",
 	typescript: {
 		// this gets checked in CI already
@@ -91,6 +90,7 @@ const modifiedConfig = withPreconstruct(
 		// tunnelRoute: "/monitoring",
 
 		// Hides source maps from generated client bundles
+		// @ts-expect-error
 		hideSourceMaps: true,
 
 		// Automatically tree-shake Sentry logger statements to reduce bundle size
@@ -102,7 +102,7 @@ const modifiedConfig = withPreconstruct(
 	})
 );
 
-export default (phase, { defaultConfig }) => {
+const config: typeof normalizeConfig = async (phase, { defaultConfig }) => {
 	if (!env.SENTRY_AUTH_TOKEN) {
 		console.warn("⚠️ SENTRY_AUTH_TOKEN is not set");
 	}
@@ -117,3 +117,5 @@ export default (phase, { defaultConfig }) => {
 	}
 	return modifiedConfig;
 };
+
+export default config;

--- a/core/prisma/exampleCommunitySeeds/arcadiaJournal.ts
+++ b/core/prisma/exampleCommunitySeeds/arcadiaJournal.ts
@@ -8,7 +8,7 @@ import {
 	StructuralFormElement,
 } from "db/public";
 
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 import { seedCommunity } from "../seed/seedCommunity";
 
 export async function seedArcadiaJournal(communityId?: CommunitiesId) {

--- a/core/prisma/exampleCommunitySeeds/croccroc.ts
+++ b/core/prisma/exampleCommunitySeeds/croccroc.ts
@@ -10,7 +10,7 @@ import {
 	StructuralFormElement,
 } from "db/public";
 
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 import { seedCommunity } from "../seed/seedCommunity";
 
 export async function seedCroccroc(communityId?: CommunitiesId) {

--- a/core/prisma/exampleCommunitySeeds/unjournal.ts
+++ b/core/prisma/exampleCommunitySeeds/unjournal.ts
@@ -7,7 +7,7 @@ import { logger } from "logger";
 
 import { db } from "~/kysely/database";
 import { createLastModifiedBy } from "~/lib/lastModifiedBy";
-import { env } from "../../lib/env/env.mjs";
+import { env } from "../../lib/env/env";
 import { FileUpload } from "../../lib/fields/fileUpload";
 
 export default async function main(communityUUID: CommunitiesId) {

--- a/core/prisma/seed.ts
+++ b/core/prisma/seed.ts
@@ -7,7 +7,7 @@ import { logger } from "logger";
 import { db } from "~/kysely/database";
 import { isUniqueConstraintError } from "~/kysely/errors";
 import { createPasswordHash } from "~/lib/authentication/password";
-import { env } from "~/lib/env/env.mjs";
+import { env } from "~/lib/env/env";
 import { seedArcadia } from "./exampleCommunitySeeds/arcadia";
 import { seedCroccroc } from "./exampleCommunitySeeds/croccroc";
 import { default as buildUnjournal } from "./exampleCommunitySeeds/unjournal";

--- a/core/sentry.client.config.ts
+++ b/core/sentry.client.config.ts
@@ -4,7 +4,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-import { env } from "./lib/env/env.mjs";
+import { env } from "./lib/env/env";
 
 if (env.NODE_ENV === "production") {
 	Sentry.init({

--- a/core/types/preconstruct_next.ts
+++ b/core/types/preconstruct_next.ts
@@ -1,0 +1,4 @@
+declare module "@preconstruct/next" {
+	import type { NextConfig } from "next";
+	export default function withPreconstruct(nextConfig: NextConfig): NextConfig;
+}


### PR DESCRIPTION
## Issue(s) Resolved

Partial #1140

## High-level Explanation of PR

This PR introduces a simple pattern for implementing global (i.e. not community-level) feature flags.

One would create a new feature flag by adding a tuple to the new [`flagSchema`](https://github.com/pubpub/platform/pull/1158/files#diff-cee86778a1a51877651456193b7e1b5e7f257b8d066456b39544acfa0dcbe3afR30) zod type in `env.ts`, where the first element of the tuple is a unique flag name, and the second element is the flag "args" or options. Default flag states/args are defined using Zod's `.default` method.

Turning a flag on or off is as simple as starting the app with `FLAGS=flag-name:off`. You can toggle multiple flags using a comma separated list, e.g. `FLAGS=flag-1:off,flag-2:on`.

Some flags may take slightly more complex options than just "off" or "on". For example, the `disabled-actions` flag has a transformer that parses the following flag expression:

```env
disabled-actions:http+email
```

into

```json
["http", "email"]
```

The state and/or arguments of a flag can be retrieved on the server like
```ts
env.FLAGS.get("disabled-actions") // ["http", "email"]
env.FLAGS.get("uploads") // false
```

The flags I've introduced here don't do anything yet. I intend to utilize them in the `em/disabled-actions` branch, and a small follow-up branch to disable file uploads and member invites in our sandbox environment.

## Test Plan

1. Start the app with `FLAGS=uploads:off,invites:off`. It should start successfully! (These flags don't do anything yet).
2. Try running the app with an unsupported flag turned on or off. The app should fail to start with an environment error.
3. Try running the app with an unsupported flag state, e.g. `FLAGS=uploads:pancakes`. The app should fail to start again.

## Screenshots (if applicable)

## Notes

Setting a feature flag currently doesn't have any effect, this PR just introduces the pattern.
