### PR TITLE
Deleting email recipient

### DIFF
--- a/core/app/components/MemberSelect/MemberSelectClient.tsx
+++ b/core/app/components/MemberSelect/MemberSelectClient.tsx
@@ -95,6 +95,9 @@ export function MemberSelectClient({
 	}, 400);
 
 	const onInputValueChange = (value: string) => {
+		if (value === "") {
+			setSelectedUser(undefined);
+		}
 		setInputValue(value);
 		updateSearch(value);
 	};
@@ -130,7 +133,12 @@ export function MemberSelectClient({
 									onUserAdded={onUserAdded}
 								/>
 							}
-							onInputValueChange={onInputValueChange}
+							onInputValueChange={(val) => {
+								onInputValueChange(val);
+								if (val === "") {
+									field.onChange(undefined);
+								}
+							}}
 							onValueChange={async (option) => {
 								const user = users.find((user) => user.id === option.value);
 								if (!user) {

--- a/core/app/components/MemberSelect/MemberSelectClient.tsx
+++ b/core/app/components/MemberSelect/MemberSelectClient.tsx
@@ -95,9 +95,6 @@ export function MemberSelectClient({
 	}, 400);
 
 	const onInputValueChange = (value: string) => {
-		if (value === "") {
-			setSelectedUser(undefined);
-		}
 		setInputValue(value);
 		updateSearch(value);
 	};
@@ -106,6 +103,10 @@ export function MemberSelectClient({
 		<FormField
 			name={fieldName}
 			render={({ field }) => {
+				const unsetUser = () => {
+					setSelectedUser(undefined);
+					field.onChange(undefined);
+				};
 				const selectedUserOption = selectedUser && makeOptionFromUser(selectedUser);
 				const formItem = (
 					<FormItem className="flex flex-col gap-y-1">
@@ -134,10 +135,10 @@ export function MemberSelectClient({
 								/>
 							}
 							onInputValueChange={(val) => {
-								onInputValueChange(val);
 								if (val === "") {
-									field.onChange(undefined);
+									unsetUser();
 								}
+								onInputValueChange(val);
 							}}
 							onValueChange={async (option) => {
 								const user = users.find((user) => user.id === option.value);
@@ -162,6 +163,7 @@ export function MemberSelectClient({
 							}}
 							onClose={resetAddUserButton}
 							icon={selectedUser ? <UserAvatar user={selectedUser} /> : null}
+							onClear={selectedUser ? unsetUser : undefined}
 						/>
 						<FormMessage />
 						{helpText && <FormDescription>{helpText}</FormDescription>}

--- a/core/playwright/actions.config.spec.ts
+++ b/core/playwright/actions.config.spec.ts
@@ -1,0 +1,130 @@
+import type { Page } from "@playwright/test";
+
+import { faker } from "@faker-js/faker";
+import test, { expect } from "@playwright/test";
+
+import { Action, CoreSchemaType, Event, MemberRole } from "db/public";
+
+import type { CommunitySeedOutput } from "~/prisma/seed/createSeed";
+import { createSeed } from "~/prisma/seed/createSeed";
+import { seedCommunity } from "~/prisma/seed/seedCommunity";
+import { LoginPage } from "./fixtures/login-page";
+import { StagesManagePage } from "./fixtures/stages-manage-page";
+
+test.describe.configure({ mode: "serial" });
+
+let page: Page;
+const adminEmail = faker.internet.email();
+
+const seed = createSeed({
+	community: {
+		name: "Test Community",
+		slug: "test-community-1",
+	},
+	pubFields: {
+		Title: { schemaName: CoreSchemaType.String },
+	},
+	pubTypes: {
+		Submission: {
+			Title: { isTitle: true },
+		},
+	},
+	stages: {
+		Test: {
+			actions: {
+				Email: {
+					action: Action.email,
+					config: { subject: "Hello", body: "Content" },
+				},
+			},
+		},
+	},
+	users: {
+		admin: {
+			email: adminEmail,
+			password: "password",
+			isSuperAdmin: true,
+			role: MemberRole.admin,
+		},
+	},
+	pubs: [
+		{
+			pubType: "Submission",
+			stage: "Test",
+			values: { Title: "Test" },
+		},
+	],
+});
+let community: CommunitySeedOutput<typeof seed>;
+
+test.beforeAll(async ({ browser }) => {
+	community = await seedCommunity(seed);
+
+	page = await browser.newPage();
+
+	const loginPage = new LoginPage(page);
+	await loginPage.goto();
+	await loginPage.loginAndWaitForNavigation(community.users.admin.email, "password");
+});
+
+test.afterAll(async () => {
+	await page.close();
+});
+
+test.describe("email action", () => {
+	const goToConfigureEmail = async (page: Page) => {
+		const stagesManagePage = new StagesManagePage(page, community.community.slug);
+		await stagesManagePage.goTo();
+		await stagesManagePage.openStagePanelTab("Test", "Actions");
+		await page
+			.getByTestId("action-instance-Email")
+			.getByRole("button", { name: "Edit action" })
+			.click();
+	};
+	const setMember = async (page: Page, email: string) => {
+		await goToConfigureEmail(page);
+		await page.getByTestId("autocomplete-recipientMember").fill(email);
+		await page.getByRole("option", { name: email }).click();
+		await page.getByRole("button", { name: "Update config" }).click();
+	};
+
+	test("can set and unset a recipient member by erasing the field via keyboard", async () => {
+		await test.step("set a member", async () => {
+			await setMember(page, adminEmail);
+		});
+
+		await test.step("verify that the field saved", async () => {
+			// Reload the page
+			await goToConfigureEmail(page);
+			await expect(page.getByTestId("autocomplete-recipientMember")).toHaveValue(adminEmail);
+		});
+
+		await test.step("unset by clearing field", async () => {
+			await page.getByTestId("autocomplete-recipientMember").clear();
+			await page.getByRole("button", { name: "Update config" }).click();
+		});
+
+		await test.step("verify that the field cleared", async () => {
+			// Reload the page
+			await goToConfigureEmail(page);
+			await expect(page.getByTestId("autocomplete-recipientMember")).toHaveValue("");
+		});
+	});
+
+	test("can set and unset a recipient member by clearing the field via button", async () => {
+		await test.step("set a member", async () => {
+			await setMember(page, adminEmail);
+		});
+
+		await test.step("unset by clearing field", async () => {
+			await page.getByRole("button", { name: "Clear" }).click();
+			await page.getByRole("button", { name: "Update config" }).click();
+		});
+
+		await test.step("verify that the field cleared", async () => {
+			// Reload the page
+			await goToConfigureEmail(page);
+			await expect(page.getByTestId("autocomplete-recipientMember")).toHaveValue("");
+		});
+	});
+});

--- a/packages/db/src/public/PublicSchema.ts
+++ b/packages/db/src/public/PublicSchema.ts
@@ -36,6 +36,12 @@ import type { StagesTable } from "./Stages";
 import type { UsersTable } from "./Users";
 
 export interface PublicSchema {
+	invites: InvitesTable;
+
+	invite_forms: InviteFormsTable;
+
+	invites_history: InvitesHistoryTable;
+
 	_prisma_migrations: PrismaMigrationsTable;
 
 	users: UsersTable;
@@ -95,10 +101,4 @@ export interface PublicSchema {
 	pub_values_history: PubValuesHistoryTable;
 
 	_FormElementToPubType: FormElementToPubTypeTable;
-
-	invites: InvitesTable;
-
-	invite_forms: InviteFormsTable;
-
-	invites_history: InvitesHistoryTable;
 }

--- a/packages/ui/src/autocomplete.tsx
+++ b/packages/ui/src/autocomplete.tsx
@@ -42,7 +42,7 @@ export const AutoComplete = ({
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	const [isOpen, setOpen] = useState(false);
-	const [selected, setSelected] = useState<Option>(value as Option);
+	const [selected, setSelected] = useState<Option|undefined>(value as Option);
 	const [inputValue, setInputValue] = useState<string>(value?.label || "");
 
 	const _setInputValue = useCallback(
@@ -79,6 +79,10 @@ export const AutoComplete = ({
 				}
 			}
 
+			if (input.value === "") {
+				setSelected(undefined);
+			}
+
 			if (event.key === "Escape") {
 				close();
 			}
@@ -108,7 +112,7 @@ export const AutoComplete = ({
 		const handler = (event: MouseEvent) => {
 			if (commandRef.current && !commandRef.current.contains(event.target as Node)) {
 				close();
-				if (selected) {
+				if (selected && inputValue !== "") {
 					_setInputValue(selected.label);
 				}
 			}
@@ -119,7 +123,7 @@ export const AutoComplete = ({
 		return () => {
 			document.removeEventListener("click", handler);
 		};
-	}, [selected, _setInputValue, close]);
+	}, [selected, _setInputValue, close, inputValue]);
 
 	return (
 		<CommandPrimitive onKeyDown={handleKeyDown} ref={commandRef}>

--- a/packages/ui/src/autocomplete.tsx
+++ b/packages/ui/src/autocomplete.tsx
@@ -3,10 +3,11 @@ import type { KeyboardEvent } from "react";
 import * as React from "react";
 import { useCallback, useRef, useState } from "react";
 import { Command as CommandPrimitive } from "cmdk";
-import { Check } from "lucide-react";
+import { Check, X } from "lucide-react";
 
 import { cn } from "utils";
 
+import { Button } from "./button";
 import { CommandGroup, CommandInput, CommandItem, CommandList } from "./command";
 import { Skeleton } from "./skeleton";
 
@@ -24,6 +25,8 @@ type AutoCompleteProps = {
 	placeholder?: string;
 	icon?: React.ReactNode;
 	name?: string;
+	// If included, will render a clear button in the input
+	onClear?: () => void;
 };
 
 export const AutoComplete = ({
@@ -38,6 +41,7 @@ export const AutoComplete = ({
 	isLoading = false,
 	icon,
 	name,
+	onClear,
 }: AutoCompleteProps) => {
 	const inputRef = useRef<HTMLInputElement>(null);
 
@@ -77,10 +81,6 @@ export const AutoComplete = ({
 					setSelected(optionToSelect);
 					onValueChange?.(optionToSelect);
 				}
-			}
-
-			if (input.value === "") {
-				setSelected(undefined);
 			}
 
 			if (event.key === "Escape") {
@@ -126,7 +126,7 @@ export const AutoComplete = ({
 	}, [selected, _setInputValue, close, inputValue]);
 
 	return (
-		<CommandPrimitive onKeyDown={handleKeyDown} ref={commandRef}>
+		<CommandPrimitive onKeyDown={handleKeyDown} ref={commandRef} className="relative">
 			<CommandInput
 				name={name}
 				ref={inputRef}
@@ -138,7 +138,21 @@ export const AutoComplete = ({
 				icon={icon}
 				data-testid={`autocomplete-${name}`}
 			/>
-			<div className="relative mt-1">
+			{onClear ? (
+				<Button
+					variant="ghost"
+					size="icon"
+					className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+					onClick={() => {
+						setInputValue("");
+						onClear();
+					}}
+				>
+					<X />
+					<span className="sr-only">Clear</span>
+				</Button>
+			) : null}
+			<div className="relative mt-1 flex">
 				<div
 					className={cn(
 						"absolute top-0 z-10 w-full rounded-xl bg-background shadow-lg outline-none animate-in fade-in-0 zoom-in-95",

--- a/packages/ui/src/autocomplete.tsx
+++ b/packages/ui/src/autocomplete.tsx
@@ -46,7 +46,7 @@ export const AutoComplete = ({
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	const [isOpen, setOpen] = useState(false);
-	const [selected, setSelected] = useState<Option | undefined>(value as Option);
+	const [selected, setSelected] = useState<Option>(value as Option);
 	const [inputValue, setInputValue] = useState<string>(value?.label || "");
 
 	const _setInputValue = useCallback(

--- a/packages/ui/src/autocomplete.tsx
+++ b/packages/ui/src/autocomplete.tsx
@@ -42,7 +42,7 @@ export const AutoComplete = ({
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	const [isOpen, setOpen] = useState(false);
-	const [selected, setSelected] = useState<Option|undefined>(value as Option);
+	const [selected, setSelected] = useState<Option | undefined>(value as Option);
 	const [inputValue, setInputValue] = useState<string>(value?.label || "");
 
 	const _setInputValue = useCallback(


### PR DESCRIPTION
## Issue(s) Resolved
Closes https://github.com/pubpub/platform/issues/1235

## High-level Explanation of PR

Configures the member select/autocomplete components so that you can clear their value, either by erasing its contents, or by clicking the 'x' button

## Test Plan

1. Visit http://localhost:3000/c/starter/stages/manage and click on a stage that has an email action (i.e. "Draft"). Or, in the preview environment, go to https://pr-1263-email-action-rec-ip-3-91-78-129.my.preview.run/c/starter/stages/manage?editingStageId=10d974ae-345f-4021-9ca2-e47f15b6b98b
3. Add a recipient member to an action email
4. Save ("Update config" button)
5. Refresh the page
6. Clear the member field by erasing its contents
7. Save 
8. Refresh the page-there should be no member saved

Repeat the steps above, but instead of clearing by erasing its contents, clear by clicking the 'x' button

## Screenshots (if applicable)

https://github.com/user-attachments/assets/c5671fca-d798-4b81-aaa5-a7d25e14fb45



## Notes
