### PR TITLE
fix: make snapshots of the db

### DIFF
--- a/infrastructure/terraform/modules/core-services/main.tf
+++ b/infrastructure/terraform/modules/core-services/main.tf
@@ -134,7 +134,13 @@ resource "aws_db_instance" "core_postgres" {
   username               = var.cluster_info.name
   password               = random_password.rds_db_password.result
   parameter_group_name   = "default.postgres14"
-  skip_final_snapshot    = true
+
+  backup_retention_period   = 7
+  backup_window             = "03:00-04:00"
+  maintenance_window        = "mon:04:00-mon:05:00"
+  copy_tags_to_snapshot     = true
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "${var.cluster_info.name}-core-postgres-${var.cluster_info.environment}-final-snapshot"
 }
 
 # see https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/v4.1.0


### PR DESCRIPTION
## Issue(s) Resolved

NO BACKUPS OF DATABASE

## High-level Explanation of PR

DO MAKE BACKUPS OF DATABASE

I have made one manual backup, this PR adds automated backups with 7 day retention

### tf plan (already executed)

```terraform
# module.deployment.module.core_dependency_services.aws_db_instance.core_postgres will be updated in-place
  ~ resource "aws_db_instance" "core_postgres" {
      ~ backup_retention_period               = 0 -> 7
      ~ backup_window                         = "10:24-10:54" -> "03:00-04:00"
      ~ copy_tags_to_snapshot                 = false -> true
        id                                    = "db-U5VCVGKEJ5PH5MKJDYJLMAY55I"
      ~ maintenance_window                    = "mon:03:39-mon:04:09" -> "mon:04:00-mon:05:00"
        tags                                  = {}
        # (52 unchanged attributes hidden)
    }
```

## Test Plan

## Screenshots (if applicable)

## Notes
