### PR TITLE
fix: make s3 endpoint optional as described in the terraform config

### DIFF
--- a/site-builder/src/lib/env/server.ts
+++ b/site-builder/src/lib/env/server.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 export const SERVER_ENV = createEnv({
 	server: {
 		PUBPUB_URL: z.string().url(),
-		S3_ENDPOINT: z.string().url(),
+		S3_ENDPOINT: z.string().url().optional(),
 		S3_REGION: z.string(),
 		S3_ACCESS_KEY: z.string(),
 		S3_SECRET_KEY: z.string(),


### PR DESCRIPTION
## Issue(s) Resolved

N/A

## High-level Explanation of PR

Quick fix to make the site builder's `S3_ENDPOINT` env var optional.

<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan

## Screenshots (if applicable)

## Notes
