### PR TITLE
fix: handle app.pubpub.org redirect in caddy directly

### DIFF
--- a/core/lib/server/errors.ts
+++ b/core/lib/server/errors.ts
@@ -90,7 +90,7 @@ export const tsRestHandleErrors = async (
 	error: unknown,
 	req: TsRestRequest
 ): Promise<TsRestResponse> => {
-	const [_err, body] = req.bodyUsed ? [null, undefined] : await tryCatch(await req.json())
+	const [_err, body] = req.bodyUsed ? [null, undefined] : await tryCatch(req.json())
 	if (error instanceof RequestValidationError) {
 		logger.error({ err: error.body, input: body })
 		return TsRestResponse.fromJson(

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -15,6 +15,23 @@
     }
 }
 
+# cannot be handled by simple redirects at eg cloudflare level
+# would strip credentials
+app.pubpub.org {
+    encode gzip
+
+    handle /api/* {
+        reverse_proxy platform:3000 {
+            # present the canonical hostname to the app
+            header_up Host {$PUBSTAR_HOSTNAME}
+        }
+    }
+
+    handle {
+        redir https://{$PUBSTAR_HOSTNAME}{uri} 301
+    }
+}
+
 :80 {
     respond "OK" 200
 }


### PR DESCRIPTION
## Issue(s) Resolved

API requests to app.pubpub.org were not working bc the cloudflare redirect would strip Credentials when using `fetch`.

## High-level Explanation of PR

This PR makes errors clearer, and makes Caddy handle redirect instead


## Test Plan

## Screenshots (if applicable)

## Notes
