### PR TITLE
chore: prune dangling docker images in preview environments

### DIFF
--- a/.github/workflows/pull-preview-script.sh
+++ b/.github/workflows/pull-preview-script.sh
@@ -1,3 +1,5 @@
 # install latest version of docker compose, by default it's using an ancient version
 sudo curl -sL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-"$(uname -m)" \
   -o "$(which docker-compose)" && sudo chmod +x "$(which docker-compose)" 
+
+docker image prune -a -f

--- a/.github/workflows/pull-preview-script.sh
+++ b/.github/workflows/pull-preview-script.sh
@@ -3,3 +3,5 @@ sudo curl -sL https://github.com/docker/compose/releases/latest/download/docker-
   -o "$(which docker-compose)" && sudo chmod +x "$(which docker-compose)" 
 
 docker image prune -a -f
+
+df -h

--- a/.github/workflows/pull-preview-script.sh
+++ b/.github/workflows/pull-preview-script.sh
@@ -1,5 +1,5 @@
 # install latest version of docker compose, by default it's using an ancient version
 sudo curl -sL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-"$(uname -m)" \
   -o "$(which docker-compose)" && sudo chmod +x "$(which docker-compose)" 
-# small change to check whether deploy takes forever
+
 docker image prune -a -f

--- a/.github/workflows/pull-preview-script.sh
+++ b/.github/workflows/pull-preview-script.sh
@@ -1,5 +1,5 @@
 # install latest version of docker compose, by default it's using an ancient version
 sudo curl -sL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-"$(uname -m)" \
   -o "$(which docker-compose)" && sudo chmod +x "$(which docker-compose)" 
-
+# small change to check whether deploy takes forever
 docker image prune -a -f

--- a/core/lib/env/flags.ts
+++ b/core/lib/env/flags.ts
@@ -9,6 +9,7 @@ type FlagArgs<F extends FlagName> = Extract<FlagSchema, [F, unknown]>[1];
 class Flags {
 	#flags;
 	constructor(flags: FlagSchema[]) {
+		console.log("hello world");
 		this.#flags = new Map(flags as [string, unknown][]);
 	}
 	get<F extends FlagName>(flagName: F): FlagArgs<F> {

--- a/core/lib/env/flags.ts
+++ b/core/lib/env/flags.ts
@@ -9,7 +9,6 @@ type FlagArgs<F extends FlagName> = Extract<FlagSchema, [F, unknown]>[1];
 class Flags {
 	#flags;
 	constructor(flags: FlagSchema[]) {
-		console.log("hello world");
 		this.#flags = new Map(flags as [string, unknown][]);
 	}
 	get<F extends FlagName>(flagName: F): FlagArgs<F> {


### PR DESCRIPTION
## Issue(s) Resolved

N/A

## High-level Explanation of PR

<!-- Using which methods does this PR resolve the issues above? -->

Amends the PullPreview pre-script to also clean up unused/dangling docker images on each deploy.

## Test Plan

Not sure... I think as long as the deployments no longer fail due to out-of-space errors we should be good to go!