### PR TITLE
Fix clear cache to clear valkey instead of filesystem cache

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -17,7 +17,7 @@
 		"db:prisma": "pnpm prisma",
 		"db:studio": "pnpm prisma studio",
 		"db:generate-history-table": "pnpm exec tsx prisma/scripts/history-tables/generate-history-table.mts",
-		"clear-cache": "dotenv -e .env.local -e .env.development -- tsx --eval \"import {getRedisClient} from 'lib/redis'; (async () => {await (await getRedisClient()).flushall(); process.exit(); })();\"",
+		"clear-cache": "dotenv -e .env.local -e .env.development echo FLUSHALL | nc ${VALKEY_HOST} 6379",
 		"dev": "next dev -p 3000 --turbo | pino-pretty",
 		"build": "SKIP_VALIDATION=true NODE_OPTIONS=\"--max-old-space-size=8192\" next build",
 		"invite-users": "dotenv -e .env.local -e .env.development  tsx scripts/invite.ts",

--- a/core/package.json
+++ b/core/package.json
@@ -17,7 +17,7 @@
 		"db:prisma": "pnpm prisma",
 		"db:studio": "pnpm prisma studio",
 		"db:generate-history-table": "pnpm exec tsx prisma/scripts/history-tables/generate-history-table.mts",
-		"clear-cache": "rm -rf .next/cache/fetch-cache",
+		"clear-cache": "dotenv -e .env.local -e .env.development -- tsx --eval \"import {getRedisClient} from 'lib/redis'; (async () => {await (await getRedisClient()).flushall(); process.exit(); })();\"",
 		"dev": "next dev -p 3000 --turbo | pino-pretty",
 		"build": "SKIP_VALIDATION=true NODE_OPTIONS=\"--max-old-space-size=8192\" next build",
 		"invite-users": "dotenv -e .env.local -e .env.development  tsx scripts/invite.ts",

--- a/core/package.json
+++ b/core/package.json
@@ -17,7 +17,7 @@
 		"db:prisma": "pnpm prisma",
 		"db:studio": "pnpm prisma studio",
 		"db:generate-history-table": "pnpm exec tsx prisma/scripts/history-tables/generate-history-table.mts",
-		"clear-cache": "source .env.development && source .env.local && echo 'FLUSHALL' | nc ${VALKEY_HOST} 6379",
+		"clear-cache": "echo 'FLUSHALL' | nc $(pnpm dotenv -e .env.local -e .env.development -p VALKEY_HOST) 6379",
 		"dev": "next dev -p 3000 --turbo | pino-pretty",
 		"build": "SKIP_VALIDATION=true NODE_OPTIONS=\"--max-old-space-size=8192\" next build",
 		"invite-users": "dotenv -e .env.local -e .env.development  tsx scripts/invite.ts",

--- a/core/package.json
+++ b/core/package.json
@@ -17,7 +17,7 @@
 		"db:prisma": "pnpm prisma",
 		"db:studio": "pnpm prisma studio",
 		"db:generate-history-table": "pnpm exec tsx prisma/scripts/history-tables/generate-history-table.mts",
-		"clear-cache": "dotenv -e .env.local -e .env.development echo FLUSHALL | nc ${VALKEY_HOST} 6379",
+		"clear-cache": "source .env.development && source .env.local && echo 'FLUSHALL' | nc ${VALKEY_HOST} 6379",
 		"dev": "next dev -p 3000 --turbo | pino-pretty",
 		"build": "SKIP_VALIDATION=true NODE_OPTIONS=\"--max-old-space-size=8192\" next build",
 		"invite-users": "dotenv -e .env.local -e .env.development  tsx scripts/invite.ts",

--- a/core/package.json
+++ b/core/package.json
@@ -17,7 +17,7 @@
 		"db:prisma": "pnpm prisma",
 		"db:studio": "pnpm prisma studio",
 		"db:generate-history-table": "pnpm exec tsx prisma/scripts/history-tables/generate-history-table.mts",
-		"clear-cache": "echo 'FLUSHALL' | nc $(pnpm dotenv -e .env.local -e .env.development -p VALKEY_HOST) 6379",
+		"clear-cache": "echo 'FLUSHALL' | nc $(dotenv -e .env.local -e .env.development -p VALKEY_HOST) 6379",
 		"dev": "next dev -p 3000 --turbo | pino-pretty",
 		"build": "SKIP_VALIDATION=true NODE_OPTIONS=\"--max-old-space-size=8192\" next build",
 		"invite-users": "dotenv -e .env.local -e .env.development  tsx scripts/invite.ts",


### PR DESCRIPTION
## Issue(s) Resolved
Resolves #1233 
## High-level Explanation of PR
After #1131 we no longer cache data on the filesystem, and instead store it in redis. In both local development and in the sandbox deployments, we regularly run the reset command, which also attempts to clear the cache. Since that cache-clearing function wasn't working, we could end up with stale data in the sandbox cache.

## Test Plan
It's easiest to see this clear the cache if you install redis-cli (or some kind of gui redis app). `redis-cli` monitor will let you see commands as they come in, and `redis cli scan 100` will print 100 keys so you can see if there's data in the cache.
- With the valkey cache running (`pnpm -w dev:cache:start`) and after using the app a bit, run `redis cli scan 100` to show there's data in the cache
- Optionally, run `redis-cli monitor` in a separate terminal
- Run `pnpm clear-cache`
- Scan again and see that the cache is clear + observe the flushall command sent in the monitor window

To actually recreate the initial sandbox bug requires a bit more effort, since you need to check out a previous commit (`1c21713d4321f728ee4b6362f2b63675542868c1`) and run reset.

I've also confirmed that this reset succeeds on lightsail by sshing into the preview instance for this branch and confirming that the migrations container exits with status 0 and that you can see the cache clearing command run in the logs for that container.

## Notes

I don't _think_ this is an issue in prod. My guess is the reason we're seeing strange behavior is that the seed scripts have a mixture of hardcoded and generated data, so we end up with some cache hits to stale data after reset. But that doesn't entirely make sense, so lmk if you have other ideas.