### PR TITLE
fix: nicer loading behavior on forms

### DIFF
--- a/core/app/components/ContextEditor/ContextEditorClient.tsx
+++ b/core/app/components/ContextEditor/ContextEditorClient.tsx
@@ -16,7 +16,12 @@ import { useServerAction } from "~/lib/serverActions";
 
 const ContextEditor = dynamic(() => import("context-editor").then((mod) => mod.ContextEditor), {
 	ssr: false,
-	loading: () => <Skeleton className="h-16 w-full" />,
+	// make sure this is the same height as the context editor, otherwise looks ugly
+	loading: () => (
+		<Skeleton className="h-[440px] w-full">
+			<Skeleton className="h-14 w-full rounded-b-none" />
+		</Skeleton>
+	),
 });
 
 export const ContextEditorClient = (

--- a/core/app/components/MemberSelect/MemberSelectClientFetch.tsx
+++ b/core/app/components/MemberSelect/MemberSelectClientFetch.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { isEnabled } from "@sentry/nextjs";
 import { skipToken } from "@tanstack/react-query";
 
 import type { Communities, CommunityMembershipsId } from "db/public";
+import { FormItem, FormLabel } from "ui/form";
+import { PubFieldSelectorToggleButton } from "ui/pubFields";
 import { Skeleton } from "ui/skeleton";
+import { cn } from "utils";
 
 import type { MemberSelectUserWithMembership } from "./types";
 import { client } from "~/lib/api";
@@ -91,7 +95,22 @@ export function MemberSelectClientFetch({
 	});
 
 	if (!initialized) {
-		return <Skeleton className="h-9 w-full" />;
+		return (
+			<FormItem className="flex flex-col gap-y-1">
+				<div className="flex items-center justify-between">
+					<FormLabel
+						className={cn(
+							"text-sm font-medium leading-none",
+							!isEnabled && "cursor-not-allowed opacity-50"
+						)}
+					>
+						{fieldLabel}
+					</FormLabel>
+					{allowPubFieldSubstitution && <PubFieldSelectorToggleButton />}
+				</div>
+				<Skeleton className="h-[46.5px] w-full" />
+			</FormItem>
+		);
 	}
 
 	return (

--- a/core/app/components/forms/elements/CheckboxElement.tsx
+++ b/core/app/components/forms/elements/CheckboxElement.tsx
@@ -48,7 +48,7 @@ export const CheckboxElement = ({ slug, label, config }: ElementProps<InputCompo
 							</FormControl>
 							<FormLabel>{config.checkboxLabel}</FormLabel>
 						</div>
-						<FormDescription>{config.help}</FormDescription>
+						{config.help && <FormDescription>{config.help}</FormDescription>}
 						<FormMessage />
 					</FormItem>
 				);

--- a/core/app/components/forms/elements/CheckboxGroupElement.tsx
+++ b/core/app/components/forms/elements/CheckboxGroupElement.tsx
@@ -121,7 +121,7 @@ export const CheckboxGroupElement = ({
 								</FormControl>
 							</FormItem>
 						) : null}
-						<FormDescription>{config.help}</FormDescription>
+						{config.help && <FormDescription>{config.help}</FormDescription>}
 						<FormMessage data-testid="error-message" />
 					</FormItem>
 				);

--- a/core/app/components/forms/elements/ConfidenceElement.tsx
+++ b/core/app/components/forms/elements/ConfidenceElement.tsx
@@ -8,6 +8,7 @@ import { confidenceIntervalConfigSchema } from "schemas";
 
 import type { InputComponent } from "db/public";
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "ui/form";
+import { Skeleton } from "ui/skeleton";
 
 import type { ElementProps } from "../types";
 import { useFormElementToggleContext } from "../FormElementToggleContext";
@@ -17,7 +18,7 @@ const Confidence = dynamic(
 	{
 		ssr: false,
 		// TODO: add better loading state
-		loading: () => <div>Loading...</div>,
+		loading: () => <Skeleton className="relative h-2 w-full" />,
 	}
 );
 
@@ -51,7 +52,7 @@ export const ConfidenceElement = ({
 					// and make sure it is not passed in as the default onChange
 					const { onChange, ...fieldProps } = field;
 					return (
-						<FormItem className="mb-6">
+						<FormItem className="relative mb-6">
 							<FormLabel className="text-[0.9em]">{label}</FormLabel>
 							<FormControl>
 								<ForwardedRefConfidence
@@ -63,7 +64,7 @@ export const ConfidenceElement = ({
 									min={0}
 									max={100}
 									onValueChange={onChange}
-									className="confidence"
+									className="confidence mb-6"
 								/>
 							</FormControl>
 							<FormMessage />
@@ -71,7 +72,7 @@ export const ConfidenceElement = ({
 					);
 				}}
 			/>
-			<FormDescription>{config.help}</FormDescription>
+			{config.help && <FormDescription>{config.help}</FormDescription>}
 		</>
 	);
 };

--- a/core/app/components/forms/elements/ContextEditorElement.tsx
+++ b/core/app/components/forms/elements/ContextEditorElement.tsx
@@ -3,7 +3,7 @@
 import type { ContextEditorGetter } from "context-editor";
 import type { ControllerRenderProps, FieldValues } from "react-hook-form";
 
-import { memo, useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Value } from "@sinclair/typebox/value";
 import { baseSchema } from "context-editor/schemas";
 import { Node } from "prosemirror-model";
@@ -98,7 +98,7 @@ const EditorFormElement = function EditorFormElement({
 						pubTypeId={pubTypeId}
 						initialDoc={initialDoc}
 						disabled={disabled}
-						className="max-h-96 overflow-scroll"
+						className="h-96 overflow-scroll"
 						onChange={handleChange}
 					/>
 				</FormControl>

--- a/core/app/components/forms/elements/DateElement.tsx
+++ b/core/app/components/forms/elements/DateElement.tsx
@@ -7,6 +7,7 @@ import { datePickerConfigSchema } from "schemas";
 
 import type { InputComponent } from "db/public";
 import { FormDescription, FormField, FormItem, FormLabel, FormMessage } from "ui/form";
+import { Skeleton } from "ui/skeleton";
 
 import type { ElementProps } from "../types";
 import { useFormElementToggleContext } from "../FormElementToggleContext";
@@ -14,7 +15,7 @@ import { useFormElementToggleContext } from "../FormElementToggleContext";
 const DatePicker = dynamic(async () => import("ui/date-picker").then((mod) => mod.DatePicker), {
 	ssr: false,
 	// TODO: add better loading state
-	loading: () => <div>Loading...</div>,
+	loading: () => <Skeleton className="h-9 w-full" />,
 });
 
 export const DateElement = ({ slug, label, config }: ElementProps<InputComponent.datePicker>) => {
@@ -31,14 +32,14 @@ export const DateElement = ({ slug, label, config }: ElementProps<InputComponent
 			name={slug}
 			control={control}
 			render={({ field }) => (
-				<FormItem className="grid gap-2">
+				<FormItem className="[&>button]:!my-1">
 					<FormLabel>{label}</FormLabel>
 					<DatePicker
 						disabled={!isEnabled}
 						date={field.value}
 						setDate={(date) => field.onChange(date)}
 					/>
-					<FormDescription>{config.help}</FormDescription>
+					{config.help && <FormDescription>{config.help}</FormDescription>}
 					<FormMessage />
 				</FormItem>
 			)}

--- a/core/app/components/forms/elements/FileUploadElement.tsx
+++ b/core/app/components/forms/elements/FileUploadElement.tsx
@@ -7,6 +7,7 @@ import { fileUploadConfigSchema } from "schemas";
 
 import type { InputComponent, PubsId } from "db/public";
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "ui/form";
+import { Skeleton } from "ui/skeleton";
 
 import type { ElementProps } from "../types";
 import { useServerAction } from "~/lib/serverActions";
@@ -18,8 +19,8 @@ const FileUpload = dynamic(
 	async () => import("ui/customRenderers/fileUpload/fileUpload").then((mod) => mod.FileUpload),
 	{
 		ssr: false,
-		// TODO: add better loading state
-		loading: () => <div>Loading...</div>,
+		// TODO: make sure this is the same height as the file upload, otherwise looks ugly
+		loading: () => <Skeleton className="h-[182px] w-full" />,
 	}
 );
 
@@ -51,7 +52,7 @@ export const FileUploadElement = ({
 				render={({ field }) => {
 					// Need the isolate to keep the FileUpload's huge z-index from covering our own header
 					return (
-						<FormItem className="isolate mb-6">
+						<FormItem className="isolate">
 							<FormLabel>{label}</FormLabel>
 							<FormControl>
 								<FileUpload
@@ -64,7 +65,10 @@ export const FileUploadElement = ({
 									id={slug}
 								/>
 							</FormControl>
-							<FormDescription>{config.help}</FormDescription>
+							{config.help && <FormDescription>{config.help}</FormDescription>}
+							{field.value && field.value.length > 0 ? (
+								<FileUploadPreview files={field.value} />
+							) : null}
 							<FormMessage />
 						</FormItem>
 					);

--- a/core/app/components/forms/elements/MultivalueInputElement.tsx
+++ b/core/app/components/forms/elements/MultivalueInputElement.tsx
@@ -51,7 +51,7 @@ export const MultivalueInputElement = ({
 								}}
 							/>
 						</FormControl>
-						<FormDescription>{config.help}</FormDescription>
+						{config.help && <FormDescription>{config.help}</FormDescription>}
 						<FormMessage />
 					</FormItem>
 				);

--- a/core/app/components/forms/elements/RadioGroupElement.tsx
+++ b/core/app/components/forms/elements/RadioGroupElement.tsx
@@ -110,7 +110,7 @@ export const RadioGroupElement = ({
 								) : null}
 							</RadioGroup>
 						</FormControl>
-						<FormDescription>{config.help}</FormDescription>
+						{config.help && <FormDescription>{config.help}</FormDescription>}
 						<FormMessage />
 					</FormItem>
 				);

--- a/core/app/components/forms/elements/SelectDropdownElement.tsx
+++ b/core/app/components/forms/elements/SelectDropdownElement.tsx
@@ -60,7 +60,7 @@ export const SelectDropdownElement = ({
 								})}
 							</SelectContent>
 						</Select>
-						<FormDescription>{config.help}</FormDescription>
+						{config.help && <FormDescription>{config.help}</FormDescription>}
 						<FormMessage />
 					</FormItem>
 				);

--- a/core/app/components/forms/elements/TextAreaElement.tsx
+++ b/core/app/components/forms/elements/TextAreaElement.tsx
@@ -46,7 +46,7 @@ export const TextAreaElement = ({
 								disabled={!isEnabled}
 							/>
 						</FormControl>
-						<FormDescription>{config.help}</FormDescription>
+						{config.help && <FormDescription>{config.help}</FormDescription>}
 						<FormMessage />
 					</FormItem>
 				);

--- a/core/app/components/forms/elements/TextInputElement.tsx
+++ b/core/app/components/forms/elements/TextInputElement.tsx
@@ -52,7 +52,7 @@ export const TextInputElement = ({
 								}}
 							/>
 						</FormControl>
-						<FormDescription>{config.help}</FormDescription>
+						{config.help && <FormDescription>{config.help}</FormDescription>}
 						<FormMessage />
 					</FormItem>
 				);


### PR DESCRIPTION
## Issue(s) Resolved

Stuff jumping around on forms

## High-level Explanation of PR

Also makes the form spacing slightly more consistent by always conditionally rendering the description.
on `main` there's always an element rendered regardless of whether the thing has a description or not, which leads to ugly spacing.

## Test Plan

Accept in your heart this looks nicer

## Screenshots (if applicable)

### Before

https://github.com/user-attachments/assets/7dc1c383-5733-410d-82d5-e8d3ed56a3ce

### After
https://github.com/user-attachments/assets/bf0560ed-623e-4e63-b8c6-50061ea934b1



## Notes

Should still work with #1347 