### PR TITLE
Remove blake deployment

### DIFF
--- a/infrastructure/terraform/environments/blake/main.tf
+++ b/infrastructure/terraform/environments/blake/main.tf
@@ -42,10 +42,10 @@ locals {
   pubpub_hostname = "blake.duqduq.org"
   route53_zone_id = "Z059164612717GL8VGM95"
   ecr_repository_urls = {
-    core             = "246372085946.dkr.ecr.us-east-1.amazonaws.com/pubpub-v7-core"
-    jobs             = "246372085946.dkr.ecr.us-east-1.amazonaws.com/pubpub-v7-jobs"
-    nginx            = "246372085946.dkr.ecr.us-east-1.amazonaws.com/nginx"
-    root             = "246372085946.dkr.ecr.us-east-1.amazonaws.com/pubpub-v7"
+    core  = "246372085946.dkr.ecr.us-east-1.amazonaws.com/pubpub-v7-core"
+    jobs  = "246372085946.dkr.ecr.us-east-1.amazonaws.com/pubpub-v7-jobs"
+    nginx = "246372085946.dkr.ecr.us-east-1.amazonaws.com/nginx"
+    root  = "246372085946.dkr.ecr.us-east-1.amazonaws.com/pubpub-v7"
   }
 
   MAILGUN_SMTP_USERNAME           = "v7@mg.pubpub.org"
@@ -62,22 +62,3 @@ locals {
 ##  Complete generic environment
 ##
 ######
-
-module "deployment" {
-  source = "../../modules/deployment"
-
-  name        = local.name
-  environment = local.environment
-  region      = local.region
-
-  pubpub_hostname     = local.pubpub_hostname
-  route53_zone_id     = local.route53_zone_id
-  ecr_repository_urls = local.ecr_repository_urls
-
-  MAILGUN_SMTP_USERNAME           = local.MAILGUN_SMTP_USERNAME
-  NEXT_PUBLIC_SUPABASE_URL        = local.NEXT_PUBLIC_SUPABASE_URL
-  NEXT_PUBLIC_SUPABASE_PUBLIC_KEY = local.NEXT_PUBLIC_SUPABASE_PUBLIC_KEY
-  ASSETS_BUCKET_NAME              = local.ASSETS_BUCKET_NAME
-  HOSTNAME                        = local.HOSTNAME
-  DATACITE_API_URL                = local.DATACITE_API_URL
-}

--- a/infrastructure/terraform/environments/cloudflare/main.tf
+++ b/infrastructure/terraform/environments/cloudflare/main.tf
@@ -45,18 +45,6 @@ resource "aws_route53_zone" "duqduq" {
 }
 
 # do this for all subdomains of duqduq that need to be NS'd to v7
-resource "cloudflare_record" "ns" {
-  for_each = toset(["0", "1", "2", "3"])
-  type     = "NS"
-
-  zone_id = data.cloudflare_zone.duqduq.id
-
-  name = "blake.${local.duqduq_domain}"
-
-  value = aws_route53_zone.duqduq.name_servers[tonumber(each.key)]
-}
-
-
 data "cloudflare_zone" "pubpub" {
   name = local.pubpub_domain
 }


### PR DESCRIPTION
## High-level Explanation of PR
Removes our unused and broken staging env at https://blake.duqduq.org to save money. After this is applied we can fully delete that directory if we want.

The terraform plan for the blake env is too big to go in a github comment so it's in this gist. https://gist.github.com/kalilsn/95cdff2371c2260060faee98f8406c38

<details>
<summary>Terraform plan for cloudflare env</summary>

```
Terraform will perform the following actions:

  # cloudflare_record.ns["0"] will be destroyed
  # (because cloudflare_record.ns is not in configuration)
  - resource "cloudflare_record" "ns" {
      - allow_overwrite = false -> null
      - created_on      = "2024-05-02T20:32:27.37627Z" -> null
      - hostname        = "blake.duqduq.org" -> null
      - id              = "10ac0f190eb92c51b239fde326777828" -> null
      - metadata        = {} -> null
      - modified_on     = "2024-05-02T20:32:27.37627Z" -> null
      - name            = "blake.duqduq.org" -> null
      - proxiable       = false -> null
      - proxied         = false -> null
      - tags            = [] -> null
      - ttl             = 1 -> null
      - type            = "NS" -> null
      - value           = "ns-1193.awsdns-21.org" -> null
      - zone_id         = "59bfa768bbbdeb76e3cb82b954ecfe2f" -> null
    }

  # cloudflare_record.ns["1"] will be destroyed
  # (because cloudflare_record.ns is not in configuration)
  - resource "cloudflare_record" "ns" {
      - allow_overwrite = false -> null
      - created_on      = "2024-05-02T20:32:27.202584Z" -> null
      - hostname        = "blake.duqduq.org" -> null
      - id              = "efe8ca29ce607cbba951444877a908e8" -> null
      - metadata        = {} -> null
      - modified_on     = "2024-05-02T20:32:27.202584Z" -> null
      - name            = "blake.duqduq.org" -> null
      - proxiable       = false -> null
      - proxied         = false -> null
      - tags            = [] -> null
      - ttl             = 1 -> null
      - type            = "NS" -> null
      - value           = "ns-1623.awsdns-10.co.uk" -> null
      - zone_id         = "59bfa768bbbdeb76e3cb82b954ecfe2f" -> null
    }

  # cloudflare_record.ns["2"] will be destroyed
  # (because cloudflare_record.ns is not in configuration)
  - resource "cloudflare_record" "ns" {
      - allow_overwrite = false -> null
      - created_on      = "2024-05-02T20:32:28.128054Z" -> null
      - hostname        = "blake.duqduq.org" -> null
      - id              = "a0e7c3aed8d81a2dd8e785bb0581bc34" -> null
      - metadata        = {} -> null
      - modified_on     = "2024-05-02T20:32:28.128054Z" -> null
      - name            = "blake.duqduq.org" -> null
      - proxiable       = false -> null
      - proxied         = false -> null
      - tags            = [] -> null
      - ttl             = 1 -> null
      - type            = "NS" -> null
      - value           = "ns-392.awsdns-49.com" -> null
      - zone_id         = "59bfa768bbbdeb76e3cb82b954ecfe2f" -> null
    }

  # cloudflare_record.ns["3"] will be destroyed
  # (because cloudflare_record.ns is not in configuration)
  - resource "cloudflare_record" "ns" {
      - allow_overwrite = false -> null
      - created_on      = "2024-05-02T20:32:27.670155Z" -> null
      - hostname        = "blake.duqduq.org" -> null
      - id              = "a2869cffee2acbf53bbb0ddb4ac0608a" -> null
      - metadata        = {} -> null
      - modified_on     = "2024-05-02T20:32:27.670155Z" -> null
      - name            = "blake.duqduq.org" -> null
      - proxiable       = false -> null
      - proxied         = false -> null
      - tags            = [] -> null
      - ttl             = 1 -> null
      - type            = "NS" -> null
      - value           = "ns-593.awsdns-10.net" -> null
      - zone_id         = "59bfa768bbbdeb76e3cb82b954ecfe2f" -> null
    }

Plan: 0 to add, 0 to change, 4 to destroy.
```
</details>
