### PR TITLE
fix: fix formswitcher bug

### DIFF
--- a/core/app/c/[communitySlug]/pubs/create/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/create/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 
 import { notFound, redirect } from "next/navigation";
 
-import { type PubTypesId } from "db/public";
+import { type PubsId, type PubTypesId } from "db/public";
 import { Button } from "ui/button";
 import { Label } from "ui/label";
 
@@ -31,11 +31,19 @@ export async function generateMetadata(props: {
 
 export default async function Page(props: {
 	params: Promise<{ communitySlug: string }>;
-	searchParams: Promise<Record<string, string> & { pubTypeId: PubTypesId; form?: string }>;
+	searchParams: Promise<
+		Record<string, string> & { pubTypeId: PubTypesId; form?: string; pubId?: PubsId }
+	>;
 }) {
 	const searchParams = await props.searchParams;
 	const params = await props.params;
 	const { communitySlug } = params;
+
+	if (!searchParams.pubId) {
+		const sparams = new URLSearchParams(searchParams);
+		sparams.set("pubId", crypto.randomUUID());
+		redirect(`/c/${communitySlug}/pubs/create?${sparams.toString()}`);
+	}
 
 	const { user } = await getPageLoginData();
 

--- a/core/app/components/pubs/PubEditor/PubEditor.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditor.tsx
@@ -108,8 +108,6 @@ export type PubEditorProps = {
 		slug?: string;
 		pubTypeId?: PubTypesId;
 		form?: string;
-		// used when creating a new pub
-		pubId?: PubsId;
 	};
 	htmlFormId?: string;
 	formSlug?: string;
@@ -119,7 +117,9 @@ export type PubEditorProps = {
 			communityId: CommunitiesId;
 	  }
 	| {
+			pubId: PubsId;
 			communityId: CommunitiesId;
+			create: true;
 	  }
 	| {
 			communityId: CommunitiesId;
@@ -133,7 +133,7 @@ export async function PubEditor(props: PubEditorProps) {
 
 	const { user } = await getLoginData();
 
-	if ("pubId" in props) {
+	if ("pubId" in props && !("create" in props)) {
 		// We explicitly do not pass the user here for two reasons:
 		// (1) It's expected that to see the PubEditor component at all, the
 		// user has the capabilities necessary to edit the pub's local values
@@ -196,7 +196,7 @@ export async function PubEditor(props: PubEditorProps) {
 	// Create the pubId before inserting into the DB if one doesn't exist.
 	// FileUpload needs the pubId when uploading the file before the pub exists
 	const isUpdating = !!pub?.id;
-	const pubId = pub?.id ?? props.searchParams.pubId ?? (randomUUID() as PubsId);
+	const pubId = pub?.id ?? (("pubId" in props && props.pubId) || (randomUUID() as PubsId));
 
 	if (pub === undefined) {
 		if (props.searchParams.pubTypeId) {

--- a/core/app/components/pubs/PubEditor/PubEditor.tsx
+++ b/core/app/components/pubs/PubEditor/PubEditor.tsx
@@ -103,7 +103,14 @@ const getRelatedPubData = async ({
 };
 
 export type PubEditorProps = {
-	searchParams: { relatedPubId?: PubsId; slug?: string; pubTypeId?: PubTypesId; form?: string };
+	searchParams: {
+		relatedPubId?: PubsId;
+		slug?: string;
+		pubTypeId?: PubTypesId;
+		form?: string;
+		// used when creating a new pub
+		pubId?: PubsId;
+	};
 	htmlFormId?: string;
 	formSlug?: string;
 } & (
@@ -189,7 +196,7 @@ export async function PubEditor(props: PubEditorProps) {
 	// Create the pubId before inserting into the DB if one doesn't exist.
 	// FileUpload needs the pubId when uploading the file before the pub exists
 	const isUpdating = !!pub?.id;
-	const pubId = pub?.id ?? (randomUUID() as PubsId);
+	const pubId = pub?.id ?? props.searchParams.pubId ?? (randomUUID() as PubsId);
 
 	if (pub === undefined) {
 		if (props.searchParams.pubTypeId) {

--- a/core/app/components/pubs/PubEditor/actions.ts
+++ b/core/app/components/pubs/PubEditor/actions.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { revalidateTag } from "next/cache";
+
 import type { Json, JsonValue } from "contracts";
 import type { PubsId, PubTypesId, StagesId, UsersId } from "db/public";
 import { Capabilities, FormAccessType, MemberRole, MembershipType } from "db/public";
@@ -129,6 +131,8 @@ export const createPubRecursive = defineServerAction(async function createPubRec
 				report: `Successfully created a new Pub`,
 			};
 		});
+
+		revalidateTag(`create-pub-id-${user.id}`);
 
 		return result;
 	} catch (error) {

--- a/core/lib/__tests__/utils.ts
+++ b/core/lib/__tests__/utils.ts
@@ -65,6 +65,7 @@ export const mockServerCode = async () => {
 
 	vi.mock("next/cache", () => {
 		return {
+			revalidateTag: vi.fn(),
 			unstable_cache: (fn: any) => fn,
 		};
 	});

--- a/core/playwright/fixtures/pubs-page.ts
+++ b/core/playwright/fixtures/pubs-page.ts
@@ -56,6 +56,8 @@ export class PubsPage {
 		await this.page.getByRole("button", { name: "Create", exact: true }).click();
 		await this.choosePubType(pubType);
 
+		// weird race condition introduced by renavigation whichmakes the field toggle selection not work
+		await this.page.waitForTimeout(500);
 		// disable all toggles
 		const fieldToggles = this.page.getByRole("button", {
 			name: "Toggle field",

--- a/core/playwright/fixtures/pubs-page.ts
+++ b/core/playwright/fixtures/pubs-page.ts
@@ -56,8 +56,6 @@ export class PubsPage {
 		await this.page.getByRole("button", { name: "Create", exact: true }).click();
 		await this.choosePubType(pubType);
 
-		// weird race condition introduced by renavigation whichmakes the field toggle selection not work
-		await this.page.waitForTimeout(500);
 		// disable all toggles
 		const fieldToggles = this.page.getByRole("button", {
 			name: "Toggle field",

--- a/packages/db/src/public/PublicSchema.ts
+++ b/packages/db/src/public/PublicSchema.ts
@@ -36,12 +36,6 @@ import type { StagesTable } from "./Stages";
 import type { UsersTable } from "./Users";
 
 export interface PublicSchema {
-	member_groups: MemberGroupsTable;
-
-	communities: CommunitiesTable;
-
-	move_constraint: MoveConstraintTable;
-
 	pub_fields: PubFieldsTable;
 
 	pub_values: PubValuesTable;
@@ -101,4 +95,10 @@ export interface PublicSchema {
 	pub_types: PubTypesTable;
 
 	stages: StagesTable;
+
+	member_groups: MemberGroupsTable;
+
+	communities: CommunitiesTable;
+
+	move_constraint: MoveConstraintTable;
 }


### PR DESCRIPTION

## Issue(s) Resolved

> ![NOTE]
> Made this a separate PR bc it messed up the tests, may need more testing


I added this to get around the following issue (see vid):

1. Go to create a Pub.
2. A pubId is internally initialized using `crypto.randomUUID()` in bc the UploadElement needs to know about it
3. Switch form
4. Content is reloaded! therefore `crypto.randomUUID()` is called again!
5. Create Pub
6. Redirect fails, bc clientside pubid is different from server one


To solve this, I madet this page always have a UUID through the searchParam. This is not optimal, if you navigate back from the edit page to this page it will behave somewhat strangely. That could be solved by doing an additional check if a UUID _is_ provided, namely to check whether that Pub already exists. If it does, try once more.

I'm not a big fan of this solution, as it forces an extra redirect. 

Another solution is to properly propagate the changes in UUID on the server to the client. The problem with this is the following:

1. Go to create a Pub.
2. Upload a File.
3. Switch the view
4. Create Pub
5. Upload file "PubId" no longer matches the pub it belongs to.

Maybe that's not a big deal and we should just do that, ill leave it to you!


## High-level Explanation of PR

<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan

## Screenshots (if applicable)

The bug 

https://github.com/user-attachments/assets/c5cd30dd-830a-4a15-adf2-e375d5cf8ef1



## Notes
