### PR TITLE
fix: incorrectly pass user from apitoken for permisisons in api routes

### DIFF
--- a/core/lib/authentication/api.ts
+++ b/core/lib/authentication/api.ts
@@ -133,7 +133,10 @@ export type AuthorizationOutput<S extends ApiAccessScope, AT extends ApiAccessTy
 	authorization: true | Exclude<(typeof baseAuthorizationObject)[S][AT], false>;
 	community: Communities;
 	lastModifiedBy: LastModifiedBy;
-	user: User;
+	// is empty for site builder tokens
+	// should be empty for other tokens, but isn't.
+	// we are incorrectly passing the user who minted the token to eg getPubs and getStages
+	user?: User;
 	isSiteBuilderToken?: boolean;
 };
 


### PR DESCRIPTION
## Issue(s) Resolved

## High-level Explanation of PR

<!-- Using which methods does this PR resolve the issues above? -->

In some places (pubs.get(Many), stages.get(Many)) we are incorrectly passing the `user` who minted an api token to the db call for permissions.

this leads to potentially getting more data than required

## Test Plan

## Screenshots (if applicable)

## Notes
