### PR TITLE
fix(minio): use new minio client syntax after breaking change

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -27,7 +27,7 @@ services:
         # this sadly can't be done by just configuring some env vars for minio itself, very annoying, you need to use their mc client. I'm not sure this is the best way to go about doing this.
         entrypoint: >
             /bin/sh -c '
-            /usr/bin/mc config host add myminio http://minio:9000 "$${MINIO_ROOT_USER}" "$${MINIO_ROOT_PASSWORD}";
+            /usr/bin/mc alias set myminio http://minio:9000 "$${MINIO_ROOT_USER}" "$${MINIO_ROOT_PASSWORD}";
             /usr/bin/mc mb --ignore-existing myminio/"$${ASSETS_BUCKET_NAME}";
             /usr/bin/mc anonymous set download myminio/"$${ASSETS_BUCKET_NAME}";
             /usr/bin/mc admin user add myminio "$${ASSETS_UPLOAD_KEY}" "$${ASSETS_UPLOAD_SECRET_KEY}";

--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -126,7 +126,7 @@ services:
     #     env_file: .env
     #     entrypoint: >
     #         /bin/sh -c '
-    #         /usr/bin/mc config host add myminio http://minio:9000 "$${MINIO_ROOT_USER}" "$${MINIO_ROOT_PASSWORD}";
+    #         /usr/bin/mc alias set myminio http://minio:9000 "$${MINIO_ROOT_USER}" "$${MINIO_ROOT_PASSWORD}";
     #         /usr/bin/mc mb --ignore-existing myminio/"$${ASSETS_BUCKET_NAME}";
     #         /usr/bin/mc anonymous set download myminio/"$${ASSETS_BUCKET_NAME}";
     #         /usr/bin/mc admin user add myminio "$${ASSETS_UPLOAD_KEY}" "$${ASSETS_UPLOAD_SECRET_KEY}";


### PR DESCRIPTION

## Issue(s) Resolved


Minio's latest client (https://github.com/minio/minio/releases/tag/RELEASE.2025-05-24T17-08-30Z) had a breaking change which made the old `mc config add` no longer work

This would cause the test in `assets.db.test.ts` to fail, and would also fail the `e2e` tests.

## High-level Explanation of PR

Use newer syntax `mc alias set` rather then old `mc config host add`, which was seeminlgy removed.

## Test Plan

See if tests pass

## Screenshots (if applicable)

## Notes
