### PR TITLE
Allow deleting pubs that have action_runs

### DIFF
--- a/core/prisma/migrations/20250528030323_disable_action_runs_trigger_on_pub_deletes/migration.sql
+++ b/core/prisma/migrations/20250528030323_disable_action_runs_trigger_on_pub_deletes/migration.sql
@@ -1,0 +1,64 @@
+CREATE OR REPLACE FUNCTION notify_change(
+    correct_row jsonb,
+    community_id text,
+    table_name text,
+    operation text
+)
+    RETURNS void AS
+$$
+DECLARE
+    channel_name text;
+BEGIN
+    -- Changed to concat to avoid errors if commmunity_id or table_name are null
+    channel_name = CONCAT('change', '_', community_id, '_', table_name);
+
+    -- construct the notification payload
+    PERFORM pg_notify(
+        channel_name,
+        json_build_object(
+            'table', table_name,
+            'operation', operation,
+            'row', correct_row
+        )::text
+    );
+END;
+$$
+LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION notify_change_action_runs()
+    RETURNS TRIGGER AS
+$$
+DECLARE
+    correct_row jsonb;
+    community_id text;
+BEGIN
+
+    -- Changed the first part of this conditional to return early if the operation is deleting a pub
+    IF (NEW."pubId" IS NULL) THEN
+        RETURN NEW;
+    ELSE
+        correct_row = to_jsonb(NEW);
+    END IF;
+
+
+    select into community_id "communityId" from "pubs" where "id" = correct_row->>'pubId'::text;
+
+    PERFORM notify_change(
+        correct_row,
+        community_id,
+        TG_TABLE_NAME,
+        TG_OP
+    );
+    
+    RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE TRIGGER action_runs_change_trigger
+    AFTER INSERT OR UPDATE -- Removed delete
+    ON action_runs
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_change_action_runs();


### PR DESCRIPTION
## Issue(s) Resolved
Resolves #1258 
## High-level Explanation of PR
The realtime notification trigger was calling `pg_notify` with an empty `channel_name` whenever a pub was deleted that had an `action_run`. This happened for a few reasons:
- When a row from `pubs` is deleted, our cascading behavior is defaulted to `SET NULL`, so `notify_change_action_runs` was run with `TG_OP = 'UPDATE'`
- `select into community_id "communityId" from "pubs" where "id" = correct_row->>'pubId'::text;` would then return NULL because `correct_row->>'pubId'` is NULL
- `notify_change()` would then set `channel_name` to null because we were concatenating with `||` which returns null if any of the arguments are null
- Finally we would get this error: https://kfg.sentry.io/issues/6591520506/?project=4505959187480576&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=0 

I couldn't figure out how to actually get the pubId from `OLD` in the function, and I wasn't sure how this would behave if the channel name was constructed with a missing parameter, so I both fixed the concatenation issue, and stopped the functions from running when a pub is deleted. @tefkah feel free to let me know (or simply change this) if that's overly cautious/you know what the correct fix would be.

## Test Plan
Run any action on a pub, then try to delete it
