### PR TITLE
trim datacite result to avoid 8kb pg_notify payload violation

### DIFF
--- a/core/actions/datacite/run.ts
+++ b/core/actions/datacite/run.ts
@@ -325,9 +325,7 @@ export const run = defineRun<typeof action>(async ({ pub, config, args, lastModi
 
 	return {
 		data: {
-			depositConfig,
-			depositPayload,
-			depositResult,
+			doi: depositResult.data.attributes.doi,
 		},
 		success: true,
 	};


### PR DESCRIPTION
## Issue(s) Resolved

N/A

## High-level Explanation of PR

This PR simply removes some unused, and maybe unuseful properties from the value returned from the DataCite action upon successful deposit. This should make the DataCite action `action_runs` rows fit into the 8kb payload limit enforced by `pg_notify` for our pseudo-real-time updates.

## Test Plan

N/A