### PR TITLE
fix: use prod datacite api url in production

### DIFF
--- a/infrastructure/terraform/environments/stevie/main.tf
+++ b/infrastructure/terraform/environments/stevie/main.tf
@@ -53,7 +53,7 @@ locals {
   NEXT_PUBLIC_SUPABASE_PUBLIC_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRzbGVxanV2enVveWNwZW90ZHdzIiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODIzNTE0MjEsImV4cCI6MTk5NzkyNzQyMX0.3HHC0f7zlFXP77N0U8cS3blr7n6hhjqdYI6_ciQJams"
   ASSETS_BUCKET_NAME              = "assets.app.pubpub.org"
   HOSTNAME                        = "0.0.0.0"
-  DATACITE_API_URL                = "https://api.test.datacite.org"
+  DATACITE_API_URL                = "https://api.datacite.org"
 }
 
 


### PR DESCRIPTION
Output of `mask tf plan -n stevie`

```
Terraform will perform the following actions:

  # module.deployment.module.service_core.module.ecs_service.data.aws_ecs_task_definition.this[0] will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_ecs_task_definition" "this" {
      + arn                  = (known after apply)
      + arn_without_revision = (known after apply)
      + execution_role_arn   = (known after apply)
      + family               = (known after apply)
      + id                   = (known after apply)
      + network_mode         = (known after apply)
      + revision             = (known after apply)
      + status               = (known after apply)
      + task_definition      = "stevie-core"
      + task_role_arn        = (known after apply)
    }

  # module.deployment.module.service_core.module.ecs_service.aws_ecs_task_definition.this[0] must be replaced
+/- resource "aws_ecs_task_definition" "this" {
      ~ arn                      = "arn:aws:ecs:us-east-1:246372085946:task-definition/stevie-core:229" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:246372085946:task-definition/stevie-core" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  ~ environment            = [
                        # (2 unchanged elements hidden)
                        {
                            name  = "ASSETS_UPLOAD_KEY"
                            value = "AKIATSXHLWC5ORF73VHS"
                        },
                      ~ {
                            name  = "DATACITE_API_URL"
                          ~ value = "https://api.test.datacite.org" -> "https://api.datacite.org"
                        },
                        {
                            name  = "HOSTNAME"
                            value = "0.0.0.0"
                        },
                        # (14 unchanged elements hidden)
                    ]
                    name                   = "core"
                    # (17 unchanged attributes hidden)
                },
              ~ {
                  ~ environment            = [
                        # (2 unchanged elements hidden)
                        {
                            name  = "ASSETS_UPLOAD_KEY"
                            value = "AKIATSXHLWC5ORF73VHS"
                        },
                      ~ {
                            name  = "DATACITE_API_URL"
                          ~ value = "https://api.test.datacite.org" -> "https://api.datacite.org"
                        },
                        {
                            name  = "HOSTNAME"
                            value = "0.0.0.0"
                        },
                        # (14 unchanged elements hidden)
                    ]
                    name                   = "migrations"
                    # (17 unchanged attributes hidden)
                },
                {
                    environment            = [
                        {
                            name  = "NGINX_LISTEN_PORT"
                            value = "8080"
                        },
                        {
                            name  = "NGINX_PREFIX"
                            value = "/"
                        },
                        {
                            name  = "NGINX_UPSTREAM_HOST"
                            value = "127.0.0.1"
                        },
                        {
                            name  = "NGINX_UPSTREAM_PORT"
                            value = "3000"
                        },
                        {
                            name  = "OTEL_SERVICE_NAME"
                            value = "core.nginx"
                        },
                    ]
                    essential              = true
                    image                  = "246372085946.dkr.ecr.us-east-1.amazonaws.com/nginx:latest"
                    interactive            = false
                    linuxParameters        = {
                        initProcessEnabled = true
                    }
                    logConfiguration       = {
                        logDriver = "awslogs"
                        options   = {
                            awslogs-group         = "stevie-ecs-production-container-logs"
                            awslogs-region        = "us-east-1"
                            awslogs-stream-prefix = "ecs"
                        }
                    }
                    mountPoints            = []
                    name                   = "nginx"
                    portMappings           = [
                        {
                            containerPort = 8080
                            hostPort      = 8080
                            name          = "core-nginx"
                            protocol      = "tcp"
                        },
                    ]
                    privileged             = false
                    pseudoTerminal         = false
                    readonlyRootFilesystem = false
                    startTimeout           = 30
                    stopTimeout            = 120
                    systemControls         = []
                    user                   = "0"
                    volumesFrom            = []
                },
            ] # forces replacement
        )
      ~ id                       = "stevie-core" -> (known after apply)
      ~ revision                 = 229 -> (known after apply)
        tags                     = {
            "Environment"         = "stevie-production"
            "LogicalName"         = "core"
            "Project"             = "Pubpub-v7"
            "Shortname"           = "94a0"
            "ShortnameAnnotation" = "Shortname is calculated as first four characters of the sha1sum of the Logical Name."
        }
        # (10 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```