### PR TITLE
fix: fetch related pub values in form regardless of membership role

### DIFF
--- a/core/app/components/forms/types.ts
+++ b/core/app/components/forms/types.ts
@@ -1,6 +1,6 @@
 import { type InputComponentConfigSchema, type SchemaTypeByInputComponent } from "schemas";
 
-import type { JsonValue, ProcessedPub } from "contracts";
+import type { JsonValue, ProcessedPubWithForm } from "contracts";
 import type {
 	CoreSchemaType,
 	ElementType,
@@ -116,5 +116,6 @@ export type SingleFormValues = {
 };
 
 export const isRelatedValue = (
-	value: ProcessedPub["values"][number]
-): value is ProcessedPub["values"][number] & RelatedFieldValue => Boolean(value.relatedPubId);
+	value: ProcessedPubWithForm["values"][number]
+): value is ProcessedPubWithForm["values"][number] & RelatedFieldValue =>
+	Boolean(value.relatedPubId);

--- a/core/app/components/pubs/PubEditor/PubEditor.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditor.tsx
@@ -126,6 +126,13 @@ export async function PubEditor(props: PubEditorProps) {
 	const { user } = await getLoginData();
 
 	if ("pubId" in props) {
+		// We explicitly do not pass the user here for two reasons:
+		// (1) It's expected that to see the PubEditor component at all, the
+		// user has the capabilities necessary to edit the pub's local values
+		// exposed by the form.
+		// (2) We want to fetch the pub's related pubs' values in order to
+		// render the related pub title/name in the related pubs form element,
+		// even if the user does not have capabilities to view the related pub.
 		pub = await getPubsWithRelatedValues(
 			{
 				pubId: props.pubId,

--- a/core/app/components/pubs/PubEditor/PubEditorClient.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditorClient.tsx
@@ -13,7 +13,7 @@ import partition from "lodash.partition";
 import { useForm } from "react-hook-form";
 import { getDefaultValueByCoreSchemaType, getJsonSchemaByCoreSchemaType } from "schemas";
 
-import type { JsonValue, ProcessedPub } from "contracts";
+import type { JsonValue, ProcessedPub, ProcessedPubWithForm } from "contracts";
 import type { PubsId, StagesId } from "db/public";
 import { CoreSchemaType, ElementType } from "db/public";
 import { Form } from "ui/form";
@@ -86,7 +86,10 @@ const preparePayload = ({
  * Set all default values
  * Special case: date pubValues need to be transformed to a Date type to pass validation
  */
-const buildDefaultValues = (elements: BasicFormElements[], pubValues: ProcessedPub["values"]) => {
+const buildDefaultValues = (
+	elements: BasicFormElements[],
+	pubValues: ProcessedPubWithForm["values"]
+) => {
 	const defaultValues: FieldValues = { deleted: [] };
 	// Build a record of the default values for array elements (related pubs) keyed by pub_values.id
 	// for dirty checking in preparePayload
@@ -105,7 +108,7 @@ const buildDefaultValues = (elements: BasicFormElements[], pubValues: ProcessedP
 				const relatedPubValues = pubValues.filter((v) => v.fieldSlug === element.slug);
 				defaultValues[element.slug] = [];
 				relatedPubValues.forEach((pv) => {
-					if (!isRelatedValue(pv)) {
+					if (!isRelatedValue(pv) || pv.id === null) {
 						return;
 					}
 					const relatedVal = {
@@ -227,7 +230,7 @@ export interface PubEditorClientProps {
 	elements: BasicFormElements[];
 	children: ReactNode;
 	isUpdating: boolean;
-	pub: Pick<ProcessedPub, "id" | "values" | "pubTypeId">;
+	pub: Pick<ProcessedPubWithForm, "id" | "values" | "pubTypeId">;
 	onSuccess: (args: {
 		values: FieldValues;
 		submitButtonId?: string;


### PR DESCRIPTION
## Issue(s) Resolved

Fixes #1128

Well, it was already fixed, but this change fixes missing title/name for pubs that contributor members are not authorized to see.

## High-level Explanation of PR

<!-- Using which methods does this PR resolve the issues above? -->

This PR updates the `PubEditor` to not consider the user when fetching the pub and its pub values. This means that related pubs are completely fetched, ensuring they have a title.

Pub values not in the form are hidden unless the user can `seeExtraPubValues` .

## Test Plan

Make sure you are unable to reproduce the issue reported in #1128. 