### PR TITLE
feat: search on all pub page

### DIFF
--- a/core/app/c/[communitySlug]/ContentLayout.tsx
+++ b/core/app/c/[communitySlug]/ContentLayout.tsx
@@ -30,17 +30,19 @@ export const ContentLayout = ({
 	left,
 	right,
 	children,
+	className,
 }: {
 	title: ReactNode;
 	left?: ReactNode;
 	right?: ReactNode;
 	children: ReactNode;
+	className?: string;
 }) => {
 	return (
 		<div className="absolute inset-0 w-full">
 			<div className="flex h-full flex-col">
 				<Heading title={title} left={left} right={right} />
-				<div className="h-full flex-1 overflow-auto">{children}</div>
+				<div className={`h-full flex-1 overflow-auto ${className || ""}`}>{children}</div>
 			</div>
 		</div>
 	);

--- a/core/app/c/[communitySlug]/pubs/PubList.tsx
+++ b/core/app/c/[communitySlug]/pubs/PubList.tsx
@@ -159,15 +159,17 @@ export const PaginatedPubList: React.FC<PaginatedPubListProps> = async (props) =
 					</Suspense>
 				</PubSearch>
 			</div>
-			<PubListFooterPagination
-				basePath={basePath}
-				searchParams={props.searchParams}
-				page={search.page}
-				communityId={props.communityId}
-				pubsPromise={pubsPromise}
-			>
-				<PubsSelectedCounter pageSize={search.perPage} />
-			</PubListFooterPagination>
+			<Suspense fallback={null}>
+				<PubListFooterPagination
+					basePath={basePath}
+					searchParams={props.searchParams}
+					page={search.page}
+					communityId={props.communityId}
+					pubsPromise={pubsPromise}
+				>
+					<PubsSelectedCounter pageSize={search.perPage} />
+				</PubListFooterPagination>
+			</Suspense>
 		</div>
 	);
 };

--- a/core/app/c/[communitySlug]/pubs/PubList.tsx
+++ b/core/app/c/[communitySlug]/pubs/PubList.tsx
@@ -51,7 +51,7 @@ const PaginatedPubListInner = async (props: PaginatedPubListProps & { communityS
 
 	return (
 		<PubsSelectedProvider pubIds={[]}>
-			<div className="flex flex-col gap-3">
+			<div className="mr-auto flex max-w-screen-lg flex-col gap-3">
 				{pubs.map((pub) => {
 					return (
 						<PubCard
@@ -112,13 +112,16 @@ export const PaginatedPubList: React.FC<PaginatedPubListProps> = async (props) =
 	const basePath = props.basePath ?? `/c/${communitySlug}/pubs`;
 
 	return (
-		<div className={cn("mb-4 flex max-h-screen flex-col gap-3 overflow-y-scroll p-4 pb-16")}>
-			<PubSearch>
-				<Suspense fallback={<PubListSkeleton />}>
-					<PaginatedPubListInner {...props} communitySlug={communitySlug} />
-				</Suspense>
-			</PubSearch>
-
+		<div className="relative flex h-full flex-col">
+			<div
+				className={cn("mb-4 flex h-full w-full flex-col gap-3 overflow-y-scroll p-4 pb-16")}
+			>
+				<PubSearch>
+					<Suspense fallback={<PubListSkeleton />}>
+						<PaginatedPubListInner {...props} communitySlug={communitySlug} />
+					</Suspense>
+				</PubSearch>
+			</div>
 			<PubListFooterPagination
 				basePath={basePath}
 				searchParams={props.searchParams}

--- a/core/app/c/[communitySlug]/pubs/PubSearchInput.tsx
+++ b/core/app/c/[communitySlug]/pubs/PubSearchInput.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import React, { useState } from "react";
+import { Search } from "lucide-react";
+import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
+import { useDebouncedCallback } from "use-debounce";
+
+import { usePlatformModifierKey } from "ui/hooks";
+import { Input } from "ui/input";
+import { cn } from "utils";
+
+type PubSearchProps = React.PropsWithChildren<{}>;
+
+export const PubSearch = (props: PubSearchProps) => {
+	const [query, setQuery] = useQueryStates(
+		{
+			query: parseAsString.withDefault(""),
+			page: parseAsInteger.withDefault(1),
+		},
+		{
+			shallow: false,
+		}
+	);
+	const [value, setValue] = useState(query.query);
+
+	const { symbol, platform } = usePlatformModifierKey();
+
+	const debouncedSetQuery = useDebouncedCallback((value: string) => {
+		if (value.length >= 2 || value.length === 0) {
+			setQuery({ query: value });
+		}
+	}, 500);
+
+	return (
+		<div className="relative flex flex-col gap-4">
+			<div className="sticky top-0 z-20 flex items-center gap-x-2">
+				<Search
+					className="absolute left-2 top-1/2 -translate-y-1/2 text-gray-500"
+					size={16}
+				/>
+				<Input
+					value={value}
+					onChange={(e) => {
+						setValue(e.target.value);
+						debouncedSetQuery(e.target.value);
+					}}
+					placeholder="Search updates as you type..."
+					className="bg-white pl-8 tracking-wide shadow-none"
+				/>
+				<span className="absolute right-2 top-1/2 hidden -translate-y-1/2 items-center gap-x-1 font-mono text-xs text-gray-500 opacity-50 md:flex">
+					<span className={cn(platform === "mac" && "text-lg")}>{symbol}</span> K
+				</span>
+			</div>
+			<div className={cn(value !== query.query && "opacity-50")}>{props.children}</div>
+		</div>
+	);
+};

--- a/core/app/c/[communitySlug]/pubs/PubSearchInput.tsx
+++ b/core/app/c/[communitySlug]/pubs/PubSearchInput.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import React, { useDeferredValue, useEffect, useState } from "react";
+import React, { useDeferredValue, useEffect, useRef, useState } from "react";
 import { Search } from "lucide-react";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useDebouncedCallback } from "use-debounce";
 
-import { usePlatformModifierKey } from "ui/hooks";
+import { KeyboardShortcutPriority, useKeyboardShortcut, usePlatformModifierKey } from "ui/hooks";
 import { Input } from "ui/input";
 import { cn } from "utils";
 
@@ -32,6 +32,19 @@ export const PubSearch = (props: PubSearchProps) => {
 	// without this, we can't only check if inputValue !== query.query,
 	// which only tells us that the debounce has happened
 	const deferredQuery = useDeferredValue(query.query);
+
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useKeyboardShortcut(
+		"Mod+k",
+		() => {
+			inputRef.current?.focus();
+			inputRef.current?.select();
+		},
+		{
+			priority: KeyboardShortcutPriority.MEDIUM,
+		}
+	);
 
 	// sync input with URL when navigating back/forward
 	useEffect(() => {
@@ -60,6 +73,7 @@ export const PubSearch = (props: PubSearchProps) => {
 					size={16}
 				/>
 				<Input
+					ref={inputRef}
 					value={inputValue}
 					onChange={(e) => {
 						setInputValue(e.target.value);

--- a/core/app/c/[communitySlug]/pubs/PubSearchInput.tsx
+++ b/core/app/c/[communitySlug]/pubs/PubSearchInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useDeferredValue, useEffect, useState } from "react";
 import { Search } from "lucide-react";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useDebouncedCallback } from "use-debounce";
@@ -10,6 +10,8 @@ import { Input } from "ui/input";
 import { cn } from "utils";
 
 type PubSearchProps = React.PropsWithChildren<{}>;
+
+const DEBOUNCE_TIME = 300;
 
 export const PubSearch = (props: PubSearchProps) => {
 	const [query, setQuery] = useQueryStates(
@@ -21,15 +23,34 @@ export const PubSearch = (props: PubSearchProps) => {
 			shallow: false,
 		}
 	);
-	const [value, setValue] = useState(query.query);
+
+	// local input state for immediate UI responsiveness + sync with URL
+	// otherwise, when navigating back/forward or refreshing, the input will be empty
+	const [inputValue, setInputValue] = useState(query.query);
+
+	// deferred query to keep track of server updates
+	// without this, we can't only check if inputValue !== query.query,
+	// which only tells us that the debounce has happened
+	const deferredQuery = useDeferredValue(query.query);
+
+	// sync input with URL when navigating back/forward
+	useEffect(() => {
+		if (query.query === inputValue) {
+			return;
+		}
+		setInputValue(query.query);
+	}, [query.query]);
 
 	const { symbol, platform } = usePlatformModifierKey();
 
 	const debouncedSetQuery = useDebouncedCallback((value: string) => {
 		if (value.length >= 2 || value.length === 0) {
-			setQuery({ query: value });
+			setQuery({ query: value, page: 1 }); // reset to page 1 on new search
 		}
-	}, 500);
+	}, DEBOUNCE_TIME);
+
+	// determine if content is stale, in order to provide a visual feedback to the user
+	const isStale = inputValue !== deferredQuery;
 
 	return (
 		<div className="relative flex flex-col gap-4">
@@ -39,9 +60,9 @@ export const PubSearch = (props: PubSearchProps) => {
 					size={16}
 				/>
 				<Input
-					value={value}
+					value={inputValue}
 					onChange={(e) => {
-						setValue(e.target.value);
+						setInputValue(e.target.value);
 						debouncedSetQuery(e.target.value);
 					}}
 					placeholder="Search updates as you type..."
@@ -51,7 +72,9 @@ export const PubSearch = (props: PubSearchProps) => {
 					<span className={cn(platform === "mac" && "text-lg")}>{symbol}</span> K
 				</span>
 			</div>
-			<div className={cn(value !== query.query && "opacity-50")}>{props.children}</div>
+			<div className={cn(isStale && "opacity-50 transition-opacity duration-200")}>
+				{props.children}
+			</div>
 		</div>
 	);
 };

--- a/core/app/c/[communitySlug]/pubs/PubSearchInput.tsx
+++ b/core/app/c/[communitySlug]/pubs/PubSearchInput.tsx
@@ -33,7 +33,7 @@ export const PubSearch = (props: PubSearchProps) => {
 
 	return (
 		<div className="relative flex flex-col gap-4">
-			<div className="sticky top-0 z-20 flex items-center gap-x-2">
+			<div className="sticky top-0 z-20 flex max-w-md items-center gap-x-2">
 				<Search
 					className="absolute left-2 top-1/2 -translate-y-1/2 text-gray-500"
 					size={16}

--- a/core/app/c/[communitySlug]/pubs/PubSearchInput.tsx
+++ b/core/app/c/[communitySlug]/pubs/PubSearchInput.tsx
@@ -71,7 +71,7 @@ export const PubSearch = (props: PubSearchProps) => {
 	const isStale = inputValue !== deferredQuery;
 
 	return (
-		<div className="relative flex flex-col gap-4">
+		<div className="flex flex-col gap-4">
 			<div className="sticky top-0 z-20 flex max-w-md items-center gap-x-2">
 				<Search
 					className="absolute left-2 top-1/2 -translate-y-1/2 text-gray-500"
@@ -98,7 +98,20 @@ export const PubSearch = (props: PubSearchProps) => {
 							<X size={14} />
 						</button>
 					)}
-					<span className={cn(platform === "mac" && "text-lg")}>{symbol}</span> K
+					<span
+						className={cn(
+							"flex w-10 items-center justify-center gap-x-1 transition-opacity duration-200",
+							{
+								// hide until hydrated, otherwise you see flash of `Ctrl` -> `Cmd` on mac
+								"opacity-0": platform === "unknown",
+							}
+						)}
+					>
+						<span className={cn({ "mt-0.5 text-lg": platform === "mac" })}>
+							{symbol}
+						</span>{" "}
+						K
+					</span>
 				</span>
 			</div>
 			<div className={cn(isStale && "opacity-50 transition-opacity duration-200")}>

--- a/core/app/c/[communitySlug]/pubs/PubSearchInput.tsx
+++ b/core/app/c/[communitySlug]/pubs/PubSearchInput.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useDeferredValue, useEffect, useRef, useState } from "react";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useDebouncedCallback } from "use-debounce";
 
@@ -62,6 +62,11 @@ export const PubSearch = (props: PubSearchProps) => {
 		}
 	}, DEBOUNCE_TIME);
 
+	const handleClearInput = () => {
+		setInputValue("");
+		setQuery({ query: "", page: 1 });
+	};
+
 	// determine if content is stale, in order to provide a visual feedback to the user
 	const isStale = inputValue !== deferredQuery;
 
@@ -80,9 +85,19 @@ export const PubSearch = (props: PubSearchProps) => {
 						debouncedSetQuery(e.target.value);
 					}}
 					placeholder="Search updates as you type..."
-					className="bg-white pl-8 tracking-wide shadow-none"
+					className={cn("bg-white pl-8 tracking-wide shadow-none", inputValue && "pr-8")}
 				/>
-				<span className="absolute right-2 top-1/2 hidden -translate-y-1/2 items-center gap-x-1 font-mono text-xs text-gray-500 opacity-50 md:flex">
+				<span className="absolute right-2 top-1/2 hidden -translate-y-1/2 items-center gap-x-2 font-mono text-xs text-gray-500 opacity-50 md:flex">
+					{inputValue && (
+						<button
+							onClick={handleClearInput}
+							className="rounded-full p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 md:right-16"
+							type="button"
+							aria-label="Clear search"
+						>
+							<X size={14} />
+						</button>
+					)}
 					<span className={cn(platform === "mac" && "text-lg")}>{symbol}</span> K
 				</span>
 			</div>

--- a/core/app/c/[communitySlug]/pubs/PubSelector.tsx
+++ b/core/app/c/[communitySlug]/pubs/PubSelector.tsx
@@ -10,6 +10,7 @@ export const PubSelector = ({ pubId, className }: { pubId: PubsId; className?: s
 
 	return (
 		<Checkbox
+			aria-label="Select pub"
 			checked={isSelected(pubId)}
 			onCheckedChange={() => {
 				toggle(pubId);

--- a/core/app/c/[communitySlug]/pubs/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 
+import { Suspense } from "react";
 import Link from "next/link";
 import { BookOpen } from "lucide-react";
 
@@ -8,6 +9,7 @@ import { Button } from "ui/button";
 
 import { FooterPagination } from "~/app/components/Pagination";
 import { CreatePubButton } from "~/app/components/pubs/CreatePubButton";
+import { SkeletonButton } from "~/app/components/skeletons/SkeletonButton";
 import { getPageLoginData } from "~/lib/authentication/loginData";
 import { env } from "~/lib/env/env";
 import { findCommunityBySlug } from "~/lib/server/community";
@@ -40,7 +42,6 @@ export default async function Page(props: Props) {
 	const basePath = `/c/${community.slug}/pubs`;
 
 	return (
-		// Position absolute to remove the parent layout padding so that the footer can hug the bottom properly
 		<ContentLayout
 			title={
 				<>
@@ -52,12 +53,15 @@ export default async function Page(props: Props) {
 					<Button variant="ghost" size="sm" asChild>
 						<Link href="types">Manage Types</Link>
 					</Button>
-					<CreatePubButton
-						communityId={community.id as CommunitiesId}
-						className="bg-emerald-500 text-white"
-					/>
+					<Suspense fallback={<SkeletonButton className="h-6 w-20" />}>
+						<CreatePubButton
+							communityId={community.id as CommunitiesId}
+							className="bg-emerald-500 text-white"
+						/>
+					</Suspense>
 				</div>
 			}
+			className="overflow-hidden"
 		>
 			<PaginatedPubList
 				communityId={community.id}

--- a/core/app/c/[communitySlug]/pubs/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/page.tsx
@@ -1,11 +1,17 @@
 import type { Metadata } from "next";
 
+import Link from "next/link";
+import { BookOpen } from "lucide-react";
+
 import type { CommunitiesId } from "db/public";
+import { Button } from "ui/button";
 
 import { FooterPagination } from "~/app/components/Pagination";
+import { CreatePubButton } from "~/app/components/pubs/CreatePubButton";
 import { getPageLoginData } from "~/lib/authentication/loginData";
 import { env } from "~/lib/env/env";
 import { findCommunityBySlug } from "~/lib/server/community";
+import { ContentLayout } from "../ContentLayout";
 import PubHeader from "./PubHeader";
 import { PaginatedPubList } from "./PubList";
 
@@ -21,9 +27,11 @@ type Props = {
 export default async function Page(props: Props) {
 	const searchParams = await props.searchParams;
 	const params = await props.params;
-	const { user } = await getPageLoginData();
 
-	const community = await findCommunityBySlug(params.communitySlug);
+	const [{ user }, community] = await Promise.all([
+		getPageLoginData(),
+		findCommunityBySlug(params.communitySlug),
+	]);
 
 	if (!community) {
 		return null;
@@ -33,10 +41,26 @@ export default async function Page(props: Props) {
 
 	return (
 		// Position absolute to remove the parent layout padding so that the footer can hug the bottom properly
-		<div className="absolute bottom-0 left-0 right-0 top-0">
+		<ContentLayout
+			title={
+				<>
+					<BookOpen size={24} strokeWidth={1} className="mr-2 text-gray-500" /> Pubs
+				</>
+			}
+			right={
+				<div className="flex items-center gap-x-2">
+					<Button variant="ghost" size="sm" asChild>
+						<Link href="types">Manage Types</Link>
+					</Button>
+					<CreatePubButton
+						communityId={community.id as CommunitiesId}
+						className="bg-emerald-500 text-white"
+					/>
+				</div>
+			}
+		>
 			{/* Restore layout padding, but give extra bottom padding so that last item is not covered by the footer */}
-			<div className="mb-4 max-h-screen overflow-y-scroll px-4 py-4 pb-16 md:px-12">
-				<PubHeader communityId={community.id as CommunitiesId} />
+			<div className="">
 				<PaginatedPubList
 					communityId={community.id}
 					searchParams={searchParams}
@@ -44,6 +68,6 @@ export default async function Page(props: Props) {
 					userId={user.id}
 				/>
 			</div>
-		</div>
+		</ContentLayout>
 	);
 }

--- a/core/app/c/[communitySlug]/pubs/page.tsx
+++ b/core/app/c/[communitySlug]/pubs/page.tsx
@@ -59,15 +59,12 @@ export default async function Page(props: Props) {
 				</div>
 			}
 		>
-			{/* Restore layout padding, but give extra bottom padding so that last item is not covered by the footer */}
-			<div className="">
-				<PaginatedPubList
-					communityId={community.id}
-					searchParams={searchParams}
-					basePath={basePath}
-					userId={user.id}
-				/>
-			</div>
+			<PaginatedPubList
+				communityId={community.id}
+				searchParams={searchParams}
+				basePath={basePath}
+				userId={user.id}
+			/>
 		</ContentLayout>
 	);
 }

--- a/core/app/c/[communitySlug]/stages/components/StageList.tsx
+++ b/core/app/c/[communitySlug]/stages/components/StageList.tsx
@@ -12,7 +12,6 @@ import { PubCard } from "~/app/components/PubCard";
 import { getStageActions } from "~/lib/db/queries";
 import { getPubsWithRelatedValues } from "~/lib/server";
 import { getCommunitySlug } from "~/lib/server/cache/getCommunitySlug";
-import { findCommunityBySlug } from "~/lib/server/community";
 import { selectAllCommunityMemberships } from "~/lib/server/member";
 import { getStages } from "~/lib/server/stages";
 import { getOrderedStages } from "~/lib/stages";
@@ -101,9 +100,8 @@ export async function StagePubs({
 	basePath: string;
 	userId: UsersId;
 }) {
-	const [communitySlug, stages, stagePubs, actionInstances] = await Promise.all([
+	const [communitySlug, stagePubs, actionInstances] = await Promise.all([
 		getCommunitySlug(),
-		getStages({ communityId: stage.communityId, userId }).execute(),
 		getPubsWithRelatedValues(
 			{ stageId: [stage.id], communityId: stage.communityId },
 			{
@@ -140,7 +138,8 @@ export async function StagePubs({
 								withRelatedPubs: false;
 							}>
 						}
-						stages={stages}
+						moveFrom={stage.moveConstraintSources}
+						moveTo={stage.moveConstraints}
 						actionInstances={actionInstances}
 						communitySlug={communitySlug}
 						withSelection={false}

--- a/core/app/components/DataTable/PubsDataTable/validations.ts
+++ b/core/app/components/DataTable/PubsDataTable/validations.ts
@@ -2,7 +2,7 @@
 
 import type { inferParserType } from "nuqs/server";
 
-import { createSearchParamsCache, parseAsInteger } from "nuqs/server";
+import { createSearchParamsCache, parseAsInteger, parseAsString } from "nuqs/server";
 
 import type { ProcessedPub } from "contracts";
 import { getSortingStateParser } from "ui/data-table-paged";
@@ -14,6 +14,7 @@ export type DataTableSearchParams = inferParserType<typeof dataTableParsers>;
 export const dataTableParsers = {
 	page: parseAsInteger.withDefault(1),
 	perPage: parseAsInteger.withDefault(DEFAULT_PAGE_SIZE),
+	query: parseAsString.withDefault(""),
 	sort: getSortingStateParser<
 		ProcessedPub<{
 			withPubType: true;

--- a/core/app/components/Pagination.tsx
+++ b/core/app/components/Pagination.tsx
@@ -138,17 +138,24 @@ export const FooterPagination = ({
 	page,
 	totalPages,
 	children,
+	className,
 }: {
 	basePath: string;
 	searchParams: Record<string, unknown>;
 	page: number;
 	totalPages: number;
 	children?: React.ReactNode;
+	className?: string;
 }) => {
 	const nextDisabled = page >= totalPages;
 	const prevDisabled = page <= 1;
 	return (
-		<div className="absolute bottom-0 left-0 flex w-full flex-col items-center justify-between gap-2 border-t border-gray-300 bg-white px-4 py-2 text-sm leading-[19px] shadow-[4px_0px_10px_-1px_rgba(0,0,0,0.2)] md:flex-row">
+		<div
+			className={cn(
+				"absolute bottom-0 left-0 flex w-full flex-col items-center justify-between gap-2 border-t border-gray-300 bg-white px-4 py-2 text-sm leading-[19px] shadow-[4px_0px_10px_-1px_rgba(0,0,0,0.2)] md:flex-row",
+				className
+			)}
+		>
 			<ResultsPerPageInput />
 			<Pagination
 				className={cn("items-center gap-2 lg:gap-8", { "mx-0 justify-end": !children })}

--- a/core/app/components/Pagination.tsx
+++ b/core/app/components/Pagination.tsx
@@ -132,23 +132,30 @@ export const BasicPagination = (props: {
 	);
 };
 
-export const FooterPagination = ({
-	basePath,
-	searchParams,
-	page,
-	totalPages,
-	children,
-	className,
-}: {
-	basePath: string;
-	searchParams: Record<string, unknown>;
-	page: number;
-	totalPages: number;
-	children?: React.ReactNode;
-	className?: string;
-}) => {
-	const nextDisabled = page >= totalPages;
+export const FooterPagination = (
+	props: {
+		basePath: string;
+		searchParams: Record<string, unknown>;
+		page: number;
+		children?: React.ReactNode;
+		className?: string;
+	} & (
+		| {
+				mode: "total";
+				totalPages: number;
+		  }
+		| {
+				mode: "cursor";
+				hasNextPage: boolean;
+		  }
+	)
+) => {
+	const { basePath, searchParams, page, children, className } = props;
+
 	const prevDisabled = page <= 1;
+	const nextDisabled = props.mode === "total" ? page >= props.totalPages : !props.hasNextPage;
+	const showLastButton = props.mode === "total";
+
 	return (
 		<div
 			className={cn(
@@ -160,9 +167,13 @@ export const FooterPagination = ({
 			<Pagination
 				className={cn("items-center gap-2 lg:gap-8", { "mx-0 justify-end": !children })}
 			>
-				<span className="whitespace-nowrap">
-					Page {page} of {totalPages}
-				</span>
+				{props.mode === "total" ? (
+					<span className="whitespace-nowrap">
+						Page {page} of {props.totalPages}
+					</span>
+				) : (
+					<span className="whitespace-nowrap">Page {page}</span>
+				)}
 
 				<PaginationContent className="gap-2">
 					<PaginationFirst
@@ -201,18 +212,20 @@ export const FooterPagination = ({
 							query: { ...searchParams, page: page + 1 },
 						}}
 					/>
-					<PaginationLast
-						iconOnly
-						aria-disabled={nextDisabled}
-						tabIndex={nextDisabled ? -1 : undefined}
-						className={cn("border px-3 py-3", {
-							"pointer-events-none opacity-50": nextDisabled,
-						})}
-						href={{
-							pathname: basePath,
-							query: { ...searchParams, page: totalPages },
-						}}
-					/>
+					{showLastButton && (
+						<PaginationLast
+							iconOnly
+							aria-disabled={nextDisabled}
+							tabIndex={nextDisabled ? -1 : undefined}
+							className={cn("border px-3 py-3", {
+								"pointer-events-none opacity-50": nextDisabled,
+							})}
+							href={{
+								pathname: basePath,
+								query: { ...searchParams, page: props.totalPages },
+							}}
+						/>
+					)}
 				</PaginationContent>
 			</Pagination>
 			{children}

--- a/core/app/components/PathAwareDialog.tsx
+++ b/core/app/components/PathAwareDialog.tsx
@@ -72,6 +72,7 @@ export const PathAwareDialog = forwardRef((props: PathAwareDialogProps, ref) => 
 					size={props.buttonSize ?? "sm"}
 					className={cn("flex items-center gap-x-2 py-4", props.className)}
 					disabled={props.disabled}
+					aria-label={props.buttonLabel ?? props.buttonText}
 				>
 					{props.icon}
 					<span className={cn({ "sr-only": props.iconOnly })}>{props.buttonText}</span>

--- a/core/app/components/PubCard.tsx
+++ b/core/app/components/PubCard.tsx
@@ -1,10 +1,10 @@
+import React from "react";
 import Link from "next/link";
 
 import type { ProcessedPub } from "contracts";
 import type { ActionInstances } from "db/public";
 import { Button } from "ui/button";
 import { Card, CardDescription, CardFooter, CardTitle } from "ui/card";
-import { Checkbox } from "ui/checkbox";
 import { Calendar, ChevronDown, FlagTriangleRightIcon, History, Pencil, Trash2 } from "ui/icon";
 import { cn } from "utils";
 
@@ -92,13 +92,42 @@ export const PubCard = async ({
 							href={`/c/${communitySlug}/pubs/${pub.id}`}
 							className={cn("hover:underline", LINK_AFTER)}
 						>
-							{getPubTitle(pub)}
+							<div
+								className="[&_mark]:bg-yellow-300"
+								dangerouslySetInnerHTML={{ __html: getPubTitle(pub) }}
+							/>
 						</Link>
 					</h3>
 				</CardTitle>
-				<CardDescription className="min-w-0 truncate">
-					<PubDescription pub={pub} />
-				</CardDescription>
+				{"description" in pub && (
+					<CardDescription className="min-w-0 truncate">
+						<PubDescription pub={pub} />
+					</CardDescription>
+				)}
+
+				{pub.matchingValues && pub.matchingValues.length > 0 && (
+					<div
+						className={cn(
+							"grid gap-1 text-xs text-gray-500 [grid-template-columns:minmax(0rem,auto)_minmax(0,1fr)]",
+							"[&_mark]:bg-yellow-200"
+						)}
+					>
+						{/* Matching values that aren't titles */}
+						{pub.matchingValues
+							.filter((match) => !match.isTitle)
+							.map((match, idx) => (
+								<React.Fragment key={idx}>
+									<span className="font-medium">{match.name}:</span>
+									<span
+										dangerouslySetInnerHTML={{
+											__html: match.highlights,
+										}}
+										className="font-light text-gray-600"
+									/>
+								</React.Fragment>
+							))}
+					</div>
+				)}
 				<CardFooter className="flex gap-2 p-0 text-xs text-gray-600">
 					<div className="flex gap-1" title="Created at">
 						<Calendar size="16px" strokeWidth="1px" className="text-neutral-500" />

--- a/core/app/components/PubCard.tsx
+++ b/core/app/components/PubCard.tsx
@@ -47,6 +47,9 @@ export const PubCard = async ({
 	actionInstances: ActionInstances[];
 	withSelection?: boolean;
 }) => {
+	const matchingValues = pub.matchingValues?.filter((match) => !match.isTitle);
+
+	const showMatchingValues = matchingValues && matchingValues.length !== 0;
 	return (
 		<Card
 			className="group relative flex items-center justify-between gap-2 rounded-md border border-gray-200 bg-white px-3 py-2 has-[[data-state=checked]]:border-blue-500"
@@ -69,7 +72,7 @@ export const PubCard = async ({
 							button={
 								<Button
 									variant="outline"
-									className="h-[22px] gap-0.5 rounded-[104px] px-2 px-[.35rem] text-xs font-semibold shadow-none"
+									className="h-[22px] gap-0.5 rounded-[104px] px-[.35rem] text-xs font-semibold shadow-none"
 								>
 									<FlagTriangleRightIcon
 										strokeWidth="1px"
@@ -102,7 +105,7 @@ export const PubCard = async ({
 				<CardDescription className="m-0 min-w-0 truncate p-0">
 					<PubDescription pub={pub} />
 				</CardDescription>
-				{pub.matchingValues && pub.matchingValues.length > 0 && (
+				{showMatchingValues && (
 					<div
 						className={cn(
 							"grid gap-1 text-xs text-gray-500 [grid-template-columns:minmax(0rem,auto)_minmax(0,1fr)]",
@@ -110,19 +113,17 @@ export const PubCard = async ({
 						)}
 					>
 						{/* Matching values that aren't titles */}
-						{pub.matchingValues
-							.filter((match) => !match.isTitle)
-							.map((match, idx) => (
-								<React.Fragment key={idx}>
-									<span className="font-medium">{match.name}:</span>
-									<span
-										dangerouslySetInnerHTML={{
-											__html: match.highlights,
-										}}
-										className="font-light text-gray-600"
-									/>
-								</React.Fragment>
-							))}
+						{matchingValues.map((match, idx) => (
+							<React.Fragment key={idx}>
+								<span className="font-medium">{match.name}:</span>
+								<span
+									dangerouslySetInnerHTML={{
+										__html: match.highlights,
+									}}
+									className="font-light text-gray-600"
+								/>
+							</React.Fragment>
+						))}
 					</div>
 				)}
 				<CardFooter className="flex gap-2 p-0 text-xs text-gray-600">

--- a/core/app/components/PubCard.tsx
+++ b/core/app/components/PubCard.tsx
@@ -99,12 +99,9 @@ export const PubCard = async ({
 						</Link>
 					</h3>
 				</CardTitle>
-				{"description" in pub && (
-					<CardDescription className="min-w-0 truncate">
-						<PubDescription pub={pub} />
-					</CardDescription>
-				)}
-
+				<CardDescription className="m-0 min-w-0 truncate p-0">
+					<PubDescription pub={pub} />
+				</CardDescription>
 				{pub.matchingValues && pub.matchingValues.length > 0 && (
 					<div
 						className={cn(

--- a/core/app/components/SearchDialog.tsx
+++ b/core/app/components/SearchDialog.tsx
@@ -14,6 +14,7 @@ import {
 	CommandItem,
 	CommandList,
 } from "ui/command";
+import { KeyboardShortcutPriority, useKeyboardShortcut } from "ui/hooks";
 import { AlertCircle, Loader2 } from "ui/icon";
 
 import type { fullTextSearch } from "~/lib/server/pub";
@@ -54,21 +55,14 @@ export function SearchDialog({ defaultOpen, onOpenChange, onPubSelect }: SearchD
 		},
 	});
 
-	// CMD+K handler
-	useEffect(() => {
-		const down = (e: KeyboardEvent) => {
-			if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
-				e.preventDefault();
-				onOpenChange?.(true);
-				setOpen(true);
-			}
-		};
-
-		document.addEventListener("keydown", down);
-		return () => document.removeEventListener("keydown", down);
-	}, [onOpenChange]);
+	useKeyboardShortcut("Mod+k", () => {
+		console.log("Mod+k");
+		onOpenChange?.(true);
+		setOpen(true);
+	});
 
 	const router = useRouter();
+
 	return (
 		<CommandDialog
 			open={open}

--- a/core/app/components/SearchDialog.tsx
+++ b/core/app/components/SearchDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useDebounce } from "use-debounce";
@@ -14,7 +14,7 @@ import {
 	CommandItem,
 	CommandList,
 } from "ui/command";
-import { KeyboardShortcutPriority, useKeyboardShortcut } from "ui/hooks";
+import { useKeyboardShortcut } from "ui/hooks";
 import { AlertCircle, Loader2 } from "ui/icon";
 
 import type { fullTextSearch } from "~/lib/server/pub";
@@ -56,7 +56,6 @@ export function SearchDialog({ defaultOpen, onOpenChange, onPubSelect }: SearchD
 	});
 
 	useKeyboardShortcut("Mod+k", () => {
-		console.log("Mod+k");
 		onOpenChange?.(true);
 		setOpen(true);
 	});

--- a/core/app/components/pubs/CreatePubButton.tsx
+++ b/core/app/components/pubs/CreatePubButton.tsx
@@ -109,8 +109,6 @@ export const CreatePubButton = async (props: Props) => {
 
 	const pubTypes = await getCreatablePubTypes(user.id, community.id).execute();
 
-	logger.debug({ msg: "Creatable pub types", pubTypes, community });
-
 	const stageId = "stageId" in props ? props.stageId : undefined;
 
 	return (

--- a/core/app/components/pubs/CreatePubButton.tsx
+++ b/core/app/components/pubs/CreatePubButton.tsx
@@ -94,14 +94,11 @@ type Props = {
 export const CreatePubButton = async (props: Props) => {
 	const id = "stageId" in props ? props.stageId : props.communityId;
 
-	const communitySlug = await getCommunitySlug();
-	const community = await findCommunityBySlug(communitySlug);
+	const [community, { user }] = await Promise.all([findCommunityBySlug(), getLoginData()]);
 
 	if (!community) {
 		return null;
 	}
-
-	const { user } = await getLoginData();
 
 	if (!user) {
 		return null;

--- a/core/app/layout.tsx
+++ b/core/app/layout.tsx
@@ -4,6 +4,7 @@ import "ui/styles.css";
 
 import { Suspense } from "react";
 
+import { KeyboardShortcutProvider } from "ui/hooks";
 // import "./globals.css";
 
 import { TooltipProvider } from "ui/tooltip";
@@ -20,16 +21,18 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 	return (
 		<html lang="en">
 			<body>
-				<ReactQueryProvider>
-					<NuqsAdapter>
-						<TooltipProvider>
-							{children}
-							<Suspense>
-								<RootToaster />
-							</Suspense>
-						</TooltipProvider>
-					</NuqsAdapter>
-				</ReactQueryProvider>
+				<KeyboardShortcutProvider>
+					<ReactQueryProvider>
+						<NuqsAdapter>
+							<TooltipProvider>
+								{children}
+								<Suspense>
+									<RootToaster />
+								</Suspense>
+							</TooltipProvider>
+						</NuqsAdapter>
+					</ReactQueryProvider>
+				</KeyboardShortcutProvider>
 			</body>
 		</html>
 	);

--- a/core/lib/authentication/loginData.ts
+++ b/core/lib/authentication/loginData.ts
@@ -21,18 +21,20 @@ export const getLoginData = cache(async (opts?: ExtraSessionValidationOptions) =
 	return validateRequest(opts);
 });
 
+const defaultPageOpts: ExtraSessionValidationOptions & LoginRedirectOpts = {
+	allowedSessions: [AuthTokenType.generic, AuthTokenType.verifyEmail],
+};
+
 /**
  * Get the login data for the current page, and redirect to the login page if the user is not logged in.
  */
 export const getPageLoginData = cache(
 	async (opts?: ExtraSessionValidationOptions & LoginRedirectOpts) => {
-		const loginData = await getLoginData({
-			...opts,
-			allowedSessions: [AuthTokenType.generic, AuthTokenType.verifyEmail],
-		});
+		const options = opts ?? defaultPageOpts;
+		const loginData = await getLoginData(options);
 
 		if (!loginData.user) {
-			redirectToLogin(opts);
+			redirectToLogin(options);
 		}
 
 		if (loginData.session && loginData.session.type === AuthTokenType.verifyEmail) {

--- a/core/lib/authentication/lucia.ts
+++ b/core/lib/authentication/lucia.ts
@@ -233,6 +233,15 @@ const defaultOptions = {
 } as const satisfies ExtraSessionValidationOptions;
 
 /**
+ * Separately cache this call because validateRequest can be called with different options
+ * leading to cache misses
+ */
+const validateLuciaSession = cache(async (sessionId: string) => {
+	const result = await lucia.validateSession(sessionId);
+	return result;
+});
+
+/**
  * Get the session and corresponding user from cookies
  *
  * Also extends the session cookie with the updated expiration date, keeping it fresh,
@@ -263,7 +272,7 @@ export const validateRequest = cache(
 			};
 		}
 
-		const result = await lucia.validateSession(sessionId);
+		const result = await validateLuciaSession(sessionId);
 
 		// do not allow unspecified sessions
 		// eg prevent generic session from being used for password reset

--- a/core/lib/server/pub.fts.db.test.ts
+++ b/core/lib/server/pub.fts.db.test.ts
@@ -221,3 +221,87 @@ describe("fullTextSearch", () => {
 		expect(invalidResults).toHaveLength(0);
 	});
 });
+
+describe("searching", () => {
+	it("should find pubs by full text search", async () => {
+		// const { community, pubFields, pubTypes } = await seedCommunity(seed);
+
+		const trx = getTrx();
+		const seeded = await seed(trx);
+
+		const { getPubsWithRelatedValues } = await import("./pub");
+
+		// search for "machine learning" - should find pub1
+		const searchResults1 = await getPubsWithRelatedValues(
+			{ communityId: seeded.community.id },
+			{
+				search: "machine",
+				withRelatedPubs: false,
+				withValues: false,
+				withPubType: true,
+				withStage: true,
+			}
+		);
+
+		expect(searchResults1).toHaveLength(1);
+
+		// search for "climate" - should find pub2
+		const searchResults2 = await getPubsWithRelatedValues(
+			{ communityId: seeded.community.id },
+			{ search: "machine" }
+		);
+
+		expect(searchResults2).toHaveLength(1);
+
+		// search for "research" - should find pub1 (in title)
+		const searchResults3 = await getPubsWithRelatedValues(
+			{ communityId: seeded.community.id },
+			{ search: "machine" }
+		);
+
+		expect(searchResults3).toHaveLength(1);
+	});
+
+	it("should return empty results for non-matching search terms", async () => {
+		const trx = getTrx();
+		const seeded = await seed(trx);
+		const { getPubsWithRelatedValues } = await import("./pub");
+
+		const searchResults = await getPubsWithRelatedValues(
+			{ communityId: seeded.community.id },
+			{ search: "nonexistent term" }
+		);
+
+		expect(searchResults).toHaveLength(0);
+	});
+
+	it("should handle search with multiple terms", async () => {
+		const trx = getTrx();
+		const seeded = await seed(trx);
+		const { getPubsWithRelatedValues } = await import("./pub");
+
+		// search with multiple terms - should find the pub
+		const searchResults = await getPubsWithRelatedValues(
+			{ communityId: seeded.community.id },
+			{ search: "machine learning neural" }
+		);
+
+		expect(searchResults).toHaveLength(1);
+	});
+
+	it("should combine search with other filters", async () => {
+		const trx = getTrx();
+		const seeded = await seed(trx);
+		const { getPubsWithRelatedValues } = await import("./pub");
+
+		// create pubs of different types
+
+		// search for "machine" but only in basic pubs
+		const searchResults = await getPubsWithRelatedValues(
+			{ communityId: seeded.community.id, pubTypeId: [seeded.pubTypes["Basic Pub"].id] },
+			{ search: "machine" }
+		);
+
+		expect(searchResults).toHaveLength(1);
+	});
+});

--- a/core/stories/PubCard.stories.tsx
+++ b/core/stories/PubCard.stories.tsx
@@ -30,7 +30,8 @@ const meta: Meta<typeof PubCard> = {
 	args: {
 		pub: pub,
 		communitySlug: "test-community",
-		stages,
+		moveFrom: [],
+		moveTo: [],
 		actionInstances: [
 			{
 				action: Action.log,

--- a/packages/contracts/src/resources/site.ts
+++ b/packages/contracts/src/resources/site.ts
@@ -194,6 +194,17 @@ export type MaybePubOptions = {
 	 * @default false
 	 */
 	withRelatedCounts?: boolean;
+
+	/**
+	 * The search query to use for matching values
+	 */
+	search?: string;
+
+	/**
+	 * Whether to include matched and highlighted values
+	 * @default true if `search` is defined
+	 */
+	withSearchValues?: boolean;
 };
 
 /**
@@ -259,6 +270,20 @@ type ProcessedPubBase = {
 	updatedAt: Date;
 };
 
+type MaybeSearchResults<Options extends MaybePubOptions> = Options["search"] extends undefined
+	? { matchingValues?: never }
+	: Options["withSearchValues"] extends false
+		? { matchingValues?: never }
+		: {
+				matchingValues?: {
+					slug: string;
+					name: string;
+					value: Json;
+					isTitle: boolean;
+					highlights: string;
+				}[];
+			};
+
 export type ProcessedPub<Options extends MaybePubOptions = {}> = ProcessedPubBase & {
 	/**
 	 * Is an empty array if `withValues` is false
@@ -267,7 +292,8 @@ export type ProcessedPub<Options extends MaybePubOptions = {}> = ProcessedPubBas
 } & MaybePubStage<Options> &
 	MaybePubPubType<Options> &
 	MaybePubMembers<Options> &
-	MaybePubRelatedCounts<Options>;
+	MaybePubRelatedCounts<Options> &
+	MaybeSearchResults<Options>;
 
 export type ProcessedPubWithForm<
 	Options extends Omit<MaybePubOptions, "withValues" & { withValues: true }> = {},

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./useLocalStorage";
 export * from "./useUnsavedChangesWarning";
 export * from "./usePlatform";
+export * from "./useKeyBoardShortcut";

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./useLocalStorage";
 export * from "./useUnsavedChangesWarning";
+export * from "./usePlatform";

--- a/packages/ui/src/hooks/useKeyBoardShortcut.tsx
+++ b/packages/ui/src/hooks/useKeyBoardShortcut.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import type { PropsWithChildren } from "react";
+
+import { useEffect } from "react";
+import * as React from "react";
+
+import type { Platform } from "./usePlatform";
+import { usePlatform } from "./usePlatform";
+
+/**
+ * The priority of the keyboard shortcut.
+ *
+ * If you find yourself using HIGH, question whether you really need to
+ */
+export enum KeyboardShortcutPriority {
+	LOW = 0,
+	MEDIUM = 1,
+	HIGH = 2,
+}
+
+interface KeyboardShortcut {
+	key: string;
+	modifiers: {
+		ctrl?: true;
+		meta?: true;
+		shift?: true;
+		alt?: true;
+		mod?: true;
+	};
+	/**
+	 * If true, the shortcut will continue to be triggered even if the key is held down.
+	 * @default false
+	 */
+	allowRepeat?: boolean;
+	handler: (event: KeyboardEvent) => void;
+	priority: KeyboardShortcutPriority; // higher number = higher priority
+}
+
+interface KeyboardShortcutContextType {
+	register: (shortcut: KeyboardShortcut) => () => void;
+}
+
+const KeyboardShortcutContext = React.createContext<KeyboardShortcutContextType | null>(null);
+
+const isMatchingEvent = (event: KeyboardEvent, shortcut: KeyboardShortcut, platform: Platform) => {
+	if (!shortcut.allowRepeat && event.repeat) {
+		return false;
+	}
+
+	const { modifiers } = shortcut;
+
+	let ctrlMatch = true;
+	let metaMatch = true;
+
+	if (modifiers.mod !== undefined) {
+		if (platform === "mac") {
+			// on mac, mod = meta (cmd)
+			metaMatch = modifiers.mod === event.metaKey;
+		} else {
+			// on other platforms, mod = ctrl
+			ctrlMatch = modifiers.mod === event.ctrlKey;
+		}
+	}
+
+	// check explicit modifier matches (these override mod if specified)
+	if (modifiers.ctrl !== undefined) {
+		ctrlMatch = modifiers.ctrl === event.ctrlKey;
+	}
+	if (modifiers.meta !== undefined) {
+		metaMatch = modifiers.meta === event.metaKey;
+	}
+
+	const shiftMatch = modifiers.shift === undefined || modifiers.shift === event.shiftKey;
+	const altMatch = modifiers.alt === undefined || modifiers.alt === event.altKey;
+
+	return ctrlMatch && metaMatch && shiftMatch && altMatch;
+};
+
+export function KeyboardShortcutProvider({ children }: PropsWithChildren) {
+	const shortcutsRef = React.useRef<Map<string, KeyboardShortcut[]>>(new Map());
+	const platform = usePlatform();
+
+	React.useEffect(() => {
+		const handleKeyDown = (event: KeyboardEvent) => {
+			const key = event.key.toLowerCase();
+			const shortcuts = shortcutsRef.current.get(key) || [];
+			event.code;
+
+			const sortedShortcuts = [...shortcuts].sort((a, b) => b.priority - a.priority);
+
+			for (const shortcut of sortedShortcuts) {
+				const matching = isMatchingEvent(event, shortcut, platform);
+
+				if (matching) {
+					event.preventDefault();
+					shortcut.handler(event);
+					return;
+				}
+			}
+		};
+
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, [platform]);
+
+	const register = (shortcut: KeyboardShortcut) => {
+		const key = shortcut.key.toLowerCase();
+		const shortcuts = shortcutsRef.current.get(key) || [];
+		shortcuts.push(shortcut);
+		shortcutsRef.current.set(key, shortcuts);
+
+		return () => {
+			const currentShortcuts = shortcutsRef.current.get(key) || [];
+			const filtered = currentShortcuts.filter((s) => s !== shortcut);
+			if (filtered.length === 0) {
+				shortcutsRef.current.delete(key);
+			} else {
+				shortcutsRef.current.set(key, filtered);
+			}
+		};
+	};
+
+	return (
+		<KeyboardShortcutContext.Provider value={{ register }}>
+			{children}
+		</KeyboardShortcutContext.Provider>
+	);
+}
+
+type Modifiers = "Mod" | "Ctrl" | "Shift" | "Alt" | "Meta";
+
+// prettier-ignore
+type Keys = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j" | "k" | "l" | "m" | "n" | "o" | "p" | "q" | "r" | "s" | "t" | "u" | "v" | "w" | "x" | "y" | "z" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "0" | "F1" | "F2" | "F3" | "F4" | "F5" | "F6" | "F7" | "F8" | "F9" | "F10" | "F11" | "F12" | "ArrowUp" | "ArrowDown" | "ArrowLeft" | "ArrowRight" | "Enter" | "Escape" | "Backspace" | "Tab" | "Space" | "Delete" | "Home" | "End" | "PageUp" | "PageDown" | "CapsLock" | "NumLock" | "ScrollLock" | "Pause" | "PrintScreen" | "Insert";
+
+export type KeyCombination =
+	| `${Modifiers}+${Keys}`
+	| `${Modifiers}+${Modifiers}+${Keys}`
+	| `${Modifiers}+${Modifiers}+${Modifiers}+${Keys}`
+	| `${Modifiers}+${Modifiers}+${Modifiers}+${Modifiers}+${Keys}`;
+
+export function parseKeyboardShortcut(
+	shortcut: string
+): Pick<KeyboardShortcut, "key" | "modifiers"> {
+	const [modifiers, key] = shortcut.split("+");
+
+	return {
+		modifiers: {
+			ctrl: modifiers.includes("Ctrl") || undefined,
+			meta: modifiers.includes("Meta") || undefined,
+			shift: modifiers.includes("Shift") || undefined,
+			alt: modifiers.includes("Alt") || undefined,
+			mod: modifiers.includes("Mod") || undefined,
+		},
+		key: key.toLowerCase(),
+	};
+}
+
+const defaultOptions: Pick<KeyboardShortcut, "priority" | "allowRepeat"> = {
+	priority: KeyboardShortcutPriority.LOW,
+	allowRepeat: false,
+};
+
+export function useKeyboardShortcut(
+	shortcut: KeyCombination,
+	handler: KeyboardShortcut["handler"],
+	options?: {
+		priority?: KeyboardShortcutPriority;
+		allowRepeat?: boolean;
+	}
+) {
+	const parsedShortcut = parseKeyboardShortcut(shortcut);
+
+	const opts = {
+		...parsedShortcut,
+		...defaultOptions,
+		...options,
+		handler,
+	};
+
+	const context = React.useContext(KeyboardShortcutContext);
+
+	if (!context) {
+		throw new Error("useKeyboardShortcut must be used within KeyboardShortcutProvider");
+	}
+
+	useEffect(() => {
+		return context.register(opts);
+	}, [shortcut, handler, options?.priority, options?.allowRepeat]);
+
+	return;
+}

--- a/packages/ui/src/hooks/usePlatform.tsx
+++ b/packages/ui/src/hooks/usePlatform.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+
+type Platform = "mac" | "windows" | "linux" | "unknown";
+
+export function usePlatform(): Platform {
+	const [platform, setPlatform] = React.useState<Platform>("unknown");
+
+	React.useEffect(() => {
+		if (typeof navigator === "undefined") {
+			return;
+		}
+
+		const userAgent = navigator.userAgent.toLowerCase();
+		const platform = navigator.platform?.toLowerCase() || "";
+
+		if (platform.includes("mac") || userAgent.includes("mac")) {
+			setPlatform("mac");
+			return;
+		}
+
+		if (platform.includes("win") || userAgent.includes("win")) {
+			setPlatform("windows");
+			return;
+		}
+
+		if (platform.includes("linux") || userAgent.includes("linux")) {
+			setPlatform("linux");
+			return;
+		}
+
+		setPlatform("unknown");
+	}, []);
+
+	return platform;
+}
+
+export function usePlatformModifierKey(): { symbol: string; name: string; platform: Platform } {
+	const platform = usePlatform();
+
+	return React.useMemo(() => {
+		if (platform === "mac") {
+			return { symbol: "⌘", name: "Cmd", platform };
+		}
+		return { symbol: "Ctrl", name: "Ctrl", platform };
+	}, [platform]);
+}

--- a/packages/ui/src/hooks/usePlatform.tsx
+++ b/packages/ui/src/hooks/usePlatform.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-type Platform = "mac" | "windows" | "linux" | "unknown";
+export type Platform = "mac" | "windows" | "linux" | "unknown";
 
 export function usePlatform(): Platform {
 	const [platform, setPlatform] = React.useState<Platform>("unknown");

--- a/packages/ui/src/sidebar.tsx
+++ b/packages/ui/src/sidebar.tsx
@@ -95,19 +95,6 @@ const SidebarProvider = React.forwardRef<
 			return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
 		}, [isMobile, setOpen, setOpenMobile]);
 
-		// Adds a keyboard shortcut to toggle the sidebar.
-		React.useEffect(() => {
-			const handleKeyDown = (event: KeyboardEvent) => {
-				if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {
-					event.preventDefault();
-					toggleSidebar();
-				}
-			};
-
-			window.addEventListener("keydown", handleKeyDown);
-			return () => window.removeEventListener("keydown", handleKeyDown);
-		}, [toggleSidebar]);
-
 		// We add a state so that we can do data-state="expanded" or "collapsed".
 		// This makes it easier to style the sidebar with Tailwind classes.
 		const state = open ? "expanded" : "collapsed";


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #1197 

## High-level Explanation of PR

Adds search capabilities to `getPubsWithRelatedValues` and adds a searching filter to `/pubs`.

Not done:
- [ ] Made global Cmd+K search use PubCards or this component. This is somewhat tricky to do as `PubCard` is still a server component. I'd need to rework it more, which i may do in #1293 
- [ ] No results screen/message (maybe i should still add that)

Video overview (kinda rambly sorry)


https://github.com/user-attachments/assets/0b75eb3b-638d-4aa1-a32d-46d6fff29cf6




## Test Plan

1. go to legacy/pubs
2. search some stuff
3. page through the results if possible

## Screenshots (if applicable)

When searching

![image](https://github.com/user-attachments/assets/1d477270-a4d4-4448-946f-8e5218469eba)

Changed the pagination a bit when searching, as i didn't want to find out how many results there are in total (that's kinda costly), so I just get `N = perPage + 1` items, check if `N > perPage`, if so i allow the user to paginate to the next page.

There's an argument to make to just remove pagination for searching entirely, and only show the first ~25 results, and the user just needs to provide a better query if they aint happy.

![image](https://github.com/user-attachments/assets/b0e48ec5-0607-4487-8420-a864ab731e0c)


## Notes
