### PR TITLE
chore: specify pullpreview custom domain

### DIFF
--- a/.github/workflows/pull-preview.yml
+++ b/.github/workflows/pull-preview.yml
@@ -65,6 +65,7 @@ jobs:
 
             - uses: pullpreview/action@v5
               with:
+                  dns: preview.pubpub.org
                   label: preview
                   admins: 3mcd
                   compose_files: ./self-host/docker-compose.yml,docker-compose.preview.yml


### PR DESCRIPTION
## Issue(s) Resolved

N/A

## High-level Explanation of PR

Configures PullPreview with our preview.pubpub.org custom domain.

## Test Plan

TBD
