### PR TITLE
Add security group to valkey instance

### DIFF
--- a/infrastructure/terraform/modules/core-services/main.tf
+++ b/infrastructure/terraform/modules/core-services/main.tf
@@ -101,6 +101,7 @@ resource "aws_elasticache_replication_group" "core_valkey" {
   num_cache_clusters   = 1
   parameter_group_name = "default.valkey8"
   port                 = 6379
+  security_group_ids   = [aws_security_group.core_valkey.id]
 }
 
 # resource "aws_elasticache_parameter_group" "core_valkey" {

--- a/infrastructure/terraform/modules/deployment/main.tf
+++ b/infrastructure/terraform/modules/deployment/main.tf
@@ -167,6 +167,7 @@ module "service_bastion" {
       { name = "SUPABASE_URL", value = var.NEXT_PUBLIC_SUPABASE_URL },
       { name = "HOSTNAME", value = var.HOSTNAME },
       { name = "PAGER", value = "less -S" },
+      { name = "VALKEY_URL", value = "redis://${module.core_dependency_services.valkey_url}" }
     ]
 
     secrets = [


### PR DESCRIPTION
## Issue(s) Resolved
#1131 
## High-level Explanation of PR
I created a security group to grant our platform containers access to valkey, but forgot to actually add the security group to the valkey instance. This PR fixes that.

```
Terraform will perform the following actions:

  # module.deployment.module.core_dependency_services.aws_elasticache_replication_group.core_valkey will be updated in-place
  ~ resource "aws_elasticache_replication_group" "core_valkey" {
        id                         = "stevie-core-valkey-production"
      ~ security_group_ids         = [
          + "sg-0e0df02a3d2a384d0",
        ]
        tags                       = {}
        # (33 unchanged attributes hidden)
    }

  # module.deployment.module.service_bastion.module.ecs_service.data.aws_ecs_task_definition.this[0] will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_ecs_task_definition" "this" {
      + arn                      = (known after apply)
      + arn_without_revision     = (known after apply)
      + container_definitions    = (known after apply)
      + cpu                      = (known after apply)
      + enable_fault_injection   = (known after apply)
      + ephemeral_storage        = (known after apply)
      + execution_role_arn       = (known after apply)
      + family                   = (known after apply)
      + id                       = (known after apply)
      + inference_accelerator    = (known after apply)
      + ipc_mode                 = (known after apply)
      + memory                   = (known after apply)
      + network_mode             = (known after apply)
      + pid_mode                 = (known after apply)
      + placement_constraints    = (known after apply)
      + proxy_configuration      = (known after apply)
      + requires_compatibilities = (known after apply)
      + revision                 = (known after apply)
      + runtime_platform         = (known after apply)
      + status                   = (known after apply)
      + task_definition          = "stevie-bastion"
      + task_role_arn            = (known after apply)
      + volume                   = (known after apply)
    }

  # module.deployment.module.service_bastion.module.ecs_service.aws_ecs_task_definition.this[0] must be replaced
+/- resource "aws_ecs_task_definition" "this" {
      ~ arn                      = "arn:aws:ecs:us-east-1:246372085946:task-definition/stevie-bastion:155" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:246372085946:task-definition/stevie-bastion" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  ~ environment            = [
                        # (7 unchanged elements hidden)
                        {
                            name  = "SUPABASE_URL"
                            value = "https://dsleqjuvzuoycpeotdws.supabase.co"
                        },
                      + {
                          + name  = "VALKEY_URL"
                          + value = "redis://stevie-core-valkey-production.we8a07.ng.0001.use1.cache.amazonaws.com"
                        },
                    ]
                    name                   = "bastion"
                    # (17 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ enable_fault_injection   = false -> (known after apply)
      ~ id                       = "stevie-bastion" -> (known after apply)
      ~ revision                 = 155 -> (known after apply)
        tags                     = {
            "Environment"         = "stevie-production"
            "LogicalName"         = "bastion"
            "Project"             = "Pubpub-v7"
            "Shortname"           = "590b"
            "ShortnameAnnotation" = "Shortname is calculated as first four characters of the sha1sum of the Logical Name."
        }
        # (10 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 1 to add, 1 to change, 1 to destroy.
```

<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan

I'll connect to the bastion and install redis (`apk add redis`) then attempt to connect to the instance `redis-cli -u $VALKEY_URL PING`