### PR TITLE
fix: GDoc Action - check for string existence

### DIFF
--- a/core/actions/googleDriveImport/gdocPlugins.ts
+++ b/core/actions/googleDriveImport/gdocPlugins.ts
@@ -111,8 +111,8 @@ export const tableToObjectArray = (node: any) => {
 		"table",
 	];
 
-	const isHoriz = validTypes.includes(headersVert[1].toLowerCase());
-	const isVert = validTypes.includes(headersHoriz[1].toLowerCase());
+	const isHoriz = validTypes.includes(headersVert[1]?.toLowerCase());
+	const isVert = validTypes.includes(headersHoriz[1]?.toLowerCase());
 
 	const getCellContent = (tableType: string, headerVal: string, cell: any): any => {
 		const isTypeWithHtmlValue =


### PR DESCRIPTION
Some tables in google docs may incorrectly trigger the tableConversion function, which has an uncaught string assumption.