### PR TITLE
feat: add fallback attribute to value directive

### DIFF
--- a/core/lib/server/render/pub/renderMarkdownWithPub.ts
+++ b/core/lib/server/render/pub/renderMarkdownWithPub.ts
@@ -60,7 +60,7 @@ const visitValueDirective = (node: Directive, context: utils.RenderWithPubContex
 				val.schemaName === CoreSchemaType.DateTime
 					? // get the date in YYYY-MM-DD format
 						// we should allow the user to specify this
-						new Date(value as string).toISOString().split("T")[0]
+						new Date(val.value as string).toISOString().split("T")[0]
 					: val.value;
 		}
 	}

--- a/core/lib/server/render/pub/renderMarkdownWithPub.ts
+++ b/core/lib/server/render/pub/renderMarkdownWithPub.ts
@@ -65,7 +65,10 @@ const visitValueDirective = (node: Directive, context: utils.RenderWithPubContex
 		}
 	}
 
-	assert(value !== undefined, `Missing value for ${field}`);
+	assert(
+		value !== undefined,
+		`Missing value for ${field}. You can avoid this error by adding a fallback like so: ":value{field=<field name> fallback=<some value>}"`
+	);
 
 	node.data = {
 		...node.data,

--- a/core/lib/server/render/pub/renderMarkdownWithPub.ts
+++ b/core/lib/server/render/pub/renderMarkdownWithPub.ts
@@ -46,7 +46,7 @@ const visitValueDirective = (node: Directive, context: utils.RenderWithPubContex
 	const attrs = expect(node.attributes, "Invalid syntax in value directive");
 	const field = expect(attrs.field, "Missing field attribute in value directive");
 
-	let value: unknown;
+	let value: unknown = attrs.fallback;
 
 	const hydratedPubValues = hydratePubValues(context.pub.values);
 
@@ -55,12 +55,13 @@ const visitValueDirective = (node: Directive, context: utils.RenderWithPubContex
 	} else {
 		const val = hydratedPubValues.find((value) => value.fieldSlug === field);
 
-		value = val?.value;
-
-		if (val?.schemaName === CoreSchemaType.DateTime) {
-			// get the date in YYYY-MM-DD format
-			// we should allow the user to specify this
-			value = new Date(value as string).toISOString().split("T")[0];
+		if (val !== undefined) {
+			value =
+				val.schemaName === CoreSchemaType.DateTime
+					? // get the date in YYYY-MM-DD format
+						// we should allow the user to specify this
+						new Date(value as string).toISOString().split("T")[0]
+					: val.value;
 		}
 	}
 


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #1299

## High-level Explanation of PR

Adds a new `fallback` attribute to the `:value` directive so emails can still be sent for pubs with optional/missing field values.

## Test Plan

1. Run the email action with a template containing a value directive for a value that doesn't exist. Specify a fallback attribute, e.g. `:value{field="pubpub:nonsense" fallback="(No value was present)"}`.
2. The sent email should render "(No value was present)" instead of failing to send.
