### PR TITLE
feat: add batch operations to PubOp, expand/fix *byValue capabilities

### DIFF
--- a/core/app/components/pubs/PubEditor/actions.ts
+++ b/core/app/components/pubs/PubEditor/actions.ts
@@ -15,7 +15,8 @@ import { ApiError, createPubRecursiveNew } from "~/lib/server";
 import { findCommunityBySlug } from "~/lib/server/community";
 import { defineServerAction } from "~/lib/server/defineServerAction";
 import { getForm, grantFormAccess, userHasPermissionToForm } from "~/lib/server/form";
-import { deletePub, maybeWithTrx, normalizePubValues } from "~/lib/server/pub";
+import { maybeWithTrx } from "~/lib/server/maybeWithTrx";
+import { deletePub, normalizePubValues } from "~/lib/server/pub";
 import { PubOp } from "~/lib/server/pub-op";
 
 type CreatePubRecursiveProps = Omit<Parameters<typeof createPubRecursiveNew>[0], "lastModifiedBy">;
@@ -177,7 +178,7 @@ export const updatePub = defineServerAction(async function updatePub({
 			updateQuery.unrelate(slug, relatedPubId);
 		}
 
-		return await updateQuery.execute();
+		return await updateQuery.executeAndReturnPub();
 	} catch (error) {
 		logger.error(error);
 		return {

--- a/core/lib/server/maybeWithTrx.ts
+++ b/core/lib/server/maybeWithTrx.ts
@@ -1,0 +1,17 @@
+import { Kysely, Transaction } from "kysely";
+
+import type { Database } from "db/Database";
+
+/**
+ * For recursive transactions
+ */
+export const maybeWithTrx = async <T>(
+	trx: Transaction<Database> | Kysely<Database>,
+	fn: (trx: Transaction<Database>) => Promise<T>
+): Promise<T> => {
+	// could also use trx.isTransaction()
+	if (trx instanceof Transaction) {
+		return await fn(trx);
+	}
+	return await trx.transaction().execute(fn);
+};

--- a/core/lib/server/pub-filters-validate.ts
+++ b/core/lib/server/pub-filters-validate.ts
@@ -74,11 +74,13 @@ export async function validateFilter(communityId: CommunitiesId, filter: Filter,
 		assertAllowedOperators(field, operators, coreSchemaTypeAllowedOperators.DateTime);
 	}
 
-	const fieldInfos = await getFieldInfoForSlugs({
-		communityId,
-		slugs: Object.keys(actualFields),
-		trx,
-	});
+	const fieldInfos = await getFieldInfoForSlugs(
+		{
+			communityId,
+			slugs: Object.keys(actualFields),
+		},
+		trx
+	);
 
 	const fieldsWithSchemaAndOperators = fieldInfos.map((field) => ({
 		...field,

--- a/core/lib/server/pub-op.db.test.ts
+++ b/core/lib/server/pub-op.db.test.ts
@@ -142,7 +142,7 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		});
 
-		const pub = await pubOp.execute();
+		const pub = await pubOp.executeAndReturnPub();
 		await expect(pub.id).toExist();
 	});
 
@@ -154,14 +154,14 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		});
 
-		const pub = await pubOp.execute();
+		const pub = await pubOp.executeAndReturnPub();
 		await expect(pub.id).toExist();
 
 		const pub2 = await PubOp.upsert(id, {
 			communityId: seededCommunity.community.id,
 			pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 			lastModifiedBy: createLastModifiedBy("system"),
-		}).execute();
+		}).executeAndReturnPub();
 
 		await expect(pub2.id).toExist();
 	});
@@ -178,7 +178,7 @@ describe("PubOp", () => {
 				[seededCommunity.pubFields["Description"].slug]: "Some description",
 			});
 
-		const pub = await pubOp.execute();
+		const pub = await pubOp.executeAndReturnPub();
 		await expect(pub.id).toExist();
 
 		expect(pub).toHaveValues([
@@ -200,7 +200,7 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		});
 
-		const pub = await pubOp.execute();
+		const pub = await pubOp.executeAndReturnPub();
 
 		await expect(pub.id).toExist();
 
@@ -210,7 +210,7 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.relate(seededCommunity.pubFields["Some relation"].slug, "test relations value", pub.id)
-			.execute();
+			.executeAndReturnPub();
 
 		await expect(pub2.id).toExist();
 		expect(pub2).toHaveValues([
@@ -248,7 +248,7 @@ describe("PubOp", () => {
 				}).set(seededCommunity.pubFields["Title"].slug, "Related Pub 2")
 			);
 
-		const result = await mainPub.execute();
+		const result = await mainPub.executeAndReturnPub();
 
 		expect(result).toHaveValues([
 			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Main Pub" },
@@ -295,7 +295,7 @@ describe("PubOp", () => {
 				relatedPub
 			);
 
-		const result = await mainPub.execute();
+		const result = await mainPub.executeAndReturnPub();
 
 		expect(result).toHaveValues([
 			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Root" },
@@ -328,7 +328,7 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Existing Pub")
-			.execute();
+			.executeAndReturnPub();
 
 		const mainPub = PubOp.create({
 			communityId: seededCommunity.community.id,
@@ -351,7 +351,7 @@ describe("PubOp", () => {
 				}).set(seededCommunity.pubFields["Title"].slug, "New Related Pub")
 			);
 
-		const result = await mainPub.execute();
+		const result = await mainPub.executeAndReturnPub();
 
 		expect(result).toHaveValues([
 			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Main Pub" },
@@ -406,7 +406,7 @@ describe("PubOp", () => {
 			pub2
 		);
 
-		const result = await pub1.execute();
+		const result = await pub1.executeAndReturnPub();
 
 		expect(result).toHaveValues([
 			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Pub 1" },
@@ -435,7 +435,7 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		});
 
-		await expect(pubOp.execute()).rejects.toThrow(
+		await expect(pubOp.executeAndReturnPub()).rejects.toThrow(
 			/Cannot create a pub with an id that already exists/
 		);
 	});
@@ -447,7 +447,7 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Pub 1")
-			.execute();
+			.executeAndReturnPub();
 
 		const pub2 = await PubOp.create({
 			communityId: seededCommunity.community.id,
@@ -456,7 +456,7 @@ describe("PubOp", () => {
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Pub 2")
 			.relate(seededCommunity.pubFields["Some relation"].slug, "initial value", pub1.id)
-			.execute();
+			.executeAndReturnPub();
 
 		const updatedPub = await PubOp.upsert(pub2.id, {
 			communityId: seededCommunity.community.id,
@@ -464,7 +464,7 @@ describe("PubOp", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.relate(seededCommunity.pubFields["Some relation"].slug, "updated value", pub1.id)
-			.execute();
+			.executeAndReturnPub();
 
 		expect(updatedPub).toHaveValues([
 			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Pub 2" },
@@ -493,7 +493,7 @@ describe("PubOp", () => {
 					lastModifiedBy: createLastModifiedBy("system"),
 				}).set(seededCommunity.pubFields["Title"].slug, "Pub 2")
 			)
-			.execute();
+			.executeAndReturnPub();
 
 		expect(pub1.pubTypeId).toBe(seededCommunity.pubTypes["Basic Pub"].id);
 		expect(pub1).toHaveValues([
@@ -529,7 +529,7 @@ describe("PubOp", () => {
 						})
 						.set(seededCommunity.pubFields["Title"].slug, "Pub 2")
 				)
-				.execute();
+				.executeAndReturnPub();
 
 			const upsertedPub = await PubOp.upsert(pub1.id, {
 				communityId: seededCommunity.community.id,
@@ -537,7 +537,7 @@ describe("PubOp", () => {
 				lastModifiedBy: createLastModifiedBy("system"),
 			})
 				.set(seededCommunity.pubFields["Title"].slug, "Pub 1, updated")
-				.execute();
+				.executeAndReturnPub();
 
 			expect(upsertedPub).toHaveValues([
 				{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Pub 1, updated" },
@@ -562,7 +562,7 @@ describe("PubOp", () => {
 			})
 				.set(seededCommunity.pubFields["Title"].slug, "Pub 1")
 				.set(seededCommunity.pubFields["Description"].slug, "Description 1")
-				.execute();
+				.executeAndReturnPub();
 
 			const upsertedPub = await PubOp.upsert(pub1.id, {
 				communityId: seededCommunity.community.id,
@@ -572,7 +572,7 @@ describe("PubOp", () => {
 				.set(seededCommunity.pubFields["Title"].slug, "Pub 1, updated", {
 					deleteExistingValues: false,
 				})
-				.execute();
+				.executeAndReturnPub();
 
 			expect(upsertedPub).toHaveValues([
 				{
@@ -593,7 +593,7 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Pub 1")
-			.execute();
+			.executeAndReturnPub();
 
 		const pub2 = await PubOp.create({
 			communityId: seededCommunity.community.id,
@@ -602,7 +602,7 @@ describe("relation management", () => {
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Pub 2")
 			.relate(seededCommunity.pubFields["Some relation"].slug, "initial value", pub1.id)
-			.execute();
+			.executeAndReturnPub();
 
 		// disrelate the relation
 		const updatedPub = await PubOp.update(pub2.id, {
@@ -610,7 +610,7 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.unrelate(seededCommunity.pubFields["Some relation"].slug, pub1.id)
-			.execute();
+			.executeAndReturnPub();
 
 		expect(updatedPub).toHaveValues([
 			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Pub 2" },
@@ -624,7 +624,7 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Soon to be orphaned")
-			.execute();
+			.executeAndReturnPub();
 
 		const mainPub = await PubOp.create({
 			communityId: seededCommunity.community.id,
@@ -637,7 +637,7 @@ describe("relation management", () => {
 				"only relation",
 				orphanedPub.id
 			)
-			.execute();
+			.executeAndReturnPub();
 
 		// disrelate with deleteOrphaned option
 		await PubOp.update(mainPub.id, {
@@ -647,7 +647,7 @@ describe("relation management", () => {
 			.unrelate(seededCommunity.pubFields["Some relation"].slug, orphanedPub.id, {
 				deleteOrphaned: true,
 			})
-			.execute();
+			.executeAndReturnPub();
 
 		await expect(orphanedPub.id).not.toExist();
 	});
@@ -676,7 +676,7 @@ describe("relation management", () => {
 			.set(seededCommunity.pubFields["Title"].slug, "Main pub")
 			.relate(seededCommunity.pubFields["Some relation"].slug, "relation 1", related1)
 			.relate(seededCommunity.pubFields["Some relation"].slug, "relation 2", related2)
-			.execute();
+			.executeAndReturnPub();
 
 		await expect(related1Id).toExist();
 		await expect(related2Id).toExist();
@@ -689,7 +689,7 @@ describe("relation management", () => {
 			.unrelate(seededCommunity.pubFields["Some relation"].slug, "*", {
 				deleteOrphaned: true,
 			})
-			.execute();
+			.executeAndReturnPub();
 
 		expect(updatedPub).toHaveValues([
 			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Main pub" },
@@ -722,7 +722,7 @@ describe("relation management", () => {
 			.set(seededCommunity.pubFields["Title"].slug, "Main pub")
 			.relate(seededCommunity.pubFields["Some relation"].slug, "relation 1", related1)
 			.relate(seededCommunity.pubFields["Some relation"].slug, "relation 2", related2)
-			.execute();
+			.executeAndReturnPub();
 
 		const relatedPub1 = mainPub.values.find((v) => v.value === "relation 1")?.relatedPubId;
 		const relatedPub2 = mainPub.values.find((v) => v.value === "relation 2")?.relatedPubId;
@@ -737,7 +737,7 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Related 3")
-			.execute();
+			.executeAndReturnPub();
 
 		// Update with override - only related3 should remain
 		const updatedPub = await PubOp.update(mainPub.id, {
@@ -747,7 +747,7 @@ describe("relation management", () => {
 			.relate(seededCommunity.pubFields["Some relation"].slug, "new relation", related3.id, {
 				replaceExisting: true,
 			})
-			.execute();
+			.executeAndReturnPub();
 
 		expect(updatedPub).toHaveValues([
 			{ fieldSlug: seededCommunity.pubFields["Title"].slug, value: "Main pub" },
@@ -770,7 +770,7 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Related 1")
-			.execute();
+			.executeAndReturnPub();
 
 		const related2 = await PubOp.create({
 			communityId: seededCommunity.community.id,
@@ -778,7 +778,7 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Related 2")
-			.execute();
+			.executeAndReturnPub();
 
 		const mainPub = await PubOp.create({
 			communityId: seededCommunity.community.id,
@@ -789,7 +789,7 @@ describe("relation management", () => {
 			.relate(seededCommunity.pubFields["Some relation"].slug, "relation 1", related1.id, {
 				replaceExisting: true,
 			})
-			.execute();
+			.executeAndReturnPub();
 
 		const updatedMainPub = await PubOp.update(mainPub.id, {
 			communityId: seededCommunity.community.id,
@@ -808,7 +808,7 @@ describe("relation management", () => {
 				}),
 				{ replaceExisting: true }
 			)
-			.execute();
+			.executeAndReturnPub();
 
 		// Should have relation 2 and 3, but not 1
 		expect(updatedMainPub).toHaveValues([
@@ -955,7 +955,7 @@ describe("relation management", () => {
 				.set(seededCommunity.pubFields["Title"].slug, "A")
 				.relate(seededCommunity.pubFields["Some relation"].slug, "to B", pubB_op)
 				.relate(seededCommunity.pubFields["Some relation"].slug, "to C", pubC_op)
-				.execute();
+				.executeAndReturnPub();
 
 			const pubJ_op = await PubOp.createWithId(pubJ, {
 				communityId: seededCommunity.community.id,
@@ -965,7 +965,7 @@ describe("relation management", () => {
 			})
 				.set(seededCommunity.pubFields["Title"].slug, "J")
 				.relate(seededCommunity.pubFields["Some relation"].slug, "to I", pubI)
-				.execute();
+				.executeAndReturnPub();
 
 			const { getPubsWithRelatedValues } = await import("~/lib/server/pub");
 
@@ -1099,7 +1099,7 @@ describe("relation management", () => {
 				.unrelate(seededCommunity.pubFields["Some relation"].slug, pubC, {
 					deleteOrphaned: true,
 				})
-				.execute();
+				.executeAndReturnPub();
 
 			// verify deletions
 			await expect(pubA, "A should exist").toExist(trx);
@@ -1128,7 +1128,7 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Related 1")
-			.execute();
+			.executeAndReturnPub();
 
 		const related2 = await PubOp.create({
 			communityId: seededCommunity.community.id,
@@ -1136,7 +1136,7 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Related 2")
-			.execute();
+			.executeAndReturnPub();
 
 		const mainPub = await PubOp.create({
 			communityId: seededCommunity.community.id,
@@ -1146,7 +1146,7 @@ describe("relation management", () => {
 			.set(seededCommunity.pubFields["Title"].slug, "Main")
 			.relate(seededCommunity.pubFields["Some relation"].slug, "relation1", related1.id)
 			.relate(seededCommunity.pubFields["Another relation"].slug, "relation2", related2.id)
-			.execute();
+			.executeAndReturnPub();
 
 		// clear one field with deleteOrphaned and one without
 		await PubOp.update(mainPub.id, {
@@ -1157,7 +1157,7 @@ describe("relation management", () => {
 				deleteOrphaned: true,
 			})
 			.unrelate(seededCommunity.pubFields["Another relation"].slug, "*")
-			.execute();
+			.executeAndReturnPub();
 
 		// related1 should be deleted (orphaned with deleteOrphaned: true)
 		await expect(related1.id).not.toExist();
@@ -1173,7 +1173,7 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Keep Me")
-			.execute();
+			.executeAndReturnPub();
 
 		const toDelete = await PubOp.create({
 			communityId: seededCommunity.community.id,
@@ -1181,7 +1181,7 @@ describe("relation management", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Delete Me")
-			.execute();
+			.executeAndReturnPub();
 
 		const mainPub = await PubOp.create({
 			communityId: seededCommunity.community.id,
@@ -1191,7 +1191,7 @@ describe("relation management", () => {
 			.set(seededCommunity.pubFields["Title"].slug, "Main")
 			.relate(seededCommunity.pubFields["Some relation"].slug, "keep", toKeep.id)
 			.relate(seededCommunity.pubFields["Another relation"].slug, "delete", toDelete.id)
-			.execute();
+			.executeAndReturnPub();
 
 		// Override relations with different deleteOrphaned flags
 		const newRelation = PubOp.create({
@@ -1211,7 +1211,7 @@ describe("relation management", () => {
 				replaceExisting: true,
 				deleteOrphaned: true,
 			})
-			.execute();
+			.executeAndReturnPub();
 
 		// toKeep should still exist (override without deleteOrphaned)
 		await expect(toKeep.id).toExist();
@@ -1235,7 +1235,7 @@ describe("relation management", () => {
 					.create({ pubTypeId: seededCommunity.pubTypes["Minimal Pub"].id })
 					.set(seededCommunity.pubFields["Title"].slug, "Relation 1")
 			)
-			.execute();
+			.executeAndReturnPub();
 
 		expect(pub).toHaveValues([
 			{
@@ -1273,7 +1273,7 @@ describe("relation management", () => {
 					value: "relation2",
 				},
 			])
-			.execute();
+			.executeAndReturnPub();
 
 		expect(pub).toHaveValues([
 			{
@@ -1309,7 +1309,7 @@ describe("PubOp stage", () => {
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Test")
 			.setStage(seededCommunity.stages["Stage 1"].id)
-			.execute();
+			.executeAndReturnPub();
 
 		expect(pub.stageId).toEqual(seededCommunity.stages["Stage 1"].id);
 	});
@@ -1323,7 +1323,7 @@ describe("PubOp stage", () => {
 			trx,
 		})
 			.setStage(seededCommunity.stages["Stage 1"].id)
-			.execute();
+			.executeAndReturnPub();
 
 		expect(pub.stageId).toEqual(seededCommunity.stages["Stage 1"].id);
 
@@ -1333,7 +1333,7 @@ describe("PubOp stage", () => {
 			trx,
 		})
 			.setStage(null)
-			.execute();
+			.executeAndReturnPub();
 
 		expect(updatedPub.stageId).toEqual(null);
 	});
@@ -1348,7 +1348,7 @@ describe("PubOp stage", () => {
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Test")
 			.setStage(seededCommunity.stages["Stage 1"].id)
-			.execute();
+			.executeAndReturnPub();
 
 		const updatedPub = await PubOp.upsert(pub.id, {
 			communityId: seededCommunity.community.id,
@@ -1357,7 +1357,7 @@ describe("PubOp stage", () => {
 			trx,
 		})
 			.setStage(seededCommunity.stages["Stage 2"].id)
-			.execute();
+			.executeAndReturnPub();
 
 		expect(updatedPub.stageId).toEqual(seededCommunity.stages["Stage 2"].id);
 	});
@@ -1371,7 +1371,7 @@ describe("By value", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["PseudoId"].slug, "4")
-			.execute();
+			.executeAndReturnPub();
 
 		const pub = await PubOp.upsertByValue(seededCommunity.pubFields["PseudoId"].slug, "4", {
 			communityId: seededCommunity.community.id,
@@ -1379,7 +1379,7 @@ describe("By value", () => {
 			lastModifiedBy: createLastModifiedBy("system"),
 		})
 			.set(seededCommunity.pubFields["Title"].slug, "Test")
-			.execute();
+			.executeAndReturnPub();
 
 		expect(pub.id).toBe(pubWithPseudoId4.id);
 		// the pseudoId is now removed from the pub
@@ -1395,7 +1395,7 @@ describe("By value", () => {
 				communityId: seededCommunity.community.id,
 				pubTypeId: seededCommunity.pubTypes["Basic Pub"].id,
 				lastModifiedBy: createLastModifiedBy("system"),
-			}).execute()
+			}).executeAndReturnPub()
 		).rejects.toThrow(/Multiple pubs found/);
 	});
 
@@ -1409,7 +1409,7 @@ describe("By value", () => {
 				slug: seededCommunity.pubFields["PseudoId"].slug,
 				value: "2",
 			})
-			.execute();
+			.executeAndReturnPub();
 
 		expect(pub).toHaveValues([
 			{

--- a/core/lib/server/pub-op.ts
+++ b/core/lib/server/pub-op.ts
@@ -543,15 +543,19 @@ abstract class PubOpBase {
 
 			const fallbackOnNotFound = operations.get(target)?.mode === "upsert";
 
-			if (pubIds.length === 0 && !fallbackOnNotFound) {
-				throw new PubOpError(
-					"INVALID_TARGET",
-					`No pub found for target: ${target.slug} = ${target.value}`
-				);
-			}
-
 			if (pubIds.length === 1) {
 				targetMap.set(target, pubIds[0]);
+			}
+
+			if (pubIds.length === 0) {
+				if (!fallbackOnNotFound) {
+					throw new PubOpError(
+						"INVALID_TARGET",
+						`No pub found for target: ${target.slug} = ${target.value}`
+					);
+				}
+
+				targetMap.set(target, crypto.randomUUID() as PubsId);
 			}
 		}
 	}

--- a/core/lib/server/pub-op.ts
+++ b/core/lib/server/pub-op.ts
@@ -115,11 +115,6 @@ type SetOptions = {
 	 * ```
 	 */
 	deleteExistingValues?: boolean;
-
-	/**
-	 * If true, nullish values will not be set.
-	 */
-	ignoreNullish?: boolean;
 };
 
 type RelationOptions = {
@@ -1111,26 +1106,11 @@ abstract class SinglePubOp extends PubOpBase {
 	 */
 	set(slug: string, value: PubValue, options?: SetOptions): this;
 	/**
-	 * Set a single value, ignoring nullish values
-	 */
-	set(
-		slug: string,
-		value: PubValue | null | undefined,
-		options: SetOptions & { ignoreNullish: true }
-	): this;
-	/**
 	 * Set multiple values
 	 */
 	set(values: Record<string, PubValue>, options?: SetOptions): this;
-	/**
-	 * Set multiple values, ignoring nullish values
-	 */
 	set(
-		values: Record<string, PubValue | null | undefined>,
-		options?: SetOptions & { ignoreNullish: true }
-	): this;
-	set(
-		slugOrValues: string | Record<string, PubValue | null | undefined>,
+		slugOrValues: string | Record<string, PubValue>,
 		valueOrOptions?: PubValue | SetOptions,
 		options?: SetOptions
 	): this {
@@ -1144,9 +1124,6 @@ abstract class SinglePubOp extends PubOpBase {
 		};
 
 		if (mode === "single") {
-			if (valueOrOptions === null && opts?.ignoreNullish) {
-				return this;
-			}
 			this.commands.push({
 				type: "set",
 				slug: slugOrValues as string,
@@ -1156,14 +1133,12 @@ abstract class SinglePubOp extends PubOpBase {
 			return this;
 		}
 
-		const commands = Object.entries(slugOrValues)
-			.filter(([_, value]) => (opts?.ignoreNullish ? value != null : true))
-			.map(([slug, value]) => ({
-				type: "set" as const,
-				slug,
-				value,
-				options: opts,
-			}));
+		const commands = Object.entries(slugOrValues).map(([slug, value]) => ({
+			type: "set" as const,
+			slug,
+			value,
+			options: opts,
+		}));
 
 		this.commands.push(...commands);
 		return this;

--- a/core/lib/server/pub-op.ts
+++ b/core/lib/server/pub-op.ts
@@ -398,7 +398,13 @@ interface UpdateOnlyOps {
 	unrelate(slug: string, target: PubsId, options?: { deleteOrphaned?: boolean }): this;
 }
 
-type ActivePubOp = CreatePubOp | UpdatePubOp | UpsertPubOp;
+export type PubOpCreate = CreatePubOp;
+export type PubOpUpdate = UpdatePubOp;
+export type PubOpUpsert = UpsertPubOp;
+
+export type PubOpBatch = BatchPubOp;
+
+export type ActivePubOp = PubOpCreate | PubOpUpdate | PubOpUpsert;
 
 /**
  * Helper function to access the protected collectOperations method on ActivePubOp
@@ -1613,7 +1619,7 @@ class UpdatePubOp extends SinglePubOp implements UpdateOnlyOps {
 /**
  * Class for batching multiple pub operations and executing them efficiently
  */
-export class BatchPubOp extends PubOpBase {
+class BatchPubOp extends PubOpBase {
 	private operations: ActivePubOp[] = [];
 	private readonly sharedOptions: Omit<PubOpOptionsBase, "target">;
 

--- a/core/lib/server/pub-op.ts
+++ b/core/lib/server/pub-op.ts
@@ -11,11 +11,11 @@ import { isUuid } from "utils/uuid";
 
 import { db } from "~/kysely/database";
 import { autoRevalidate } from "./cache/autoRevalidate";
+import { maybeWithTrx } from "./maybeWithTrx";
 import {
 	deletePub,
 	deletePubValuesByValueId,
 	getPubsWithRelatedValues,
-	maybeWithTrx,
 	upsertPubRelationValues,
 	upsertPubValues,
 	validatePubValues,

--- a/core/lib/server/pub-op.ts
+++ b/core/lib/server/pub-op.ts
@@ -1,13 +1,11 @@
 import type { Kysely, Transaction } from "kysely";
 
 import { sql } from "kysely";
-import pMap from "p-map";
 
 import type { JsonValue, ProcessedPub } from "contracts";
 import type { Database } from "db/Database";
 import type { CommunitiesId, PubFieldsId, PubsId, PubTypesId, StagesId } from "db/public";
 import type { LastModifiedBy } from "db/types";
-import { logger } from "logger";
 import { assert, expect } from "utils";
 import { isUuid } from "utils/uuid";
 

--- a/core/lib/server/pub-op.ts
+++ b/core/lib/server/pub-op.ts
@@ -1670,6 +1670,11 @@ class BatchPubOp extends PubOpBase {
 				options: Partial<PubOpOptionsBase> & { pubTypeId: PubTypesId }
 			) => CreatePubOp;
 			update: (id: PubsId, options?: Partial<PubOpOptionsBase>) => UpdatePubOp;
+			updateByValue: (
+				slug: string,
+				value: PubValue,
+				options: Omit<PubOpOptions, "pubTypeId">
+			) => UpdatePubOp;
 			upsert: (
 				id: PubsId,
 				options: Omit<PubOpOptionsCreateUpsert, keyof Omit<PubOpOptionsBase, "pubTypeId">>
@@ -1692,6 +1697,12 @@ class BatchPubOp extends PubOpBase {
 
 			update: (id: PubsId, options: Partial<PubOpOptionsBase> = {}) =>
 				new UpdatePubOp({ ...this.sharedOptions, ...options }, id),
+
+			updateByValue: (
+				slug: string,
+				value: PubValue,
+				options: Omit<PubOpOptions, "pubTypeId">
+			) => new UpdatePubOp({ ...this.sharedOptions, ...options }, { slug, value }),
 
 			upsert: (
 				id: PubsId,

--- a/core/lib/server/pub-op.ts
+++ b/core/lib/server/pub-op.ts
@@ -1,4 +1,4 @@
-import type { Transaction } from "kysely";
+import type { Kysely, Transaction } from "kysely";
 
 import { sql } from "kysely";
 
@@ -26,7 +26,7 @@ type PubValue = string | number | boolean | JsonValue | Date;
 type PubOpOptionsBase = {
 	communityId: CommunitiesId;
 	lastModifiedBy: LastModifiedBy;
-	trx?: Transaction<Database>;
+	trx?: Kysely<Database>;
 };
 
 type PubOpOptionsCreateUpsert = PubOpOptionsBase & {

--- a/core/lib/server/pub-op.ts
+++ b/core/lib/server/pub-op.ts
@@ -275,7 +275,7 @@ type PubOpErrorCode =
 	| "AMBIGUOUS_TARGET"
 	| "UNKNOWN";
 
-class PubOpError extends Error {
+export class PubOpError extends Error {
 	readonly code: PubOpErrorCode;
 	constructor(code: PubOpErrorCode, message: string) {
 		super(message);

--- a/core/lib/server/pub.ts
+++ b/core/lib/server/pub.ts
@@ -7,7 +7,7 @@ import type {
 	StringReference,
 } from "kysely";
 
-import { sql, Transaction } from "kysely";
+import { sql } from "kysely";
 import { jsonArrayFrom, jsonObjectFrom } from "kysely/helpers/postgres";
 import partition from "lodash.partition";
 
@@ -54,8 +54,9 @@ import { findRanksBetween } from "../rank";
 import { autoCache } from "./cache/autoCache";
 import { autoRevalidate } from "./cache/autoRevalidate";
 import { BadRequestError, NotFoundError } from "./errors";
+import { maybeWithTrx } from "./maybeWithTrx";
 import { applyFilters } from "./pub-filters";
-import { getPubFields } from "./pubFields";
+import { _getPubFields, getPubFields } from "./pubFields";
 import { getPubTypeBase } from "./pubtype";
 import { movePub } from "./stages";
 import { SAFE_USER_SELECT } from "./user";
@@ -206,20 +207,6 @@ export const doesPubExist = async (
 ): Promise<{ exists: false; pub?: undefined } | { exists: true; pub: Pubs }> => {
 	const { exists, pubs } = await doPubsExist([pubId], communitiyId, trx);
 	return exists ? { exists: true as const, pub: pubs[0] } : { exists: false as const };
-};
-
-/**
- * For recursive transactions
- */
-export const maybeWithTrx = async <T>(
-	trx: Transaction<Database> | Kysely<Database>,
-	fn: (trx: Transaction<Database>) => Promise<T>
-): Promise<T> => {
-	// could also use trx.isTransaction()
-	if (trx instanceof Transaction) {
-		return await fn(trx);
-	}
-	return await trx.transaction().execute(fn);
 };
 
 const isRelatedPubInit = (value: unknown): value is { value: unknown; relatedPubId: PubsId }[] =>
@@ -505,26 +492,29 @@ export const getPlainPub = (pubId: PubsId, trx = db) =>
  * Validates that all provided slugs exist in the community.
  * @throws Error if any slugs don't exist in the community
  */
-export const getFieldInfoForSlugs = async ({
-	slugs,
-	communityId,
-	trx = db,
-}: {
-	slugs: string[];
-	communityId: CommunitiesId;
-	trx?: typeof db;
-}) => {
+export const getFieldInfoForSlugs = async (
+	{
+		slugs,
+		communityId,
+	}: {
+		slugs: string[];
+		communityId: CommunitiesId;
+	},
+	trx = db
+) => {
 	const toBeUpdatedPubFieldSlugs = Array.from(new Set(slugs));
 
 	if (toBeUpdatedPubFieldSlugs.length === 0) {
 		return [];
 	}
 
-	const { fields } = await getPubFields({
-		communityId,
-		slugs: toBeUpdatedPubFieldSlugs,
-		trx,
-	}).executeTakeFirstOrThrow();
+	const { fields } = await _getPubFields(
+		{
+			communityId,
+			slugs: toBeUpdatedPubFieldSlugs,
+		},
+		trx
+	).executeTakeFirstOrThrow();
 
 	const pubFields = Object.values(fields);
 
@@ -568,11 +558,13 @@ export const validatePubValues = async <T extends { slug: string; value: unknown
 	continueOnValidationError?: boolean;
 	trx?: typeof db;
 }) => {
-	const relevantPubFields = await getFieldInfoForSlugs({
-		slugs: pubValues.map(({ slug }) => slug),
-		communityId,
-		trx,
-	});
+	const relevantPubFields = await getFieldInfoForSlugs(
+		{
+			slugs: pubValues.map(({ slug }) => slug),
+			communityId,
+		},
+		trx
+	);
 
 	const mergedPubFields = mergeSlugsWithFields(pubValues, relevantPubFields);
 
@@ -738,10 +730,13 @@ export const removePubRelations = async ({
 	lastModifiedBy: LastModifiedBy;
 	trx?: typeof db;
 }) => {
-	const consolidatedRelations = await getFieldInfoForSlugs({
-		slugs: relations.map(({ slug }) => slug),
-		communityId,
-	});
+	const consolidatedRelations = await getFieldInfoForSlugs(
+		{
+			slugs: relations.map(({ slug }) => slug),
+			communityId,
+		},
+		trx
+	);
 
 	const mergedRelations = mergeSlugsWithFields(relations, consolidatedRelations);
 
@@ -790,10 +785,13 @@ export const removeAllPubRelationsBySlugs = async ({
 		return [];
 	}
 
-	const fields = await getFieldInfoForSlugs({
-		slugs: slugs,
-		communityId,
-	});
+	const fields = await getFieldInfoForSlugs(
+		{
+			slugs: slugs,
+			communityId,
+		},
+		trx
+	);
 	const fieldIds = fields.map(({ fieldId }) => fieldId);
 	if (!fieldIds.length) {
 		throw new Error(`No fields found for slugs: ${slugs.join(", ")}`);

--- a/core/lib/server/pubFields.ts
+++ b/core/lib/server/pubFields.ts
@@ -14,7 +14,6 @@ type GetPubFieldsInput =
 			communityId: CommunitiesId;
 			isRelated?: boolean;
 			slugs?: string[];
-			trx?: typeof db;
 	  }
 	| {
 			pubId: PubsId;
@@ -22,7 +21,6 @@ type GetPubFieldsInput =
 			communityId: CommunitiesId;
 			isRelated?: boolean;
 			slugs?: string[];
-			trx?: typeof db;
 	  }
 	| {
 			pubId?: never;
@@ -30,7 +28,6 @@ type GetPubFieldsInput =
 			communityId: CommunitiesId;
 			isRelated?: boolean;
 			slugs?: string[];
-			trx?: typeof db;
 	  };
 
 /**
@@ -42,10 +39,11 @@ type GetPubFieldsInput =
  * @param props.communityId - When supplied, return all the pub fields associated with the community ID
  * @param props.slugs - Adds a `where('pub_fields.slug', 'in', props.slugs)` clause
  */
-export const getPubFields = (props: GetPubFieldsInput) => autoCache(_getPubFields(props));
+export const getPubFields = (props: GetPubFieldsInput, trx = db) =>
+	autoCache(_getPubFields(props, trx));
 
-export const _getPubFields = (props: GetPubFieldsInput) =>
-	(props.trx ?? db)
+export const _getPubFields = (props: GetPubFieldsInput, trx = db) =>
+	trx
 		.with("ids", (eb) =>
 			eb
 				.selectFrom("pub_fields")


### PR DESCRIPTION
## Issue(s) Resolved

-

The goal is to split off some work from the migrations pr to make it more reviewable in the long term.

## High-level Explanation of PR

<!-- Using which methods does this PR resolve the issues above? -->

This PR does two things that are necessary for #1171 

1. Allow batch updating/creating/upserting of pubs. that way in order to create N pubs, rather than needing `N x M` calls to the db, where `M` is the number of calls pubop makes for creating one pub, we now only need `M` calls. Much more efficient.
2. Fix and expand the `byValue` pattern established by `PubOp.upsertByValue` and `PubOp.updateByValue` to actually work, and also be available for `relateByValue`. This allows you to do `pubOp`s of which you may only know a specific value (in the case of the migration the `legacy-id`), rather than the id. This is very useful for doing imports.

## Test Plan

- Convince yourself of the tests
- See for instance the `createCollections` fn in the migrations pr on how both are to be used

https://github.com/pubpub/platform/blob/187f0148bd7c220b275a32164ccb1fcdd8b7eb11/core/lib/server/legacy-migration/legacy-migration.ts#L875-L1067

## Screenshots (if applicable)

Explanatory video




https://github.com/user-attachments/assets/1d0febec-3fa5-44b8-b737-8e3fb26f24fb







## Notes
