### PR TITLE
fix: add forgotten migration to #1399

### DIFF
--- a/core/prisma/migrations/20251111112637_google_drive_config_updates/migration.sql
+++ b/core/prisma/migrations/20251111112637_google_drive_config_updates/migration.sql
@@ -1,0 +1,19 @@
+-- migrate docUrl to folderUrl and remove outputField in googleDriveImport action configs
+UPDATE
+    action_instances
+SET
+    config =(config::jsonb - 'docUrl' - 'outputField' || jsonb_build_object('folderUrl', config::jsonb -> 'docUrl'))::json
+WHERE
+    action = 'googleDriveImport'
+    AND config IS NOT NULL
+    AND config::jsonb ? 'docUrl';
+
+UPDATE
+    action_config_defaults
+SET
+    config =(config::jsonb - 'docUrl' - 'outputField' || jsonb_build_object('folderUrl', config::jsonb -> 'docUrl'))::json
+WHERE
+    action = 'googleDriveImport'
+    AND config IS NOT NULL
+    AND config::jsonb ? 'docUrl';
+


### PR DESCRIPTION
## Issue(s) Resolved

Forgot to add migration to #1399 which actually moves the `docUrl` fields to `folderUrl`...

## High-level Explanation of PR

<!-- Using which methods does this PR resolve the issues above? -->

## Test Plan

## Screenshots (if applicable)

## Notes
