### PR TITLE
fix: only redirect comm:con to stages page if they have access to any stages

### DIFF
--- a/core/app/c/(public)/[communitySlug]/public/signup/page.tsx
+++ b/core/app/c/(public)/[communitySlug]/public/signup/page.tsx
@@ -18,6 +18,7 @@ import { publicSignup } from "~/lib/authentication/actions";
 import { getLoginData } from "~/lib/authentication/loginData";
 import { findCommunityBySlug } from "~/lib/server/community";
 import { InviteService } from "~/lib/server/invites/InviteService";
+import { redirectToBaseCommunityPage } from "~/lib/server/navigation/redirects";
 import { publicSignupsAllowed } from "~/lib/server/user";
 import { signupThroughInvite } from "../invite/actions";
 import { InvalidInviteError } from "../invite/InviteStatuses";
@@ -97,7 +98,7 @@ const Wrapper = ({ children, notice }: { children: React.ReactNode; notice?: Not
 	);
 };
 
-const PublicSignupFlow = ({
+const PublicSignupFlow = async ({
 	user,
 	community,
 	redirectTo,
@@ -108,7 +109,11 @@ const PublicSignupFlow = ({
 }) => {
 	if (user) {
 		if (user.memberships.some((m) => m.communityId === community.id)) {
-			redirect(redirectTo ?? `/c/${community.slug}/stages`);
+			if (redirectTo) {
+				redirect(redirectTo);
+			} else {
+				await redirectToBaseCommunityPage();
+			}
 		}
 
 		// TODO: figure this out based on the invite

--- a/core/app/c/[communitySlug]/CommunitySwitcher.tsx
+++ b/core/app/c/[communitySlug]/CommunitySwitcher.tsx
@@ -12,18 +12,31 @@ import { SidebarMenuButton } from "ui/sidebar";
 import { cn } from "utils";
 
 import type { CommunityData } from "~/lib/server/community";
+import { constructRedirectToBaseCommunityPage } from "~/lib/server/navigation/redirects";
 
 type Props = {
 	community: NonNullable<CommunityData>;
 	availableCommunities: NonNullable<CommunityData>[];
 };
 
-const CommunitySwitcher: React.FC<Props> = function ({ community, availableCommunities }) {
+const CommunitySwitcher: React.FC<Props> = async function ({ community, availableCommunities }) {
 	const avatarClasses =
 		"rounded-md w-9 h-9 mr-1 group-data-[collapsible=icon]:h-8 group-data-[collapsible=icon]:w-8 border";
 	const textClasses = "flex-auto text-base font-semibold w-44 text-left";
 
 	const onlyOneCommunity = availableCommunities.length === 1;
+
+	// pre-compute redirect urls for all available communities
+	const communityRedirectUrls = await Promise.all(
+		availableCommunities.map(async (option) => ({
+			communityId: option.id,
+			redirectUrl: await constructRedirectToBaseCommunityPage({ communitySlug: option.slug }),
+		}))
+	);
+
+	const redirectUrlMap = new Map(
+		communityRedirectUrls.map(({ communityId, redirectUrl }) => [communityId, redirectUrl])
+	);
 
 	const button = (
 		<SidebarMenuButton
@@ -55,7 +68,7 @@ const CommunitySwitcher: React.FC<Props> = function ({ community, availableCommu
 						return (
 							<DropdownMenuItem asChild key={option.id}>
 								<Link
-									href={`/c/${option.slug}/stages`}
+									href={redirectUrlMap.get(option.id) || `/c/${option.slug}`}
 									className="cursor-pointer hover:bg-gray-50"
 								>
 									<div className="flex items-center gap-2">

--- a/core/app/c/[communitySlug]/SideNav.tsx
+++ b/core/app/c/[communitySlug]/SideNav.tsx
@@ -1,12 +1,9 @@
-import { link } from "fs";
-
 import type { User } from "lucia";
 
 import { cache, Suspense } from "react";
 
 import type { Communities, CommunitiesId, UsersId } from "db/public";
-import { Capabilities, MemberRole, MembershipType } from "db/public";
-import { logger } from "logger";
+import { Capabilities, MembershipType } from "db/public";
 import {
 	Activity,
 	BookOpen,
@@ -37,10 +34,8 @@ import {
 
 import type { CommunityData } from "~/lib/server/community";
 import type { MaybeHas } from "~/lib/types";
-import { db } from "~/kysely/database";
 import { getLoginData } from "~/lib/authentication/loginData";
-import { userCan } from "~/lib/authorization/capabilities";
-import { userCanViewAnyStages, viewableStagesCte } from "~/lib/server/stages";
+import { userCan, userCanViewStagePage } from "~/lib/authorization/capabilities";
 import CommunitySwitcher from "./CommunitySwitcher";
 import LoginSwitcher from "./LoginSwitcher";
 import NavLink from "./NavLink";
@@ -108,7 +103,7 @@ const viewLinks: LinkGroupDefinition = {
 			pattern: "/stages$",
 			text: "All Workflows",
 			icon: <FlagTriangleRightIcon size={16} />,
-			authorization: userCanViewAnyStages,
+			authorization: userCanViewStagePage,
 		},
 		{
 			href: "/activity/actions",

--- a/core/app/login/page.tsx
+++ b/core/app/login/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 
 import { LAST_VISITED_COOKIE } from "~/app/components/LastVisitedCommunity/constants";
 import { getLoginData } from "~/lib/authentication/loginData";
+import { redirectToBaseCommunityPage } from "~/lib/server/navigation/redirects";
 import { DotBackground } from "../components/DotBackground";
 import { LogoWithText } from "../components/Logo";
 import { Notice } from "../components/Notice";
@@ -27,7 +28,7 @@ export default async function Login({
 		const communitySlug = lastVisited?.value ?? firstSlug;
 
 		if (firstSlug) {
-			redirect(`/c/${communitySlug}/stages`);
+			await redirectToBaseCommunityPage({ communitySlug });
 		}
 
 		redirect("/settings");

--- a/core/app/page.tsx
+++ b/core/app/page.tsx
@@ -6,6 +6,7 @@ import { AuthTokenType } from "db/public";
 import { LAST_VISITED_COOKIE } from "~/app/components/LastVisitedCommunity/constants";
 import { getPageLoginData } from "~/lib/authentication/loginData";
 import { createRedirectUrl } from "~/lib/redirect";
+import { redirectToBaseCommunityPage } from "~/lib/server/navigation/redirects";
 
 export default async function Page({
 	searchParams,
@@ -32,5 +33,8 @@ export default async function Page({
 		redirect(createRedirectUrl("/settings", params).toString());
 	}
 
-	redirect(createRedirectUrl(`/c/${communitySlug}/stages`, params).toString());
+	await redirectToBaseCommunityPage({
+		searchParams: params,
+		communitySlug,
+	});
 }

--- a/core/lib/authentication/actions.ts
+++ b/core/lib/authentication/actions.ts
@@ -37,7 +37,7 @@ import { LAST_VISITED_COOKIE } from "../../app/components/LastVisitedCommunity/c
 import { findCommunityBySlug } from "../server/community";
 import * as Email from "../server/email";
 import { insertCommunityMemberships, selectCommunityMemberships } from "../server/member";
-import { redirectToLogin } from "../server/navigation/redirects";
+import { redirectToBaseCommunityPage, redirectToLogin } from "../server/navigation/redirects";
 import { invalidateTokensForUser } from "../server/token";
 import { SignupErrors } from "./errors";
 import { getLoginData } from "./loginData";
@@ -68,7 +68,9 @@ async function redirectUser(
 	const lastVisited = cookieStore.get(LAST_VISITED_COOKIE);
 	const communitySlug = lastVisited?.value ?? memberships[0].community?.slug;
 
-	redirect(`/c/${communitySlug}/stages`);
+	return redirectToBaseCommunityPage({
+		communitySlug,
+	});
 }
 
 export const loginWithPassword = defineServerAction(async function loginWithPassword(props: {

--- a/core/lib/server/email.tsx
+++ b/core/lib/server/email.tsx
@@ -168,9 +168,7 @@ export function _legacy_signupInvite(
 			{
 				type: AuthTokenType.signup,
 				expiresAt,
-				path: `/signup?redirectTo=${encodeURIComponent(
-					`/c/${props.community.slug}/stages`
-				)}`,
+				path: `/signup?redirectTo=${encodeURIComponent(`/c/${props.community.slug}/pubs`)}`,
 				userId: props.user.id,
 			},
 			trx

--- a/core/lib/server/stages.ts
+++ b/core/lib/server/stages.ts
@@ -110,15 +110,25 @@ export const viewableStagesCte = ({
 		.select("stageId");
 };
 
-export const userCanViewAnyStages = cache(async (userId: UsersId, communityId: CommunitiesId) => {
-	return autoCache(
-		viewableStagesCte({ db, userId, communityId })
-			.clearSelect()
-			.select((eb) => eb.fn.countAll<number>().as("count"))
-	)
-		.executeTakeFirstOrThrow()
-		.then((res) => (res?.count ?? 0) > 0);
-});
+export const getStagesViewableByUser = cache(
+	async (
+		userId: UsersId,
+		communityId: CommunitiesId,
+		/* manually supply this when calling outside a community context */
+		communitySlug?: string
+	) => {
+		return autoCache(
+			viewableStagesCte({ db, userId, communityId })
+				.clearSelect()
+				.select((eb) => eb.fn.countAll<number>().as("count")),
+			{
+				communitySlug,
+			}
+		)
+			.executeTakeFirstOrThrow()
+			.then((res) => (res?.count ?? 0) > 0);
+	}
+);
 
 type CommunityStageProps = { communityId: CommunitiesId; stageId?: StagesId; userId: UsersId };
 type CommunityStageOptions = {

--- a/core/playwright/externalFormCreatePub.spec.ts
+++ b/core/playwright/externalFormCreatePub.spec.ts
@@ -259,6 +259,7 @@ test.describe("Rich text editor", () => {
 		// Add a new form
 		const formsPage = new FormsPage(page, community.community.slug);
 		formsPage.goto();
+		await page.waitForURL(`/c/${community.community.slug}/forms`);
 		const formSlug = "rich-text-test";
 		await formsPage.addForm("Rich text test", formSlug);
 

--- a/core/playwright/fixtures/login-page.ts
+++ b/core/playwright/fixtures/login-page.ts
@@ -15,9 +15,8 @@ export class LoginPage {
 		await this.page.getByRole("button", { name: "Sign in" }).click();
 	}
 
-	async loginAndWaitForNavigation(email: string, password: string) {
+	async loginAndWaitForNavigation(email: string, password: string, slug?: "pubs" | "stages") {
 		await this.login(email, password);
-		// await this.page.waitForURL(/.*\/c\/.+\/stages.*/);
-		await waitForBaseCommunityPage(this.page);
+		await waitForBaseCommunityPage(this.page, undefined, slug);
 	}
 }

--- a/core/playwright/formAccess.spec.ts
+++ b/core/playwright/formAccess.spec.ts
@@ -242,10 +242,14 @@ test.describe("public signup cases", () => {
 		}) => {
 			const loginPage = new LoginPage(page);
 			await loginPage.goto();
-			await loginPage.loginAndWaitForNavigation(community.users.baseMember.email, password);
+			await loginPage.loginAndWaitForNavigation(
+				community.users.baseMember.email,
+				password,
+				"pubs"
+			);
 
 			const res = await page.goto(`/c/${community.community.slug}/public/signup`);
-			await waitForBaseCommunityPage(page, community.community.slug);
+			await waitForBaseCommunityPage(page, community.community.slug, "pubs");
 		});
 	});
 });

--- a/core/playwright/helpers.ts
+++ b/core/playwright/helpers.ts
@@ -117,8 +117,12 @@ export const PubFieldsOfEachType = Object.fromEntries(
 	])
 ) as Record<CoreSchemaType, { schemaName: CoreSchemaType }>;
 
-export const waitForBaseCommunityPage = async (page: Page, communitySlug?: string) => {
-	await page.waitForURL(new RegExp(`.*/c/${communitySlug ?? ".*"}/stages.*`), {
+export const waitForBaseCommunityPage = async (
+	page: Page,
+	communitySlug?: string,
+	slug?: "pubs" | "stages"
+) => {
+	await page.waitForURL(new RegExp(`.*/c/${communitySlug ?? ".*"}/${slug ?? "stages"}.*`), {
 		timeout: 10_000,
 	});
 };

--- a/core/playwright/member.spec.ts
+++ b/core/playwright/member.spec.ts
@@ -93,7 +93,7 @@ test.describe("Community members", () => {
 
 			await page.click("button[type='submit']");
 
-			await page.waitForURL(/\/c\/.*?\/stages/);
+			await page.waitForURL(/\/c\/.*?\/pubs/);
 
 			await page.close();
 		});

--- a/core/playwright/redirects.spec.ts
+++ b/core/playwright/redirects.spec.ts
@@ -1,0 +1,105 @@
+import type { Page } from "@playwright/test";
+
+import { test } from "@playwright/test";
+
+import { CoreSchemaType, MemberRole } from "db/public";
+
+import type { CommunitySeedOutput } from "~/prisma/seed/createSeed";
+import { createSeed } from "~/prisma/seed/createSeed";
+import { seedCommunity } from "~/prisma/seed/seedCommunity";
+import { LoginPage } from "./fixtures/login-page";
+
+let COMMUNITY_SLUG = `playwright-test-community`;
+
+const seed = createSeed({
+	community: {
+		name: `test community`,
+		slug: "test-community",
+	},
+	pubFields: {
+		Title: {
+			schemaName: CoreSchemaType.String,
+		},
+	},
+	users: {
+		admin: {
+			role: MemberRole.admin,
+			password: "password",
+		},
+		user2: {
+			role: MemberRole.contributor,
+			password: "password",
+		},
+		user3: {
+			role: MemberRole.contributor,
+			password: "password",
+		},
+		user4: {
+			role: MemberRole.contributor,
+			password: "password",
+		},
+	},
+	pubTypes: {
+		Submission: {
+			Title: { isTitle: true },
+			Content: { isTitle: false },
+		},
+		Evaluation: {
+			Title: { isTitle: true },
+			Content: { isTitle: false },
+			Email: { isTitle: false },
+		},
+	},
+	stages: {
+		Evaluating: {
+			members: {
+				user4: MemberRole.contributor,
+			},
+		},
+	},
+	pubs: [
+		{
+			pubType: "Evaluation",
+			values: {
+				Title: "Evaluation of The Activity of Snails",
+			},
+			stage: "Evaluating",
+			members: {
+				user3: MemberRole.contributor,
+			},
+		},
+	],
+});
+
+let community: CommunitySeedOutput<typeof seed>;
+test.beforeAll(async ({ browser }) => {
+	community = await seedCommunity(seed);
+
+	COMMUNITY_SLUG = community.community.slug;
+});
+
+test.describe("Community members", () => {
+	test("Admin or editor gets redirected to stages page", async ({ page }) => {
+		const loginPage = new LoginPage(page);
+		await loginPage.goto();
+		await loginPage.loginAndWaitForNavigation(community.users.admin.email, "password");
+	});
+
+	test("Contributor with no pubs nor stages gets redirected to pubs page", async ({ page }) => {
+		const loginPage = new LoginPage(page);
+		await loginPage.goto();
+		await loginPage.loginAndWaitForNavigation(community.users.user2.email, "password", "pubs");
+	});
+
+	test("Contributor with pub in stage gets redirected to pub page", async ({ page }) => {
+		const loginPage = new LoginPage(page);
+		await loginPage.goto();
+		await loginPage.loginAndWaitForNavigation(community.users.user3.email, "password", "pubs");
+	});
+
+	test("Contributor with stages gets redirected to stages page", async ({ page }) => {
+		const loginPage = new LoginPage(page);
+		await loginPage.goto();
+		await loginPage.loginAndWaitForNavigation(community.users.user4.email, "password");
+	});
+});


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #1325

## High-level Explanation of PR

Instead of always redirecting users to `/stages`, only redirect them there if either
- They are community editors/admins
- They are able to see a non-zero number of stages (due to stage memberships)

Otherwise take them to `/pubs`

The same logic applies for showing the `/stages` page on the left. This is an improvement on the previous logic, which only checked whether any stages were visible. This would cause an issue if the community had 0 stages, which would then (even for admins) never show the `/stages` link on the sidebar.

## Test Plan

Look at tests.

(Optional):
- Login as a `comm:con` (like `none@pubpub.org`)
- See you are taken to `<communityslug>/pubs`
- See that you can't see the `/stages` page in the sidebar.
- Add `none@pubpub.org` as a contributor to a stage
- Login again as `none@pubpub.org`
- See you are taken to `/stages`
- See you can see the `/stages` page in the sidebar.

## Screenshots (if applicable)

## Notes
